### PR TITLE
Fix match-url non-matching in auto-mode

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -138,7 +138,7 @@ in auto-mode-list on mode activation/deactivation.")
           (with-result (url (read-from-minibuffer
                              (make-minibuffer
                               :input-prompt "URL:"
-                              :input-buffer (object-string (url (buffer mode)))
+                              :input-buffer (object-display (url (buffer mode)))
                               :must-match-p nil)))
             (let* ((test (make-dwim-match url))
                    (rule (find test (auto-mode-list *browser*)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -811,7 +811,7 @@ The following example does a few things:
   "Return a predicate for URLs exactly matching ONE-URL or OTHER-URLS."
   #'(lambda (url)
       (some (alex:rcurry #'string= (object-display url))
-            (cons one-url other-urls))))
+            (mapcar #'quri:url-decode (cons one-url other-urls)))))
 
 (defun javascript-error-handler (condition)
   (echo-warning "JavaScript error: ~a" condition))


### PR DESCRIPTION
This fixes the problem with `match-url` never wofking on `auto-mode`-saved URLs, mentioned in #868.

### Roots

The root of the problem was `object-string` used instead of `object-display` in `auto-mode` code.

### Caveats

As a precaution against the decoding issues, all the URLs passed to `match-url` are now decoded. Can it cause any problem?