### PR TITLE
Simplify request-resource-hook's handlers return value

### DIFF
--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -151,7 +151,7 @@ Example:
             (hooks:add-hook (request-resource-hook (buffer mode))
                             (make-handler-resource #'request-resource-block))
             (make-hook-resource
-             :combination #'combine-composed-hook-until-non-nil-second-value
+             :combination #'combine-composed-hook-until-nil
              :handlers (list #'request-resource-block)))))))
 
 (defmethod blacklisted-host-p ((mode blocker-mode) host)
@@ -174,7 +174,7 @@ This is an acceptable handler for `request-resource-hook'."
                      (object-display (url request-data))
                      (buffer request-data)
                      (object-string (buffer request-data)))
-          (values request-data :stop))
+          nil)
         ;; Pass request to the other handlers.
         request-data)))
 

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -3,17 +3,17 @@
   (:documentation "Mode for enforcing HTTPS on any URL clicked/hinted/set by user."))
 (in-package :nyxt/force-https-mode)
 
-(defun force-https-handler (resource)
+(defun force-https-handler (request-data)
   "Impose HTTPS on any link with HTTP scheme."
-  (let ((uri (url resource)))
+  (let ((uri (url request-data)))
     (when (string= (quri:uri-scheme uri) "http")
       (log:info "HTTPS enforced on \"~a\"" (object-display uri))
       ;; FIXME: http-only websites are displayed as "https://foo.bar"
       ;; FIXME: some websites (e.g., go.com) simply time-out
       (setf (quri:uri-scheme uri) "https"
             (quri:uri-port uri) (quri.port:scheme-default-port "https")
-            (url resource) uri)))
-  (values resource :forward))
+            (url request-data) uri)))
+  request-data)
 
 (define-mode force-https-mode ()
   "Impose HTTPS on every queried URI.


### PR DESCRIPTION
This changes the ambiguous format of the `request-resource-hook`'s handlers return value from `(values request-data &optional (or (eql :stop) (eql :forward)))` to a simpler `(or request-data null)` while still retaining all the power of the `request-resource-hook` and making it more readable and understandable, both for maintainers and users. Documentation was adjusted accordingly.

### Motivation

The format of what `request-resource-hook` return values was relatively complex for me as a project newcomer and there seemed to be no strong use-case for such a complexity of the return value format. Bringing the format of the `request-resource-hook` handlers to a conventional lispy format of "either it's nil, or something meaningful" seemed as a good step towards readability, ease of use and conventionality of the `request-resource-hook`.

### How Has This Been Tested

Because the most breaking change was the change from the expression `(values request-data :stop)` to `nil`, the testing mainly employed enabling several handlers together with the `request-resource-block` handler of `blocker-mode` that returned `nil` instead of the two-valued expression now. Testing revealed that there's a need in failure-testing for each handler, and `hooks:run-hook` was replaced with `hooks:run-hook-with-args-until-failure` the result of which was unwrapped after it's call.

### Other things

- The absence of log notes about blocking the hosts from the default blocking list emerged during testing, but this bug seems to be present in the upstream version, so it's unrelated to this patch.
- The name of the `force-https-handler` argument was changed from `resource` to `request-data` to unify it with other similar handlers.