### PR TITLE
Rename auto-mode-list to auto-mode-rules

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -3,19 +3,19 @@
   (:import-from #:serapeum #:export-always)
   (:documentation "Mode for automatic URL-based mode toggling."))
 (in-package :nyxt/auto-mode)
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria))
 
 (export-always '*prompt-on-mode-toggle*)
 (defvar *prompt-on-mode-toggle* nil
   "Whether user will be asked about adding the mode to included/excluded modes
-in auto-mode-list on mode activation/deactivation.")
+in `auto-mode-rules' on mode activation/deactivation.")
 
 (export-always '*non-rememberable-modes*)
 (defvar *non-rememberable-modes*
   ;; Base mode conflicts with its Nyxt symbol if it's not prefixed
   '(help-mode web-mode auto-mode nyxt::base-mode)
-  "Modes that AUTO-MODE won't even try to save.")
+  "Modes that `auto-mode' won't even try to save.
+Append names of modes you want to always control manually to this list.
+Be careful with deleting the defaults -- it can be harmful for your browsing.")
 
 (declaim (ftype (function ((or symbol root-mode)) (values symbol &optional)) maybe-mode-name))
 (defun maybe-mode-name (mode)
@@ -54,7 +54,7 @@ in auto-mode-list on mode activation/deactivation.")
                   #'(lambda (rule)
                       (funcall-safely
                        (apply (first (test rule)) (rest (test rule))) url))
-                  (or (auto-mode-list *browser*) (restore-auto-mode-list)))
+                  (or (auto-mode-rules *browser*) (restore-auto-mode-rules)))
                  #'priority :key #'test))))
 
 (declaim (ftype (function (quri:uri buffer)) enable-matching-modes))
@@ -127,7 +127,7 @@ in auto-mode-list on mode activation/deactivation.")
                 :test #'mode-equal))))
 
 (declaim (ftype (function (boolean t) (function (root-mode)))
-                make-mode-toggle-auto-mode-handler))
+                make-mode-toggle-prompting-handler))
 (defun make-mode-toggle-prompting-handler (enable-p auto-mode-instance)
   #'(lambda (mode)
       (when (and (not (mode-covered-by-auto-mode-p mode auto-mode-instance))
@@ -141,14 +141,14 @@ in auto-mode-list on mode activation/deactivation.")
                               :input-buffer (object-display (url (buffer mode)))
                               :must-match-p nil)))
             (let* ((test (make-dwim-match url))
-                   (rule (find test (auto-mode-list *browser*)
+                   (rule (find test (auto-mode-rules *browser*)
                                :key #'test :test #'equal))
                    (rule-modes (if rule (modes rule) (modes (buffer mode))))
                    (modes (if enable-p
                               (union (list mode) rule-modes :test #'mode-equal)
                               (set-difference rule-modes (list mode)
                                               :test #'mode-equal))))
-              (add-modes-to-auto-mode-list test modes)))))))
+              (add-modes-to-auto-mode-rules test modes)))))))
 
 (defun initialize-auto-mode (mode)
   (unless (last-active-modes mode)
@@ -186,15 +186,15 @@ These modes will then be activated on every visit to this domain/host/URL."
             `(match-host ,(quri:uri-host url)))
         `(match-url ,(object-display url)))))
 
-(define-command save-modes-to-auto-mode-list ()
-  "Store the enabled modes to auto-mode-list for all the future visits of this
+(define-command save-modes-to-auto-mode-rules ()
+  "Store the enabled modes to `auto-mode-rules' for all the future visits of this
 domain/host/URL/group of websites inferring the suitable matching condition by user input.
 The rules are:
 - If it's a plain domain-only URL (i.e. \"http://domain.com\") -- then use `match-domain'.
 - If it's host with subdomains (\"http://whatever.subdomain.domain.com\") -- use `match-host'.
 - Use `match-url' otherwise.
 
-For the storage format see the comment in the head of your `auto-mode-list-data-path' file."
+For the storage format see the comment in the head of your `auto-mode-rules-data-path' file."
   (if (find-submode (current-buffer) 'auto-mode)
       (with-result (url (read-from-minibuffer
                          (make-minibuffer
@@ -208,22 +208,22 @@ For the storage format see the comment in the head of your `auto-mode-list-data-
                           :must-match-p nil)))
         (when (typep url 'nyxt::history-entry)
           (setf url (url url)))
-        (add-modes-to-auto-mode-list (make-dwim-match url)
-                                     (modes (current-buffer))))
+        (add-modes-to-auto-mode-rules (make-dwim-match url)
+                                      (modes (current-buffer))))
       (echo "Enable auto-mode first.")))
 
 (declaim (ftype (function (list (or null list)) (values list &optional))
-                add-modes-to-auto-mode-list))
-(defun add-modes-to-auto-mode-list (test modes)
-  (let ((rule (or (find test (auto-mode-list *browser*) :key #'test :test #'equal)
+                add-modes-to-auto-mode-rules))
+(defun add-modes-to-auto-mode-rules (test modes)
+  (let ((rule (or (find test (auto-mode-rules *browser*) :key #'test :test #'equal)
                   (make-instance 'auto-mode-rule :test test))))
     (when modes
       (setf (modes rule) (rememberable-of (mapcar #'maybe-mode-name modes))
-            (auto-mode-list *browser*) (delete-duplicates
-                                        (push rule (auto-mode-list *browser*))
-                                        :key #'test :test #'equal))
-      (store-auto-mode-list)
-      (auto-mode-list *browser*))))
+            (auto-mode-rules *browser*) (delete-duplicates
+                                         (push rule (auto-mode-rules *browser*))
+                                         :key #'test :test #'equal))
+      (store-auto-mode-rules)
+      (auto-mode-rules *browser*))))
 
 (defmethod serialize-object ((rule auto-mode-rule) stream)
   (let ((*standard-output* stream)
@@ -233,9 +233,7 @@ For the storage format see the comment in the head of your `auto-mode-list-data-
              (= 2 (length (test rule))))
         (format t "~s " (second (test rule)))
         (format t "~s " (test rule)))
-    (format t ":modes ~a"
-            (mapcar (alex:compose #'string-downcase #'symbol-name)
-                    (modes rule)))
+    (format t ":modes ~a" (modes rule))
     (write-string ")" stream)))
 
 (defmethod deserialize-auto-mode-rules (stream)
@@ -252,8 +250,8 @@ For the storage format see the comment in the head of your `auto-mode-list-data-
       (log:error "During auto-mode rules deserialization: ~a" c)
       nil)))
 
-(defun store-auto-mode-list ()
-  (with-data-file (file (auto-mode-list-data-path *browser*)
+(defun store-auto-mode-rules ()
+  (with-data-file (file (auto-mode-rules-data-path *browser*)
                         :direction :output
                         :if-does-not-exist :create
                         :if-exists :supersede)
@@ -283,24 +281,24 @@ For the storage format see the comment in the head of your `auto-mode-list-data-
 ;; Example: (match-host \"reddit.com\" \"old.reddit.com\" \"www6.reddit.com\")
 " file)
     (write-string "(" file)
-    (dolist (rule (slot-value *browser* 'auto-mode-list))
+    (dolist (rule (slot-value *browser* 'auto-mode-rules))
       (write-char #\newline file)
       (serialize-object rule file))
     (format file "~%)~%")
     (echo "Saved ~a auto-mode rules to ~s."
-          (length (slot-value *browser* 'auto-mode-list))
-          (expand-path (auto-mode-list-data-path *browser*)))))
+          (length (slot-value *browser* 'auto-mode-rules))
+          (expand-path (auto-mode-rules-data-path *browser*)))))
 
-(defun restore-auto-mode-list ()
+(defun restore-auto-mode-rules ()
   (handler-case
-      (let ((data (with-data-file (file (auto-mode-list-data-path *browser*)
+      (let ((data (with-data-file (file (auto-mode-rules-data-path *browser*)
                                         :direction :input
                                         :if-does-not-exist nil)
                     (when file (deserialize-auto-mode-rules file)))))
         (when data
           (echo "Loading ~a auto-mode rules from ~s."
-                (length data) (expand-path (auto-mode-list-data-path *browser*)))
-          (setf (slot-value *browser* 'auto-mode-list) data)))
+                (length data) (expand-path (auto-mode-rules-data-path *browser*)))
+          (setf (slot-value *browser* 'auto-mode-rules) data)))
     (error (c)
-      (echo-warning "Failed to load auto-mode-list from ~s: ~a"
-                    (expand-path (auto-mode-list-data-path *browser*)) c))))
+      (echo-warning "Failed to load auto-mode-rules from ~s: ~a"
+                    (expand-path (auto-mode-rules-data-path *browser*)) c))))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -179,8 +179,8 @@ the empty string.")))
             session-store-function
             session-restore-function
             session-restore-prompt
-            auto-mode-list
-            auto-mode-list-data-path
+            auto-mode-rules
+            auto-mode-rules-data-path
             standard-output-path
             error-output-path
             before-exit-hook
@@ -375,13 +375,14 @@ from `session-path'.")
                            :initform :always-ask
                            :documentation "Ask whether to restore the
 session. Possible values are :always-ask :always-restore :never-restore.")
-   (auto-mode-list :accessor auto-mode-list
-                   :type list
-                   :initform '()
-                   :documentation "The auto-mode rules kept in memory.")
-   (auto-mode-list-data-path :accessor auto-mode-list-data-path
-                             :type data-path
-                             :initform (make-instance 'auto-mode-list-data-path :basename "auto-mode-list")
+   (auto-mode-rules :accessor auto-mode-rules
+                    :type list
+                    :initform '()
+                    :documentation "The list of auto-mode rules kept in memory.")
+   (auto-mode-rules-data-path :accessor auto-mode-rules-data-path
+                              :type data-path
+                              :initform (make-instance 'auto-mode-rules-data-path
+                                                       :basename "auto-mode-rules")
                  :documentation "The path where the auto-mode rules are saved.")
    (standard-output-path :accessor standard-output-path
                          :type data-path

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -71,8 +71,8 @@ This can be used to set the path from command line.  See
   ((ref :initform "history")))
 (defclass-export download-data-path (data-path) ; TODO: Rename to downloads-data-path?
   ((ref :initform "download")))
-(defclass-export auto-mode-list-data-path (data-path)
-  ((ref :initform "auto-mode-list")))
+(defclass-export auto-mode-rules-data-path (data-path)
+  ((ref :initform "auto-mode-rules")))
 
 (declaim (ftype (function (string) (or string null)) find-ref-path))
 (defun find-ref-path (ref)


### PR DESCRIPTION
This changes the names of the `auto-mode-list`, `auto-mode-list-data-path` and related functions&commands (ending with `-auto-mode-list`) in `auto-mode`, to `auto-mode-rules`, `auto-mode-rules-data-patch` and `*-auto-mode-rules` (i.e. names ending with `-auto-mode-rules`).

Additionally, there are several minor code/formatting changes like small docstring fixes and serialization of modes' list without `symbol-name` and `string-downcase`.

### Motivation

`auto-mode-list` can sound similar to Emacs' `auto-mode-alist`, but not all the Nyxt userbase is using Emacs, so it's better to stick to a more straightforward name. `*-auto-mode-rules` names fit the situation better, because these are `auto-mode-rule` objects that we manipulate with these variables.

### Caveats

You need to manually rename auto-mode-list.lisp to auto-mode-rules.lisp in your Nyxt data directory to keep the `auto-mode` rules accumulated there for future sessions.

### How Has It Been Tested

I renamed the rules file and ran Nyxt. I've added several rules for different domains, and they were stored. I was browsing the matching and non-matching websites, and it all was working well. 

Given that this change is mainly just a variable renaming, it's not going to be extremely buggy (and I've `grep`-d it to make sure that there are no more `*-auto-mode-list` names in the code).

I'll be glad if you test it and say what you think!

Related to discussion in #868.

EDIT: add the reference to the issue.