### PR TITLE
Add auto-mode for automatic mode white- and blacklisting

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -72,6 +72,7 @@
                (:file "bookmark")
                (:file "history")
                (:file "autofill")
+               (:file "auto-mode")
                (:file "external-editor")
                (:file "url-group")
                ;; Core Modes

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -1,0 +1,306 @@
+(uiop:define-package :nyxt/auto-mode
+  (:use :common-lisp :nyxt)
+  (:import-from #:serapeum #:export-always)
+  (:documentation "Mode for automatic URL-based mode toggling."))
+(in-package :nyxt/auto-mode)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria))
+
+(export-always '*prompt-on-mode-toggle*)
+(defparameter *prompt-on-mode-toggle* nil
+  "Whether user will be asked about adding the mode to included/excluded modes
+in auto-mode-list on mode activation/deactivation.")
+
+(export-always '*non-rememberable-modes*)
+(defparameter *non-rememberable-modes*
+  ;; Base mode conflicts with its Nyxt symbol if it's not prefixed
+  '(help-mode web-mode auto-mode nyxt::base-mode)
+  "Modes that AUTO-MODE won't even try to save.")
+
+(declaim (ftype (function ((or symbol root-mode)) (values symbol &optional)) maybe-mode-name))
+(defun maybe-mode-name (mode)
+  (if (symbolp mode) mode (mode-name mode)))
+
+(declaim (ftype (function ((or symbol root-mode) (or symbol root-mode)) boolean)
+                mode-equal))
+(defun mode-equal (mode1 mode2)
+  (string-equal (symbol-name (maybe-mode-name mode1))
+                (symbol-name (maybe-mode-name mode2))))
+
+(defun non-rememberable-mode-p (mode)
+  (member mode *non-rememberable-modes* :test #'mode-equal))
+
+(defun rememberable-of (modes)
+  (remove-if #'non-rememberable-mode-p modes))
+
+(defclass-export auto-mode-rule ()
+  ((test :initarg :test
+         :accessor test
+         :type list
+         :initform (error "Slot `test' should be set."))
+   (modes :initarg :modes
+          :accessor modes
+          :type list-of-symbols
+          :initform '())))
+
+(declaim (ftype (function (quri:uri) (or auto-mode-rule null))
+                matching-auto-mode-rule))
+(defun matching-auto-mode-rule (url)
+  (flet ((priority (test1 test2)
+           (let ((priority-list '(match-regex match-url match-host match-domain)))
+             (< (or (position (first test1) priority-list) 4)
+                (or (position (first test2) priority-list) 4)))))
+    (first (sort (remove-if-not
+                  #'(lambda (rule)
+                      (funcall-safely
+                       (apply (first (test rule)) (rest (test rule))) url))
+                  (or (auto-mode-list *browser*) (restore-auto-mode-list)))
+                 #'priority :key #'test))))
+
+(declaim (ftype (function (quri:uri buffer)) enable-matching-modes))
+(defun enable-matching-modes (url buffer)
+  (let ((rule (matching-auto-mode-rule url)))
+    (enable-modes (rememberable-of (set-difference
+                                    (modes rule)
+                                    (mapcar #'mode-name (modes buffer))
+                                    :test #'mode-equal))
+                  buffer)
+    (disable-modes (rememberable-of (set-difference
+                                     (mapcar #'mode-name (modes buffer))
+                                     (modes rule) :test #'mode-equal))
+                   buffer)))
+
+(defun clean-up-auto-mode (mode)
+  (dolist (handler-name '(auto-mode-request-handler
+                          enable-mode-prompting-handler
+                          disable-mode-prompting-handler))
+    (hooks:remove-hook (request-resource-hook (buffer mode)) handler-name)))
+
+(defun store-last-active-modes (auto-mode)
+  (setf (last-active-modes auto-mode)
+        (modes (buffer auto-mode))))
+
+(defun restore-last-active-modes (auto-mode)
+  (disable-modes
+   (mapcar #'maybe-mode-name
+           (set-difference (modes (buffer auto-mode))
+                           (last-active-modes auto-mode)
+                           :test #'mode-equal))
+   (buffer auto-mode))
+  (enable-modes
+   (mapcar #'maybe-mode-name
+           (set-difference (last-active-modes auto-mode)
+                           (modes (buffer auto-mode))
+                           :test #'mode-equal))
+   (buffer auto-mode)))
+
+(defun auto-mode-request-handler (request-data)
+  (let* ((auto-mode (find-submode (buffer request-data) 'auto-mode))
+         ;; We need to supress prompting when auto-mode modifies modes.
+         (*prompt-on-mode-toggle* nil)
+         (web-mode (find-submode (buffer request-data) 'web-mode))
+         (prev-url
+           (unless (eq (htree:root (history web-mode))
+                       (htree:current (history web-mode)))
+             (url (htree:data
+                   (htree:parent (htree:current (history web-mode))))))))
+    (if (matching-auto-mode-rule (url request-data))
+        (progn
+          (when (and prev-url (not (matching-auto-mode-rule prev-url)))
+            (store-last-active-modes auto-mode))
+          (enable-matching-modes (url request-data) (buffer request-data)))
+        ;; Apply previous saved modes only on buffer-loads, not anytime else.
+        ;;
+        ;; TODO: Relies on somewhat illogical behavior of (url (current-buffer))
+        ;; and (url request-data) being equal after buffer-load is called.
+        ;; Replace with more stable and logical condition?
+        (when (quri:uri= (url request-data) (url (buffer auto-mode)))
+          (restore-last-active-modes auto-mode))))
+  request-data)
+
+(defun mode-covered-by-auto-mode-p (mode auto-mode-instance)
+  (or (non-rememberable-mode-p mode)
+      (let ((matching-rule (matching-auto-mode-rule
+                            (url (buffer auto-mode-instance)))))
+        (member mode (or (and matching-rule (modes matching-rule))
+                         (last-active-modes auto-mode-instance))
+                :test #'mode-equal))))
+
+(declaim (ftype (function (boolean t) (function (root-mode)))
+                make-mode-toggle-auto-mode-handler))
+(defun make-mode-toggle-prompting-handler (enable-p auto-mode-instance)
+  #'(lambda (mode)
+      (when (and (not (mode-covered-by-auto-mode-p mode auto-mode-instance))
+                 *prompt-on-mode-toggle*)
+        (nyxt::with-confirm ("Permanently ~a ~a for this URL?"
+                             (if enable-p "enable" "disable")
+                             (mode-name mode))
+          (with-result (url (read-from-minibuffer
+                             (make-minibuffer
+                              :input-prompt "URL:"
+                              :input-buffer (object-string (url (buffer mode)))
+                              :must-match-p nil)))
+            (let* ((test (make-dwim-match url))
+                   (rule (find test (auto-mode-list *browser*)
+                               :key #'test :test #'equal))
+                   (rule-modes (if rule (modes rule) (modes (buffer mode))))
+                   (modes (if enable-p
+                              (union (list mode) rule-modes :test #'mode-equal)
+                              (set-difference rule-modes (list mode)
+                                              :test #'mode-equal))))
+              (add-modes-to-auto-mode-list test modes)))))))
+
+(defun initialize-auto-mode (mode)
+  (unless (last-active-modes mode)
+    (setf (last-active-modes mode)
+          (default-modes (buffer mode))))
+  (hooks:add-hook (enable-mode-hook (buffer mode))
+                  (nyxt::make-handler-mode
+                   (make-mode-toggle-prompting-handler t mode)
+                   :name 'enable-mode-auto-mode-handler))
+  (hooks:add-hook (disable-mode-hook (buffer mode))
+                  (nyxt::make-handler-mode
+                   (make-mode-toggle-prompting-handler nil mode)
+                   :name 'disable-mode-auto-mode-handler))
+  (hooks:add-hook (request-resource-hook (buffer mode))
+                  (make-handler-resource #'auto-mode-request-handler)))
+
+(define-mode auto-mode ()
+  "Remember the modes setup for given domain/host/URL and store it in an editable form.
+These modes will then be activated on every visit to this domain/host/URL."
+  ((last-active-modes :accessor last-active-modes
+                      :type list
+                      :initform '())
+   (destructor :initform #'clean-up-auto-mode)
+   (constructor :initform #'initialize-auto-mode)))
+
+(declaim (ftype (function (string) list) make-dwim-match))
+(defun make-dwim-match (url)
+  (let ((url (or (ignore-errors (quri:uri url)) url)))
+    (if (and (quri:uri-p url)
+             (empty-path-url-p url)
+             (host-only-url-p url))
+        (if (string= (quri:uri-domain url)
+                     (cl-ppcre:regex-replace "www[0-9]?\\." (quri:uri-host url) ""))
+            `(match-domain ,(quri:uri-domain url))
+            `(match-host ,(quri:uri-host url)))
+        `(match-url ,(object-display url)))))
+
+(define-command save-modes-to-auto-mode-list ()
+  "Store the enabled modes to auto-mode-list for all the future visits of this
+domain/host/URL/group of websites inferring the suitable matching condition by user input.
+The rules are:
+- If it's a plain domain-only URL (i.e. \"http://domain.com\") -- then use `match-domain'.
+- If it's host with subdomains (\"http://whatever.subdomain.domain.com\") -- use `match-host'.
+- Use `match-url' otherwise.
+
+For the storage format see the comment in the head of your `auto-mode-list-data-path' file."
+  (if (find-submode (current-buffer) 'auto-mode)
+      (with-result (url (read-from-minibuffer
+                         (make-minibuffer
+                          :input-prompt "URL:"
+                          :input-buffer (object-string (url (current-buffer)))
+                          :suggestion-function (nyxt::history-suggestion-filter
+                                                :prefix-urls (list
+                                                              (object-string
+                                                               (url (current-buffer)))))
+                          :history (minibuffer-set-url-history *browser*)
+                          :must-match-p nil)))
+        (when (typep url 'nyxt::history-entry)
+          (setf url (url url)))
+        (add-modes-to-auto-mode-list (make-dwim-match url)
+                                     (modes (current-buffer))))
+      (echo "Enable auto-mode first.")))
+
+(declaim (ftype (function (list (or null list)) (values list &optional))
+                add-modes-to-auto-mode-list))
+(defun add-modes-to-auto-mode-list (test modes)
+  (let ((rule (or (find test (auto-mode-list *browser*) :key #'test :test #'equal)
+                  (make-instance 'auto-mode-rule :test test))))
+    (when modes
+      (setf (modes rule) (rememberable-of (mapcar #'maybe-mode-name modes))
+            (auto-mode-list *browser*) (remove-duplicates
+                                        (push rule (auto-mode-list *browser*))
+                                        :key #'test :test #'equal))
+      (store-auto-mode-list)
+      (auto-mode-list *browser*))))
+
+(defmethod serialize-object ((rule auto-mode-rule) stream)
+  (let ((*standard-output* stream)
+        (*print-case* :downcase))
+    (write-string "(" stream)
+    (if (and (eq (first (test rule)) 'match-url)
+             (= 2 (length (test rule))))
+        (format t "~s " (second (test rule)))
+        (format t "~s " (test rule)))
+    (format t ":MODES ~a"
+            (mapcar (alex:compose #'string-downcase #'symbol-name)
+                    (modes rule)))
+    (write-string ")" stream)))
+
+(defmethod deserialize-auto-mode-rules (stream)
+  (handler-case
+      (let ((*standard-input* stream))
+        (let ((rules (read stream)))
+          (mapcar #'(lambda (rule)
+                      (let ((rule (append '(:test) rule)))
+                        (when (stringp (getf rule :test))
+                          (setf (getf rule :test) `(match-url ,(getf rule :test))))
+                        (apply #'make-instance 'auto-mode-rule rule)))
+                  rules)))
+    (error (c)
+      (log:error "During auto-mode rules deserialization: ~a" c)
+      nil)))
+
+(defun store-auto-mode-list ()
+  (with-data-file (file (auto-mode-list-data-path *browser*)
+                        :direction :output
+                        :if-does-not-exist :create
+                        :if-exists :supersede)
+    (write-string ";; List of auto-mode rules.
+;; It is made to be easily readable and editable, but you still need to remember some things:
+;;
+;; Every rule starts on a new line and consists of two parts:
+;; - Condition for rule activation. It is either (match-domain ...),
+;;   (match-host ...), (match-regex ...) or a string.
+;; - :MODES -- List of the modes to enable on condition. Edit carefully:
+;;   all the modes except these and nyxt/auto-mode:*non-rememberable-modes*
+;;   will be disabled on matching URL.
+;;
+;; Conditions work this way:
+;; - match-domain matches the URL domains only.
+;;   Example: (match-domain \"reddit.com\") will work for all of Reddit.
+;; - match-host is more specific -- it activates only on certain subdomains of the website.
+;;   Example: (match-host \"old.reddit.com\") will work on old Reddit only.
+;; - match-regex works for any address that matches a given regex. You can add these manually,
+;;   but remember: with great regex comes great responsibility!
+;;   Example: \"https://github.com/.*/.*\" will activate only in repos on GitHub.
+;; - String format matches the exact URL and nothing else
+;;   Example: \"https://lispcookbook.github.io/cl-cookbook/pattern_matching.html\"
+;;            will work on the Pattern Matching article of CL Cookbook, and nowhere else.
+;;
+;; You can write additional URLs in the bracketed conditions, to reuse the rule for other URL
+;; Example: (match-host \"reddit.com\" \"old.reddit.com\" \"www6.reddit.com\")
+" file)
+    (write-string "(" file)
+    (dolist (rule (slot-value *browser* 'auto-mode-list))
+      (write-char #\newline file)
+      (serialize-object rule file))
+    (format file "~%)~%")
+    (echo "Saved ~a auto-mode rules to ~s."
+          (length (slot-value *browser* 'auto-mode-list))
+          (expand-path (auto-mode-list-data-path *browser*)))))
+
+(defun restore-auto-mode-list ()
+  (handler-case
+      (let ((data (with-data-file (file (auto-mode-list-data-path *browser*)
+                                        :direction :input
+                                        :if-does-not-exist nil)
+                    (when file (deserialize-auto-mode-rules file)))))
+        (when data
+          (echo "Loading ~a auto-mode rules from ~s."
+                (length data) (expand-path (auto-mode-list-data-path *browser*)))
+          (setf (slot-value *browser* 'auto-mode-list) data)))
+    (error (c)
+      (echo-warning "Failed to load auto-mode-list from ~s: ~a"
+                    (expand-path (auto-mode-list-data-path *browser*)) c))))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -200,6 +200,8 @@ Without handler, return ARG.  This is an acceptable `combination' for
      load-status
      modes
      default-modes
+     enable-mode-hook
+     disable-mode-hook
      keymap-scheme-name
      current-keymaps-hook
      override-map
@@ -256,6 +258,18 @@ have an empty ID.")
                   :initform '(certificate-whitelist-mode web-mode base-mode)
                   :type list-of-symbols
                   :documentation "The symbols of the classes to instantiate on buffer creation.")
+   (enable-mode-hook :accessor enable-mode-hook
+                     :initarg :enable-mode-hook
+                     :initform (make-hook-mode)
+                     :type hook-mode
+                     :documentation "Hook run on every mode activation,
+after the mode-specific hook.")
+   (disable-mode-hook :accessor disable-mode-hook
+                      :initarg :disable-mode-hook
+                      :initform (make-hook-mode)
+                      :type hook-mode
+                      :documentation "Hook run on every mode deactivation,
+after the mode-specific hook.")
    (keymap-scheme-name
     :accessor keymap-scheme-name
     :initarg :keymap-scheme-name
@@ -559,6 +573,8 @@ the empty string.")))
             session-store-function
             session-restore-function
             session-restore-prompt
+            auto-mode-list
+            auto-mode-list-data-path
             standard-output-path
             error-output-path
             before-exit-hook
@@ -756,6 +772,14 @@ from `session-path'.")
                            :initform :always-ask
                            :documentation "Ask whether to restore the
 session. Possible values are :always-ask :always-restore :never-restore.")
+   (auto-mode-list :accessor auto-mode-list
+                   :type list
+                   :initform '()
+                   :documentation "The auto-mode rules kept in memory.")
+   (auto-mode-list-data-path :accessor auto-mode-list-data-path
+                             :type data-path
+                             :initform (make-instance 'auto-mode-list-data-path :basename "auto-mode-list")
+                 :documentation "The path where the auto-mode rules are saved.")
    (standard-output-path :accessor standard-output-path
                          :type data-path
                          :initform (make-instance 'data-path :basename "standard-out.txt")
@@ -1153,7 +1177,8 @@ The following example does a few things:
    :name name))
 
 (declaim (ftype (function (string &rest string) (function (quri:uri) boolean))
-                match-scheme match-host match-domain match-file-extension))
+                match-scheme match-host match-domain
+                match-file-extension match-regex match-url))
 (export-always 'match-scheme)
 (defun match-scheme (scheme &rest other-schemes)
   "Return a predicate for URLs matching one of SCHEME or OTHER-SCHEMES."
@@ -1181,6 +1206,20 @@ The following example does a few things:
   #'(lambda (url)
       (some (alex:curry #'string= (pathname-type (or (quri:uri-path url) "")))
             (cons extension other-extensions))))
+
+(export-always 'match-regex)
+(defun match-regex (regex &rest other-regex)
+  "Return a predicate for URLs matching one of REGES or OTHER-REGEX."
+  #'(lambda (url)
+      (some (alex:rcurry #'cl-ppcre:scan (object-display url))
+            (cons regex other-regex))))
+
+(export-always 'match-url)
+(defun match-url (one-url &rest other-urls)
+  "Return a predicate for URLs exactly matching ONE-URL or OTHER-URLS."
+  #'(lambda (url)
+      (some (alex:rcurry #'string= (object-display url))
+            (cons one-url other-urls))))
 
 (defun javascript-error-handler (condition)
   (echo-warning "JavaScript error: ~a" condition))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -421,11 +421,31 @@ The current buffer access time is set to be the last."
                               oldest-buffer)))
     (set-current-buffer oldest-buffer)))
 
+(export-always 'mode-name)
+(defun mode-name (mode)
+  (class-name (class-of mode)))
+
+(declaim (ftype (function (list-of-symbols &optional buffer)) disable-modes enable-modes))
+(export-always 'disable-modes)
+(defun disable-modes (modes &optional (buffer (current-buffer)))
+  "Disable MODES for BUFFER.
+MODES should be a list symbols, each possibly returned by `mode-name'."
+  (dolist (mode modes)
+    (funcall-safely (sym (mode-command mode))
+                    :buffer buffer :activate nil)))
+
+(export-always 'enable-modes)
+(defun enable-modes (modes &optional (buffer (current-buffer)))
+  "Enable MODES for BUFFER.
+MODES should be a list of symbols, each possibly returned by `mode-name'."
+  (dolist (mode modes)
+    (funcall-safely (sym (mode-command mode))
+                    :buffer buffer :activate t)))
+
 (defun active-mode-suggestion-filter (buffers)
   "Return the union of the active modes in BUFFERS."
-  (let ((modes (delete-duplicates (mapcar (lambda (m)
-                                            (class-name (class-of m)))
-                                          (apply #'append (mapcar #'modes buffers))))))
+  (let ((modes (delete-duplicates (mapcar #'mode-name
+                                          (alex:mappend #'modes buffers)))))
     (lambda (minibuffer)
       (fuzzy-match (input-buffer minibuffer) modes))))
 
@@ -438,8 +458,7 @@ The current buffer access time is set to be the last."
                     (mode-list)))
         (common-modes (reduce #'intersection
                               (mapcar (lambda (b)
-                                        (mapcar (lambda (m) (class-name (class-of m)))
-                                                (modes b)))
+                                        (mapcar #'mode-name (modes b)))
                                       buffers))))
     (lambda (minibuffer)
       (fuzzy-match (input-buffer minibuffer) (set-difference all-non-minibuffer-modes common-modes)))))
@@ -452,9 +471,7 @@ The current buffer access time is set to be the last."
                         :multi-selection-p t
                         :suggestion-function (active-mode-suggestion-filter buffers))))
     (dolist (buffer buffers)
-      (dolist (mode modes)
-        (funcall (sym (mode-command mode))
-                 :buffer buffer :activate nil)))))
+      (disable-modes modes buffer))))
 
 (define-command disable-mode-for-buffer ()
   "Disable queried mode(s) for select buffer(s)."
@@ -473,9 +490,7 @@ The current buffer access time is set to be the last."
                         :multi-selection-p t
                         :suggestion-function (inactive-mode-suggestion-filter buffers))))
     (dolist (buffer buffers)
-      (dolist (mode modes)
-        (funcall (sym (mode-command mode))
-                 :buffer buffer :activate t)))))
+      (enable-modes modes buffer))))
 
 (define-command enable-mode-for-buffer ()
   "Enable queried mode(s) for select buffer(s)."

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -71,6 +71,8 @@ This can be used to set the path from command line.  See
   ((ref :initform "history")))
 (defclass-export download-data-path (data-path) ; TODO: Rename to downloads-data-path?
   ((ref :initform "download")))
+(defclass-export auto-mode-list-data-path (data-path)
+  ((ref :initform "auto-mode-list")))
 
 (declaim (ftype (function (string) (or string null)) find-ref-path))
 (defun find-ref-path (ref)

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -72,11 +72,13 @@ Example:
                        (when (constructor new-mode)
                          (funcall-safely (constructor new-mode) new-mode))
                        (push new-mode (modes buffer))
-                       (hooks:run-hook (enable-hook new-mode) new-mode))
+                       (hooks:run-hook (enable-hook new-mode) new-mode)
+                       (hooks:run-hook (enable-mode-hook buffer) new-mode))
                      (print-status)
                      (log:debug "~a enabled." ',name))
                    (when existing-instance
                      (hooks:run-hook (disable-hook existing-instance) existing-instance)
+                     (hooks:run-hook (disable-mode-hook buffer) existing-instance)
                      (when (destructor existing-instance)
                        (funcall-safely (destructor existing-instance) existing-instance))
                      (setf (modes buffer) (delete existing-instance

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -63,6 +63,20 @@ If it cannot be derived, return an empty `quri:uri'."
        (when url
          (uiop:emptyp (object-string url)))))
 
+(declaim (ftype (function (quri:uri) boolean)
+                empty-path-url-p host-only-url-p))
+(export-always 'empty-path-url-p)
+(defun empty-path-url-p (url)
+  (or (string= (quri:uri-path url) "/")
+      (null (quri:uri-path url))))
+
+(export-always 'host-only-url-p)
+(defun host-only-url-p (url)
+  (every #'null
+         (list (quri:uri-query url)
+               (quri:uri-fragment url)
+               (quri:uri-userinfo url))))
+
 (declaim (ftype (function (quri:uri quri:uri) boolean) schemeless-uri=))
 (defun schemeless-uri= (uri1 uri2)
   "Like `quri:uri=' but ignore scheme in comparison.


### PR DESCRIPTION
This adds a new mode that remembers the current buffer mode setup for given URLs and recovers it when the matching URL is visited.

### Motivation

Having such a mode can simplify a routine of enabling/disabling some modes (e.g., `proxy-mode`) on the websites where you need them, while not needing these modes in other places. This mode then resembles the idea of `default-modes` and make it more flexible with the ability to define the included/excluded (i.e. whitelisted/blacklisted) modes for even a small subdomain/directory of a website!

My personal pain that this mode solves is the necessity to constantly toggle proxy-mode when I need to access some academic/software-related resources blocked in Russia. Including the `proxy-mode` to the newly introduced `auto-mode-list` solves this problem and proxy gets enabled at the moment I request the addresses of the blocked websites without any additional action on my side.

### What's New

- `enable-mode-hook` and `disable-mode-hook` `buffer` slots, whose appearance was necessary for one of the use scenarios of this mode.
- `auto-mode-list` and `auto-mode-list-data-path` slots in `browser` that store the `auto-model-list` itself and the path to its serialized version respectively.
- `auto-mode` mode and two main commands of this mode `include-modes-to-auto-mode-list` and `disable-and-exclude-modes-from-auto-mode-list` that help in manipulation on the white- and blacklisted modes and seem sufficient to me (and, probably, that's not the case for everyone, so your feedback on user experience can help me a lot!).
- `*prompt-on-mode-toggle*` and `*non-rememberable-modes*` special variables that change the behavior of auto-mode:
    - `*prompt-on-mode-toggle*` defines whether `auto-mode` asks the user if they want to permanently enable/disable the mode they do enable/disable, for the URL they are visiting. That's what new hooks were necessary for!
    - `*non-rememberable-modes*` lists modes that (possibly) no user would want to white- or blacklist. There are `web-mode` that is planned to transform to `web-buffer` soon (#838); `help-mode`, whitelisting which could break Nyxt behavior given that most buffers using `help-mode` are inner and URL-less ones; and `auto-mode` itself, because it is illogical to put the `auto-mode-list`-moderating mode into `auto-mode-list` and it can cause some bugs or illogical behaviors.
- A lot of helper functions that belong to `auto-mode` and are not intended to be exported.
- auto-mode-list.lisp data-storing file intended to be easily readable and editable.
- Documentation to this mode, scattered around the `include-modes-to-auto-mode-list`, auto-mode-list.lisp and several other functions and classes.

### Use scenarios

We had a discussion on use experience with this mode is #376 with @Ambrevar. As a consequence, there are two use scenarios that I made way for:

#### Manual and undisturbing

This is the default scenario, because the `*prompt-on-mode-toggle*` variable is `nil` by default. This mode means that user manages modes themselves and adds them to the `auto-mode-list` only when there's a necessity. These additions are done through the introduced commands (`include-modes-to-auto-mode-list` and `disable-and-exclude-modes-from-auto-mode-list`) only.

#### "Smart" and annoying

This needs `*prompt-on-mode-toggle*` set to `t`. In this use scenario, on every not `non-remembered-mode` toggle on the website that is not in `auto-mode-list` yet, user is asked `"Permanently (enable|disable) %MODE-NAME for this URL?"`. Mode is included in either `included-modes` or `excluded-modes` (on mode enable/disable respectively) of suitable `auto-mode-list` entry on user consent then. The commands of the `auto-mode` are accessible in this scenario too, but they are used less because of these "smart" prompts.

### How has this been tested

- I've added `auto-mode` to the `default-modes` and ran Nyxt. There are 8 entries in my auto-mode-list.lisp now, as a result of testing, and no problems were noticed with `auto-mode` itself, but there were difficulties with other modes:
    - `proxy-mode` starts working only after page reload, but that's not a bug, that's a natural behavior of this mode :)
    - `reading-line-mode` needs toggling after you `follow-hint` the link with `reading-line-mode` enabled. It causes lots of JS errors like this otherwise:
```
<WARN> [22:27:03] Warning: JavaScript error: GError: Domain: "WebKitJavascriptError", Code: 699, Message: https://habr.com/ru/post/510588/:1:47: TypeError: null is not an object (evaluating 'document.querySelector('#reading-line-cursor').scrollIntoViewIfNeeded')
```

I'll be glad to see your feedback on this and your ideas on how to enhance the user experience with this mode!

Closes #376