### PR TITLE
Add shell-command strings support in url-dispatching-handler

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -1103,12 +1103,17 @@ Deal with REQUEST-DATA with the following rules:
          request-data)))))
 
 (export-always 'url-dispatching-handler)
+(declaim (ftype (function (symbol
+                           (function (quri:uri) boolean)
+                           (or string (function (quri:uri) (or quri:uri null)))))
+                url-dispatching-handler))
 (defun url-dispatching-handler (name test action)
   "Return a `resource' handler that, if `add-hook'ed to the `request-resource-hook',
 will automatically apply its ACTION on the URLs that conform to TEST.
 
-TEST and ACTION should be functions of one argument, the requested URL.
-In case ACTION returns nil, URL request is aborted.
+TEST should be function of one argument, the requested URL.
+ACTION can be either a shell command as a string, or a function taking a URL as argument.
+In case ACTION returns nil (always the case for shell command), URL request is aborted.
 The new URL returned by ACTION is loaded otherwise.
 
 `match-host', `match-scheme', `match-domain' and `match-file-extension'
@@ -1128,22 +1133,40 @@ Example:
                                           (url-dispatching-handler
                                            'transmission-magnet-links
                                            (match-scheme \"magnet\")
+                                           \"transmission-remote --add ~a\")
+                                          (url-dispatching-handler
+                                           'emacs-file
+                                           (match-scheme \"file\")
                                            (lambda (url)
                                              (uiop:launch-program
-                                              (list \"transmission-remote\" \"--add\"
-                                                    (object-string url))
-                                              nil))))
+                                              `(\"emacs\" ,(quri:uri-path url)))
+                                             nil)))
                                     :initial-value %slot-default))))"
   (make-handler-resource
-    #'(lambda (request-data)
-        (let ((url (url request-data)))
-          (if (funcall-safely test url)
-              (let ((new-url (funcall-safely action url)))
-                (log:info "Applied \"~a\" URL-dispatcher on \"~a\" and got \"~a\""
-                          (symbol-name name) (object-display url) (object-display new-url))
-                (when new-url (setf (url request-data) new-url) request-data))
-              request-data)))
-    :name name))
+   #'(lambda (request-data)
+       (let ((url (url request-data)))
+         (if (funcall-safely test url)
+             (etypecase action
+               (function
+                (let* ((new-url (funcall-safely action url)))
+                  (log:info "Applied ~s URL-dispatcher on ~s and got ~s"
+                            (symbol-name name)
+                            (object-display url)
+                            (object-display new-url))
+                  (when new-url
+                    (setf (url request-data) new-url)
+                    request-data)))
+               (string (let ((action #'(lambda (url)
+                                         (uiop:launch-program
+                                          (format nil action
+                                                  (object-string url)))
+                                         nil)))
+                         (funcall-safely action url)
+                         (log:info "Applied ~s shell-command URL-dispatcher on ~s"
+                            (symbol-name name)
+                            (object-display url)))))
+             request-data)))
+   :name name))
 
 (declaim (ftype (function (string) (function (quri:uri) boolean))
                 match-scheme match-host match-domain match-file-extension))


### PR DESCRIPTION
This adds the ability to pass shell-commands as strings to `url-dispatching-handler`.

### Motivation

While a lot of things can be done with high-level mechanisms, like lambdas, shell isn't going anywhere, and having a simple and convenient way to call shell commands is a great extensibility advantage. Having a short and straight-to-the-point string-encoded shell-command syntax in `url-dispatching-handler` `action` argument is a step towards this convenience.

### What's New
- `run-shell-command` helper function, inspired by StumpWM's `run-shell-command`. It supports only `sh` for now, but can be easily extended to support other shells.
- Possibility to pass strings (actually, `format`'s `control-string`s, so `"transmission-remote --add ~s"` is a valid `action` there) as `action`s to `url-dispatching-handler`.
- New optional `url-formatter` argument to `url-dispatching-handler`, whose sole purpose is to format URL properly before passing them to shell-commands.
- Documentation of `url-dispatching-handler` was changed accordingly.

### How Has This Been Tested

- I've added new `url-dispatching-handler` to `request-resource-hook` and ran Nyxt with it. No bugs were noticed, except for the fact that the directory Nyxt runs shell scripts in is "~/.config/nyxt/", but that's not a bug. That's what this handler looked like.
``` lisp 
(url-dispatching-handler
  'emacs-file
  (match-scheme "emacs")
  "emacs ~s"
  #'quri:uri-path)
```

I am conscious that this testing is not exhaustive (sorry, I haven't come up with the cases to use this syntax for), and you can test it yourself to make sure that it works properly. I'll be happy to see your feedback and testing notes on that!

Closes #834.