### PR TITLE
Add customizable URL-dispatching

### DIFF
--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -67,6 +67,9 @@ have priorities over the other modes key bindings.")
     (:p "See the " (:code "search-engines") " browser slot documentation.
 Bookmarks can also be used as search engines, see the corresponding section.")
 
+    (:h3 "URL-dispatchers")
+    (:p "See the" (:code "url-dispatching-handler") " function documentation.")
+
     (:h3 "Downloads")
     (:p "See the " (:code "download-list") " command and the "
         (:code "download-path") " browser slot documentation.")


### PR DESCRIPTION
This adds a mechanism for a customizable URL-dispatching and a simple way to customize it.

### Motivation

There can be a necessity to change browser behavior while encountering a certain type of link (e.g., open torrent client on "magnet:" link, redirect "doi:" protocol link to the DOI website). Using handlers and `request-resource-hook` is too much of a work for a simple task of doing something depending on domain/scheme/host/whatever in a URL. There's a need in a simpler way to act on URLs while having robustness of hooks.

### What's Not There (Yet)

- Shorter syntax for shell command invocations on matching URLs. Although it can be built on top of this URL dispatching mechanism easily, it needs more discussion.

### How Has This Been Tested

Browser was started with this config file:
``` lisp
(in-package #:nyxt-user)

(define-configuration browser
  ((url-dispatchers `(,(url-dispatching-handler
                        (match-scheme "doi")
                        (lambda (url)
                          (quri:uri (format nil "https://doi.org/~a"
                                            (quri:uri-path url))))
                        "Resolve DOI links")
                      ,(url-dispatching-handler
                        (match-host "reddit.com")
                        (lambda (url)
                          (quri:copy-uri url :host "old.reddit.com"))
                        "Open old Reddit")
                      ,(url-dispatching-handler
                        (match-scheme "javascript")
                        (lambda (url)
                          (ffi-buffer-evaluate-javascript
                           (current-buffer) (quri:uri-path url))
                          nil))
                      ,@%slot-default))))
```
And the given handlers worked in the appropriate situations. No bugs were noticed.

I'll be glad to see your feedback on that!

Closes #817 