### PR TITLE
Define default search engine via default-search-engine slot

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -275,6 +275,12 @@ if there are errors, they will be reported by this function.")
                                        :documentation "When open links from an external program, or
 when C-cliking on a URL, decide whether to open in a new
 window or not.")
+   (default-search-engine :accessor default-search-engine
+                          :initform "default"
+                          :type string
+                          :documentation "Specify the default seacrh engine.
+The search-engine with this shortcut is used when none are explicitly specified
+and the query is not a valid URL.")
    (search-engines :accessor search-engines
                    :initform (list (make-instance 'search-engine
                                                   :shortcut "default"
@@ -290,9 +296,9 @@ You can invoke them from the minibuffer by prefixing your query with SHORTCUT.
 If the query is empty, FALLBACK-URL is loaded instead.  If
 FALLBACK-URL is empty, SEARCH-URL is used on an empty search.
 
-The engine with the \"default\" shortcut (or the first engine if there is no
-\"default\") is used when the query is not a valid URL, or the first keyword is
-not recognized.")
+The engine specified by default-search-engine (or the first engine if there is
+no \"default\") is used when the query is not a valid URL, or the first keyword
+is not recognized.")
    (key-stack :accessor key-stack :initform '()
               :documentation "A stack that keeps track of the key chords a user has pressed.")
    (downloads :accessor downloads :initform '()

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -113,8 +113,8 @@ bookmarks."
             (bookmark-search-engines))))
 
 (defun default-search-engine (&optional (search-engines (all-search-engines)))
-  "Return the search engine with the 'default' shortcut, or the first one if
-there is none."
-  (or (find "default"
+  "Return the search-engine that matches default-search-engine, or the first
+one if there is none."
+  (or (find (slot-value *browser* 'default-search-engine)
             search-engines :test #'string= :key #'shortcut)
       (first search-engines)))


### PR DESCRIPTION
Previously, the magic value "default" in a search-engine signified it as
the default search engine. This commit factors that hard-coded value
into the browser slot default-search-engine instead.

The motivating use case for this change is to provide modes an easy
method of changing the default search engine. In particular, users may
wish to default to an onion URL when proxy-mode is enabled with Tor.