### PR TITLE
Allow quri:uri in set-url* and rename it to buffer-load.

### DIFF
--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -318,8 +318,7 @@ rest in background buffers."
                           :multi-selection-p t)))
     (dolist (entry (rest entries))
       (make-buffer :url (object-string (url entry))))
-    (set-url* (object-string (url (first entries)))
-              :raw-url-p t)))
+    (buffer-load (url (first entries)))))
 
 (define-command set-url-from-bookmark-new-buffer ()
   "Open selected bookmarks in new buffers."
@@ -331,9 +330,8 @@ rest in background buffers."
                           :multi-selection-p t)))
     (dolist (entry (rest entries))
       (make-buffer :url (object-string (url entry))))
-    (set-url* (object-string (url (first entries)))
-              :buffer (make-buffer-focus :url nil)
-              :raw-url-p t)))
+    (buffer-load (url (first entries))
+                 :buffer (make-buffer-focus :url nil))))
 
 (defmethod serialize-object ((entry bookmark-entry) stream)
   (unless (url-empty-p (url entry))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -220,7 +220,6 @@ Without handler, return ARG.  This is an acceptable `combination' for
      highlighted-box-style
      proxy
      certificate-whitelist
-     set-url-hook
      buffer-delete-hook
      default-cookie-policy)))
 (defclass buffer ()
@@ -385,11 +384,11 @@ renderers might support this.")
                           :initform '()
                           :type list-of-strings
                           :documentation  "A list of hostnames for which certificate errors shall be ignored.")
-   (set-url-hook ;; :accessor set-url-hook ; TODO: Export?  Maybe not since `request-resource-hook' mostly supersedes it.
+   (buffer-load-hook ;; :accessor buffer-load-hook ; TODO: Export?  Maybe not since `request-resource-hook' mostly supersedes it.
                  :initform (make-hook-uri->uri
                             :combination #'hooks:combine-composed-hook)
                  :type hook-uri->uri
-                 :documentation "Hook run in `set-url*' after `parse-url' was processed.
+                 :documentation "Hook run in `buffer-load' after `parse-url' was processed.
 The handlers take the URL going to be loaded as argument
 and must return a (possibly new) URL.")
    (buffer-delete-hook :accessor buffer-delete-hook
@@ -987,12 +986,12 @@ This is useful to tell REPL instances from binary ones."
 (declaim (ftype (function (list-of-strings &key (:no-focus boolean)))))
 (defun open-urls (urls &key no-focus)
   "Create new buffers from URLs.
-   First URL is focused if NO-FOCUS is nil."
+First URL is focused if NO-FOCUS is nil."
   (handler-case
       (let ((first-buffer (first (mapcar
                                   (lambda (url)
                                     (let ((buffer (make-buffer)))
-                                      (set-url* url :buffer buffer)
+                                      (buffer-load url :buffer buffer)
                                       buffer))
                                   urls))))
         (when (and first-buffer (not no-focus))

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -259,7 +259,7 @@ identifier for every hinted element."
   (format nil "~a  Textarea" (hint textarea-hint)))
 
 (defmethod %follow-hint ((link-hint link-hint))
-  (set-url* (url link-hint) :buffer (current-buffer) :raw-url-p t))
+  (buffer-load (url link-hint) :buffer (current-buffer)))
 
 (defmethod %follow-hint ((button-hint button-hint))
   (click-button :nyxt-identifier (identifier button-hint)))
@@ -272,7 +272,7 @@ identifier for every hinted element."
 
 (defmethod %follow-hint-new-buffer-focus ((link-hint link-hint))
   (let ((new-buffer (make-buffer)))
-    (set-url* (url link-hint) :buffer new-buffer :raw-url-p t)
+    (buffer-load (url link-hint) :buffer new-buffer)
     (set-current-buffer new-buffer)))
 
 (defmethod %follow-hint-new-buffer-focus ((hint hint))
@@ -280,7 +280,7 @@ identifier for every hinted element."
 
 (defmethod %follow-hint-new-buffer ((link-hint link-hint))
   (let ((new-buffer (make-buffer)))
-    (set-url* (url link-hint) :buffer new-buffer :raw-url-p t)))
+    (buffer-load (url link-hint) :buffer new-buffer)))
 
 (defmethod %follow-hint-new-buffer ((hint hint))
   (echo "Unsupported operation for hint: can't open in new buffer."))

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -61,11 +61,11 @@ Can be used as a `*open-file-function*'."
       (cond
         ((and (uiop:directory-pathname-p filename)
               (uiop:directory-exists-p filename))
-         (set-url* (format nil "file://~a" (uiop:ensure-directory-pathname filename))
-                  :buffer (make-buffer-focus :url nil)))
+         (buffer-load (format nil "file://~a" (uiop:ensure-directory-pathname filename))
+                      :buffer (make-buffer-focus :url nil)))
         ((supported-media filename)
-         (set-url* (format nil "file://~a" filename)
-                  :buffer (make-buffer-focus :url nil)))
+         (buffer-load (format nil "file://~a" filename)
+                      :buffer (make-buffer-focus :url nil)))
         (t
          (uiop:launch-program
           #+linux

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -437,7 +437,7 @@ Warning: This behaviour may change in the future."
            context
            (gobject:pointer certificate)
            host)
-          (set-url* (object-string url) :buffer buffer)
+          (buffer-load url :buffer buffer)
           t)
         (progn
           (tls-help buffer url)

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -162,7 +162,7 @@ search.")
        "pagedown" 'scroll-page-down))))
   ;; Init.
   ;; TODO: Do we need to set the default URL?  Maybe not.
-  ;; (set-url* (default-new-buffer-url (buffer %mode))
+  ;; (buffer-load (default-new-buffer-url (buffer %mode))
   ;;                 (buffer %mode))
   )
 
@@ -191,7 +191,7 @@ search.")
     (if (and (input-tag-p response)
              (url-empty-p (url-at-point buffer)))
         (funcall-safely #'paste)
-        (set-url* (object-string (url-at-point buffer)) :buffer (make-buffer-focus :url nil)))))
+        (buffer-load (url-at-point buffer) :buffer (make-buffer-focus :url nil)))))
 
 (define-command maybe-scroll-to-bottom (&optional (buffer (current-buffer)))
   "Scroll to bottom if no input element is active, forward event otherwise."
@@ -209,7 +209,7 @@ search.")
         (echo "History entry is already the current URL.")
         (progn
           (setf (htree:current history) history-node)
-          (set-url* (object-string (url (htree:data history-node))))))))
+          (buffer-load (url (htree:data history-node)))))))
 
 (define-command history-backwards (&optional (buffer (current-buffer)))
   "Go to parent URL in history."
@@ -219,7 +219,7 @@ search.")
         (progn
           (htree:back (history mode))
           (match (htree:current (history mode))
-            ((guard n n) (set-url* (object-string (url (htree:data n))))))))))
+            ((guard n n) (buffer-load (url (htree:data n)))))))))
 
 (define-command history-forwards (&optional (buffer (current-buffer)))
   "Go to forward URL in history."
@@ -228,7 +228,7 @@ search.")
         (progn
           (htree:forward (history mode))
           (match (htree:current (history mode))
-            ((guard n n) (set-url* (object-string (url (htree:data n)))))))
+            ((guard n n) (buffer-load (url (htree:data n))))))
         (echo "No forward history."))))
 
 (defun history-backwards-suggestion-filter (&optional (mode (find-submode


### PR DESCRIPTION
set-url* was a wrapper around the low-level ffi-buffer-load, so to be consistent
with our other wrappers, we rename it like its low-level function minus "ffi-".

Now that our URLs are quri:uri objects, we can easily make the distinction
between raw URLs and user input that needs to be passed to parse-url: we simply
check if the argument is a string or a quri:uri.
This rids us of all the object-string conversions.

While we are at it, we unexport set-url-hook which was mistakenly exported.  We
also rename it to buffer-load-hook for consistency.