### PR TITLE
Restore sessions lazily.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -59,8 +59,11 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
     ;; Modes might require that buffer exists, so we need to initialize them
     ;; after the view has been created.
     (initialize-modes buffer)
-    (when dead-buffer
-      (setf (url buffer) (url dead-buffer)))
+    (if dead-buffer
+        (progn
+          (setf (url buffer) (url dead-buffer))
+          (setf (slot-value buffer 'load-status) :unloaded))
+        (setf (slot-value buffer 'load-status) :void))
     (when (expand-path (cookies-path buffer))
       (ensure-parent-exists (expand-path (cookies-path buffer))))
     (setf (gethash (id buffer) (buffers browser)) buffer)

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -74,9 +74,9 @@ Currently we store the list of current URLs of all buffers."
            (loop for history in buffer-histories
                  for buffer = (make-buffer)
                  for mode = (find-submode buffer 'web-mode)
-                 do (set-url* (object-string
-                               (url (htree:data (htree:current history))))
-                              :buffer buffer)
+                 do (setf (url buffer)
+                          (object-string (url (htree:data (htree:current history)))))
+                 do (setf (slot-value buffer 'load-status) :unloaded)
                  do (setf (nyxt/web-mode:history mode) history))
            ;; TODO: Switch to the last active buffer.  We probably need to serialize *browser*.
            ;; Or else we could include `access-time' in the buffer class.


### PR DESCRIPTION
Previously we would tell GTK to load all restored buffers on startup.  This
would hang the browser for a while before it displayed the first window because
the queries are done within a single GTK main loop cycle.

It's hard to load more than very few URIs in a single GTK loop cycle because of
how long it takes.

The easiest (and possibly best) option is to restore the buffers on demand.
This is what this patch does.

Another option would be to restore about one buffer per second, or when the
browser is idle.  The benefit is that this would make all the buffers ready to
browse after a certain time and the user would not have to wait on every buffer switch.