### PR TITLE
Add force-https-mode

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -87,6 +87,7 @@
                (:file "file-manager-mode")
                (:file "download-mode")
                (:file "vcs-mode")
+               (:file "force-https-mode")
                ;; Web-mode commands
                (:file "element-hint")
                (:file "jump-heading")

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -3,18 +3,10 @@
   (:documentation "Mode for enforcing HTTPS on any URL clicked/hinted/set by user."))
 (in-package :nyxt/force-https-mode)
 
-(serapeum:export-always '*http-only-urls*)
-(defparameter *http-only-urls* '()
-  "A list of the URLs to be ignored by force-https-mode.")
-
 (defun force-https-handler (resource)
   "Imposes HTTPS on any link with HTTP scheme."
   (let ((uri (quri:uri (url resource))))
-    (if (and (string= (quri:uri-scheme uri) "http")
-             (not (member-if #'(lambda (url)
-                                 (search (quri:uri-host uri)
-                                         (quri:uri-host (quri:uri url))))
-                             *http-only-urls*)))
+    (if (string= (quri:uri-scheme uri) "http")
         (progn (log:info "HTTPS enforced on ~a" (quri:render-uri uri))
                ;; FIXME: http-only websites are displayed as "https://foo.bar"
                ;; FIXME: some websites (e.g., go.com) simply time-out
@@ -31,10 +23,6 @@ and websites that still don't have HTTPS version (shame on them!).
 To escape \"Unacceptable TLS Certificate\" error:
 \(setf nyxt/certificate-whitelist-mode:*default-certificate-whitelist*
        '(\"your.unacceptable.cert.website\"))
-
-To escape lags and inaccessibility of some stubborn non-HTTPS websites:
-\(setf nyxt/force-https-mode:*http-only-urls*
-       '(\"stubborn.website\"))
 
 Example:
 

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -1,0 +1,55 @@
+(uiop:define-package :nyxt/force-https-mode
+  (:use :common-lisp :nyxt)
+  (:documentation "Mode for enforcing HTTPS on any URL clicked/hinted/set by user."))
+(in-package :nyxt/force-https-mode)
+
+(serapeum:export-always '*http-only-urls*)
+(defparameter *http-only-urls* '()
+  "A list of the URLs to be ignored by force-https-mode.")
+
+(defun force-https-handler (resource)
+  "Imposes HTTPS on any link with HTTP scheme."
+  (let ((uri (quri:uri (url resource))))
+    (if (and (string= (quri:uri-scheme uri) "http")
+             (not (member-if #'(lambda (url)
+                                 (search (quri:uri-host uri)
+                                         (quri:uri-host (quri:uri url))))
+                             *http-only-urls*)))
+        (progn (log:info "HTTPS enforced on ~a" (quri:render-uri uri))
+               ;; FIXME: http-only websites are displayed as "https://foo.bar"
+               ;; FIXME: some websites (e.g., go.com) simply time-out
+               ;; FIXME: the URL string in "Loading ~s." (renderer-gtk.lisp)
+               ;;        is empty (old-reddit-handler causes the same effect,
+               ;;        I guess the problem is in the request hook)
+               (setf (quri:uri-scheme uri) "https"
+                     (quri:uri-port uri) (quri.port:scheme-default-port "https")
+                     (url resource) (quri:render-uri uri)))))
+  (values resource :forward))
+
+(define-mode force-https-mode ()
+  "Impose HTTPS on any link being set. Use at your own risk --
+can break websites whose certificates are not included in nss-certs
+and websites that still don't have an HTTPS version (shame on them)!
+
+To escape \"Unacceptable TLS Certificate\" error:
+\(setf nyxt/certificate-whitelist-mode:*default-certificate-whitelist*
+       '(\"your.unacceptable.cert.website\"))
+
+To escape lags and inaccessibility of some stubborn non-HTTPS websites:
+\(setf nyxt/force-https-mode:*http-only-urls*
+       '(\"stubborn.website\"))
+
+Example:
+
+\(define-configuration buffer
+  ((default-modes (append '(force-https-mode) %slot-default))))"
+  ((destructor
+    :initform
+    (lambda (mode)
+      (hooks:remove-hook (request-resource-hook (buffer mode))
+                         'force-https-handler)))
+   (constructor
+    :initform
+    (lambda (mode)
+      (hooks:add-hook (request-resource-hook (buffer mode))
+                      (make-handler-resource #'force-https-handler))))))

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -18,9 +18,6 @@
         (progn (log:info "HTTPS enforced on ~a" (quri:render-uri uri))
                ;; FIXME: http-only websites are displayed as "https://foo.bar"
                ;; FIXME: some websites (e.g., go.com) simply time-out
-               ;; FIXME: the URL string in "Loading ~s." (renderer-gtk.lisp)
-               ;;        is empty (old-reddit-handler causes the same effect,
-               ;;        I guess the problem is in the request hook)
                (setf (quri:uri-scheme uri) "https"
                      (quri:uri-port uri) (quri.port:scheme-default-port "https")
                      (url resource) (quri:render-uri uri)))))

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -25,8 +25,8 @@
 
 (define-mode force-https-mode ()
   "Impose HTTPS on any link being set. Use at your own risk --
-can break websites whose certificates are not included in nss-certs
-and websites that still don't have an HTTPS version (shame on them)!
+can break websites whose certificates are not known
+and websites that still don't have HTTPS version (shame on them!).
 
 To escape \"Unacceptable TLS Certificate\" error:
 \(setf nyxt/certificate-whitelist-mode:*default-certificate-whitelist*


### PR DESCRIPTION
This adds the mode for obligatory switching to `https://` even if the link (be it button, hyperlink, or something user enters in the minibuffer) explicitly uses `http://` scheme.

## Motivation
There is a necessity behind this mode, because some, especially hardcoded, links/buttons/inputs contain non-HTTPS links and lead to less secure versions of websites. Enforcing HTTPS can make one's browsing safer, and it's in line with Nyxt care about users' safety.

## Caveats
Several issues that ideally need to be resolved before merging this are still open, but the `force-https-mode` works well enough even without resolving these issues (namely, #672 and #687). As a precaution measure, `*http-only-urls*` variable is added to disable HTTPS enforcement for individual addresses.

## How Has This Been Tested?
- Several certified websites were requested with `http://` scheme that was changed to `https://` on the requests hook. No surprises there.
- Several links from [Why No HTTPS](https://whynohttps.com/) were opened with this mode enabled. Some did break, but it was due to the websites themselves improperly handling TLS connection, so I can do nothing about that.
- [Website](https://post.de) with the certificate problem from #687 was forced to HTTPS too, with an expectable error message. After whitelisting it with `add-domain-to-certificate-whitelist`, the address loaded flawlessly.
- [HTTP-only-website](http://go.com) that was breaking in this mode (and on any attempt to use HTTPS in general, even in other browsers), have loaded flawlessly (yet insecurely) after whitelisting in `nyxt/force-https-mode:*http-only-urls*`.

I'll be glad to see your feedback on the code! If there are some inconsistencies with the appropriate style, I'll try to correct them as fast as I can. If you consider that this mode needs more testing and I can help with that, let me know too!

Closes: #778