### PR TITLE
auto-mode: fix dangling prompting handlers outside auto-mode

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -71,10 +71,12 @@ in auto-mode-list on mode activation/deactivation.")
                    buffer)))
 
 (defun clean-up-auto-mode (mode)
-  (dolist (handler-name '(auto-mode-request-handler
-                          enable-mode-prompting-handler
-                          disable-mode-prompting-handler))
-    (hooks:remove-hook (request-resource-hook (buffer mode)) handler-name)))
+  (hooks:remove-hook (request-resource-hook (buffer mode))
+                     'auto-mode-request-handler)
+  (hooks:remove-hook (enable-mode-hook (buffer mode))
+                     'enable-mode-auto-mode-handler)
+  (hooks:remove-hook (disable-mode-hook (buffer mode))
+                     'disable-mode-auto-mode-handler))
 
 (defun store-last-active-modes (auto-mode)
   (setf (last-active-modes auto-mode)


### PR DESCRIPTION
This fixes the issue of prompting handlers of `auto-mode` still being active even when `auto-mode` is disabled.

Additionally, this fixes a small naming mismatch of these handlers in `initialize-auto-mode` and `clean-up-auto-mode`.

### How Has This Been Tested (and bug recipe)
- Add `(setf nyxt/auto-mode:*prompt-on-mode-toggle* t)` in your init file and `start` Nyxt.
- Enable `auto-mode` if it's not enabled yet.
- Navigate to the website that has no associated `auto-mode` rules.
- Disable `auto-mode`.
- Turn some mode on/off (I tested with `reading-line-mode`, but any rememberable mode should behave the same).
    - Without this patch: you'll be prompted whether to save the mode settings, even though `auto-mode` is disabled.
    - With this patch: the toggled mode will toggle just fine, no prompts.

Is in line with the changes discussed in #868.

EDIT: add the reference to the issue.