### PR TITLE
Tls error in same buffer

### DIFF
--- a/source/help.lisp
+++ b/source/help.lisp
@@ -252,11 +252,7 @@ A command is a special kind of function that can be called with
 (defun tls-help (buffer url)
   "This function is invoked upon TLS certificate errors to give users
 help on how to proceed."
-  (declare (ignore buffer))             ; TODO: Display tls-help in buffer with TLS error.
-  (let* ((help-buffer (nyxt/help-mode:help-mode
-                       :activate t
-                       :buffer (make-buffer :title "TLS Error")))
-         (help-contents
+  (let* ((help-contents
            (markup:markup
             (:h1 (format nil "TLS Certificate Error: ~a" url))
             (:p "The address you are trying to visit has an invalid
@@ -264,16 +260,23 @@ certificate. By default Nyxt refuses to establish a secure connection
 to a host with an erroneous certificate (e.g. self-signed ones). This
 could mean that the address you are attempting the access is
 compromised.")
-            (:p "If you trust the address
-nonetheless, you can add an exception for the current hostname with
-=add-domain-to-certificate-whitelist=.  The =certificate-whitelist-mode= must be
-active for the current buffer (which is the default).")
-            (:p "You can persist hostname exceptions in your init
-file, see the =add-domain-to-certificate-whitelist= documentation.")))
+            (:p "If you trust the address nonetheless, you can add an exception
+for the current hostname with the "
+                (:code "add-domain-to-certificate-whitelist")
+                " command.  The "
+                (:code "certificate-whitelist-mode")
+                " must be active for the current buffer (which is the
+default).")
+            (:p "To persist hostname exceptions in your initialization
+file, see the "
+                (:code "add-domain-to-certificate-whitelist")
+                " documentation.")))
          (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
                                    (ps:lisp help-contents)))))
-    (ffi-buffer-evaluate-javascript help-buffer insert-help)
-    (set-current-buffer help-buffer)))
+    ;; Set (url buffer) so that the user can simply reload the page after
+    ;; allowing the exception:
+    (setf (url buffer) url)
+    (ffi-buffer-evaluate-javascript buffer insert-help)))
 
 (defun describe-key-dispatch-input (event buffer window printable-p)
   "Display documentation of the value bound to the keys pressed by the user.

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -430,14 +430,18 @@ Warning: This behaviour may change in the future."
   "Return nil to propagate further (i.e. raise load-failed signal), T otherwise."
   (let* ((context (webkit:webkit-web-view-web-context (gtk-object buffer)))
          (host (host url)))
-    (when (and (certificate-whitelist buffer)
-               (member-string host (certificate-whitelist buffer)))
-      (webkit:webkit-web-context-allow-tls-certificate-for-host
-       context
-       (gobject:pointer certificate)
-       host)
-      (set-url* url :buffer buffer)
-      t)))
+    (if (and (certificate-whitelist buffer)
+             (member-string host (certificate-whitelist buffer)))
+        (progn
+          (webkit:webkit-web-context-allow-tls-certificate-for-host
+           context
+           (gobject:pointer certificate)
+           host)
+          (set-url* url :buffer buffer)
+          t)
+        (progn
+          (tls-help buffer url)
+          t))))
 
 (defmethod on-signal-decide-policy ((buffer gtk-buffer) response-policy-decision policy-decision-type-response)
   (let ((is-new-window nil) (is-known-type t) (event-type :other)
@@ -611,8 +615,7 @@ Warning: This behaviour may change in the future."
    (gtk-object buffer) "load-failed-with-tls-errors"
    (lambda (web-view failing-uri certificate errors)
      (declare (ignore web-view errors))
-     (on-signal-load-failed-with-tls-errors buffer certificate failing-uri)
-     (tls-help buffer failing-uri)))
+     (on-signal-load-failed-with-tls-errors buffer certificate failing-uri)))
   (gobject:g-signal-connect
    (gtk-object buffer) "notify::uri"
    (lambda (web-view param-spec)


### PR DESCRIPTION
This supersedes #710 which purpose actually was to print the TLS error in the same buffer, not to handle `:load-failed`.

This seems to work now, I don't know why it failed in #710.  Maybe a GTK / WebKitGTK update.

@jmercouris Can you test and see if it works for you with https://intra.ec.krugercorp.com/ and when you try to load a page while being offline?