### PR TITLE
GTK: Switch to gtk:gtk-main for FreeBSD

### DIFF
--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -67,7 +67,7 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
           (gdk:gdk-set-program-class "nyxt")
           (finalize browser urls startup-timestamp))
         (unless *keep-alive*
-          (gtk:join-gtk-main)))
+          (#-freebsd gtk:join-gtk-main #+freebsd gtk:gtk-main)))
       #+darwin
       (progn
         (setf gtk-running-p t)


### PR DESCRIPTION
Launching `nyxt` on FreeBSD (`12.1-RELEASE` in my case), gives a white/gray/empty window, although in _verbose_ mode, i can see keypress events on console.

After applying this patch, `nyxt` works as expected. Although, I'm not sure if it's any other side-effects, but for now, it causes browser to work in FreeBSD.

Thanks!