### PR TITLE
query-buffer: avoid overwritting a global variable, fixes #567

### DIFF
--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -5,7 +5,8 @@
 (define-parenscript query-buffer (query)
   (defvar *identifier* 0)
   (defvar *matches* (array))
-  (defvar *nodes* (ps:new (-Object)))
+  (when (= (typeof (ps:chain self *nodes*)) "undefined")
+    (defvar *nodes* (ps:new (-Object))))
 
   (defun qs (context selector)
     "Alias of document.querySelector"


### PR DESCRIPTION
This is the cause of #567, and it turned out to be a simple thing, the global variable NODES has global state that must be preserved, and query-buffer was overwriting it regardless