### PR TITLE
Add an RPM build.

### DIFF
--- a/build-scripts/build-rpm.lisp
+++ b/build-scripts/build-rpm.lisp
@@ -1,0 +1,74 @@
+(defpackage :next/build-rpm
+  (:use :cl)
+  (:import-from :asdf #:perform #:system)
+  (:import-from :cffi-toolchain #:static-program-op)
+  (:import-from :cffi
+                #:foreign-library-pathname
+                #:foreign-library-type
+                #:list-foreign-libraries
+                #:close-foreign-library)
+  (:import-from :ppcre #:split)
+  (:import-from :uiop
+                #:run-program
+                #:getenv
+                #:register-image-dump-hook)
+  (:import-from :next #:+version+))
+
+(in-package :next/build-rpm)
+
+(defun find-library-rpm-packages (ldconfig library)
+  (with-input-from-string (s ldconfig)
+    ;; skip the first line
+    (read-line s)
+
+    (loop for line = (read-line s nil 'eof)
+       until (eq line 'eof)
+       when (let ((parts (split " " (subseq line 1))))
+              (string= (first parts) (namestring (foreign-library-pathname library))))
+       collect (let ((parts (split " " (subseq line 1))))
+                 (run-program
+                  `("rpm" "-q" "--whatprovides" ,(first (last parts)) "--qf" "%{NAME}")
+                  :output '(:string))))))
+
+(defun find-rpm-packages (libraries)
+  (let ((ldconfig (run-program "ldconfig -p" :output '(:string))))
+    (delete-duplicates
+     (reduce (lambda (packages library)
+               (append
+                packages
+                (unless (eq (foreign-library-type library) :grovel-wrapper)
+                  (find-library-rpm-packages ldconfig library))))
+             libraries
+             :initial-value nil)
+     :test #'string=)))
+
+;;; Make sure we close statically linked libraries.
+;;; Remove when this or similar is done in cffi: https://github.com/cffi/cffi/pull/163
+(register-image-dump-hook
+ (lambda ()
+   (loop for library in (list-foreign-libraries)
+      when (eq (foreign-library-type library) :grovel-wrapper)
+      do (close-foreign-library library))))
+
+(defclass build-rpm (static-program-op)
+  ())
+
+(defmethod perform ((operation build-rpm) (system system))
+  (call-next-method operation system)
+
+  (let ((deps (delete-duplicates
+               (append
+                (find-rpm-packages (list-foreign-libraries))
+                ;; sbcl images always depends on those
+                #+sbcl '("zlib" "glibc")))))
+    (run-program `("fpm" "-s" "dir"
+                         "-t" "rpm"
+                         "-n" "next"
+                         "-v" ,+version+
+                         ,@(mapcar (lambda (dep) (format nil "--depends=~a" dep)) deps)
+                         "next=/usr/bin/"
+                         "assets/next.desktop=/usr/share/applications/")
+                 :output :interactive
+                 :error-output :interactive)))
+
+(setf (find-class 'asdf::build-rpm) (find-class 'build-rpm))

--- a/next.asd
+++ b/next.asd
@@ -135,6 +135,17 @@
   :build-pathname "next"
   :entry-point "next:entry-point")
 
+(asdf:defsystem :next/build-rpm
+  :depends-on (:cffi-toolchain :cl-ppcre :next)
+  :pathname "build-scripts/"
+  :components ((:file "build-rpm")))
+
+(asdf:defsystem :next/gtk-application-rpm
+  :depends-on (:next/build-rpm :next/gtk)
+  :build-operation "build-rpm"
+  :build-pathname "next"
+  :entry-point "next:entry-point")
+
 (asdf:defsystem :next/qt-application
   :depends-on (:next/qt)
   :build-operation "program-op"


### PR DESCRIPTION
Some caveats:

- This needs an SBCL built with --sb-linkable-runtime
- This needs to skip sbcl 2.0.4
- This needs current master of https://github.com/cffi/cffi
- This is missing some bit about not reloading foreign libraries on
  startup, but shouldn't be hard to do once the other questions are
  answered.

The current code assumes that during the release build, the `VERSION`
environment variable exists.

The code currently relies on https://github.com/jordansissel/fpm. This
means creating a .deb is also very easy.

That said, to build the package correctly, you need to run it on the
distribution you intend to distribute the package to. Which means you
need one build per distribution version, e.g. fedora 31, fedora 32,
debian 9, debian 10, debian 11, ubuntu 20.04, etc etc. Which shouldn't
be too hard to do on docker, but that opens the question of: how are
the current release builds done?

Anyway, here is some goodies:

```
[ralt@tag next]$ ls -lh next-1.0.0-1.x86_64.rpm
-rw-rw-r--. 1 ralt ralt 28M May 30 01:21 next-1.0.0-1.x86_64.rpm

[ralt@tag next]$ rpm -ql next
/usr/bin/next
/usr/lib/.build-id
/usr/lib/.build-id/1e
/usr/lib/.build-id/1e/875a286ae31e5065ce73525b20d7db4ecd2bbd

[ralt@tag next]$ rpm -qi next
Name        : next
[... skipping ...]

[ralt@tag next]$ rpm -qR next
cairo
gdk-pixbuf2
glib2
glibc
gtk3
libfixposix-devel
openssl-libs
pango
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
webkit2gtk3-devel
```