### PR TITLE
Per buffer contexts

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -61,7 +61,10 @@ Parent directories are created if necessary."
      status-formatter
      window-delete-hook)))
 (defclass window ()
-  ((id :accessor id :initarg :id)
+  ((id :accessor id
+       :initarg :id
+       :type string
+       :initform "")
    (active-buffer :reader active-buffer :initform nil)
    (active-minibuffers :accessor active-minibuffers :initform nil
                        :documentation "The stack of currently active minibuffers.")
@@ -215,7 +218,10 @@ Without handler, return ARG.  This is an acceptable `combination' for
      buffer-delete-hook
      default-cookie-policy)))
 (defclass buffer ()
-  ((id :accessor id :initarg :id :initform ""
+  ((id :accessor id
+       :initarg :id
+       :type string
+       :initform ""
        :documentation "Unique identifier for a buffer.
 Dead buffers (i.e. those not associated with a web view) have an empty ID.")
    ;; TODO: Or maybe a dead-buffer should just be a buffer history?
@@ -946,10 +952,10 @@ current buffer."
             nil))))))
 
 (defmethod get-unique-window-identifier ((browser browser))
-  (incf (slot-value browser 'total-window-count)))
+  (format nil "~s" (incf (slot-value browser 'total-window-count))))
 
 (defmethod get-unique-buffer-identifier ((browser browser))
-  (incf (slot-value browser 'total-buffer-count)))
+  (format nil "~s" (incf (slot-value browser 'total-buffer-count))))
 
 (declaim (ftype (function (&optional window buffer)) set-window-title))
 (export-always 'set-window-title)


### PR DESCRIPTION
Great news!  Since @aartaka implemented data-manager support in cl-webkit, we can now use per-buffer contexts without crashing Nyxt (I've ran it for half an hour so far).

This fixes #826.
Can you test on your site and confirm the browser does not crash (leave it up for at least 10 minutes).

@hsanjuan This might also fix the Protonmail logouts (#644).  Could you check if it works for you?  I've tried it here, Protonmail is still logged in after 30 minutes and many buffer switches.
