### PR TITLE
auto-mode: Make auto-mode dynamic & extract auto-mode-handler to a new hook

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -16,6 +16,7 @@
      current-keymaps-hook
      override-map
      forward-input-events-p
+     pre-request-hook
      request-resource-scheme
      request-resource-hook
      default-new-buffer-url
@@ -128,6 +129,15 @@ forwarded when no binding is found.")
                :initform nil
                ;; TODO: Store multiple events?  Maybe when implementing keyboard macros.
                :documentation "The last event that was received for the current buffer.")
+   (pre-request-hook :accessor pre-request-hook
+                     :initarg :pre-request-hook
+                     :initform (make-hook-resource
+                                :combination #'combine-composed-hook-until-nil)
+                     :type hook-resource
+                     :documentation "Hook run before the `request-resource-hook'.
+One example of it's application is `auto-mode' that changes mode setup. Any
+action on modes that can possibly change the handlers in `request-resource-hook'
+should find its place there.")
    (request-resource-scheme :accessor request-resource-scheme
                             :initarg :request-resource-scheme
                             :initform (define-scheme "request-resource"
@@ -568,7 +578,7 @@ See `make-buffer'."
 (define-command delete-all-buffers ()
   "Delete all buffers, with confirmation."
   (let ((count (length (buffer-list))))
-    (with-confirm ("Are you sure to delete ~a buffer~p?" count count)
+    (if-confirm ("Are you sure to delete ~a buffer~p?" count count)
       (delete-buffers))))
 
 (define-command delete-current-buffer (&optional (buffer (current-buffer)))
@@ -583,7 +593,7 @@ to the currently active buffer."
   (let* ((all-buffers (buffer-list))
          (buffers-to-delete (remove buffer all-buffers))
          (count (list-length buffers-to-delete)))
-    (with-confirm ("Are you sure to delete ~a buffer~p?" count count)
+    (if-confirm ("Are you sure to delete ~a buffer~p?" count count)
       (mapcar #'buffer-delete buffers-to-delete))))
 
 ;; WARNING: Don't use this parenscript, use the TITLE buffer slot instead.

--- a/source/macro.lisp
+++ b/source/macro.lisp
@@ -105,7 +105,7 @@ Example:
 (export-always '*yes-no-choices*)
 (defparameter *yes-no-choices* '(:yes "yes" :no "no")
   "The suggestions when asking the user for a yes/no choice.
-See `with-confirm'.
+See `if-confirm'.
 The first suggestion poses as a default.")
 
 (defun yes-no-suggestion-filter ()
@@ -115,20 +115,22 @@ The first suggestion poses as a default.")
 (defun confirmed-p (answer)
   (string-equal answer (getf *yes-no-choices* :yes)))
 
-(export-always 'with-confirm)
-(defmacro with-confirm (prompt &body body)
-  "Ask the user for confirmation before executing BODY.
+(export-always 'if-confirm)
+(defmacro if-confirm (prompt yes-form &optional no-form)
+  "Ask the user for confirmation before executing either YES-FORM of NO-FORM.
+YES-FORM is executed on  \"yes\" answer, NO-FORM -- on \"no\".
 PROMPT is a list fed to `format nil'.
 
 Example usage defaulting to \"no\":
 
 \(let ((*yes-no-choices* '(:no \"no\" :yes \"yes\")))
-  (with-confirm (\"Are you sure to kill ~a buffers?\" count)
+  (if-confirm (\"Are you sure to kill ~a buffers?\" count)
      (delete-buffers)))"
   `(with-result (answer (read-from-minibuffer
                          (make-minibuffer
                           :input-prompt (format nil ,@prompt)
                           :suggestion-function (yes-no-suggestion-filter)
                           :hide-suggestion-count-p t)))
-     (when (confirmed-p answer)
-       ,@body)))
+     (if (confirmed-p answer)
+         ,yes-form
+         ,no-form)))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -509,17 +509,19 @@ Warning: This behaviour may change in the future."
           (webkit:webkit-policy-decision-use response-policy-decision)
           nil)
         (let ((request-data
-                (hooks:run-hook (request-resource-hook buffer)
-                                (make-instance 'request-data
-                                               :buffer buffer
-                                               :url (quri:copy-uri url)
-                                               :keys (unless (uiop:emptyp mouse-button)
-                                                       (list (keymap:make-key
-                                                              :value mouse-button
-                                                              :modifiers modifiers)))
-                                               :event-type event-type
-                                               :new-window-p is-new-window
-                                               :known-type-p is-known-type))))
+                (hooks:run-hook
+                 (request-resource-hook buffer)
+                 (hooks:run-hook (pre-request-hook buffer)
+                                 (make-instance 'request-data
+                                                :buffer buffer
+                                                :url (quri:copy-uri url)
+                                                :keys (unless (uiop:emptyp mouse-button)
+                                                        (list (keymap:make-key
+                                                               :value mouse-button
+                                                               :modifiers modifiers)))
+                                                :event-type event-type
+                                                :new-window-p is-new-window
+                                                :known-type-p is-known-type)))))
           (cond
             ((null request-data)
              (log:debug "Don't forward to renderer (null request data).")

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -249,7 +249,7 @@ To change the default buffer, e.g. set it to a given URL:
                  (log:info "Restoring session ~s." (expand-path (session-path *browser*)))
                  (funcall (session-restore-function *browser*)))))
         (match (session-restore-prompt *browser*)
-          (:always-ask (with-confirm ("Restore previous session?")
+          (:always-ask (if-confirm ("Restore previous session?")
                          (restore-session)))
           (:always-restore (restore-session))
           (:never-restore (log:info "Not restoring session.")))))))


### PR DESCRIPTION
This refactors `auto-mode` to make it more stable and enables somewhat dynamic default behavior at the cost of minor backwards-incompatibility.

### What's New (numbered as in #868):
- [**7**](https://github.com/atlas-engineer/nyxt/issues/868#issuecomment-664440162): `pre-request-hook` made exclusively for `auto-mode` and ran right before `request-resource-hook`. Putting `auto-mode-handler` into `request-resource-hook` was dangerous, because `auto-mode` modifies the contents of `request-resource-hook` and cannot control the order of handlers in it. This makes for the unpredictable behavior, as described in #868.
- [**4**](https://github.com/atlas-engineer/nyxt/issues/868#issuecomment-664311865): New commands, `enable-modes-for-future-visits` and `disable-modes-for-future-visits`, to enable the dynamic control of the enabled\disabled modes (e.g. modes' inclusion and exclusion that doesn't define the exact mode list, but only states that some modes should be there and some shouldn't).
- [**2**](https://github.com/atlas-engineer/nyxt/issues/868#issue-666172472): Several conditions are now extracted to the dedicated predicates for debugging and ease of reading. Examples are `can-store-last-active-modes`, `new-page-request-p`, and `history-empty-p`.
- `save-modes-to-auto-mode-list` is now called `save-exact-modes-for-future-visits` and saves an exact list of modes, much like it was in the initial version of auto-mode.
- `add-modes-to-auto-mode-rules` is now a Swiss knife of mode storage and has a lot of keyword arguments that help to put most repetitive mode control tasks in one place.
- User-oriented rename:
  - `save-modes-to-auto-mode-list` → `save-exact-modes-for-future-visits` (new commands are named in the same style).
  - `make-dwim-match` → `url-infer-match`.
- Documentation fixes, examples and additions.

### What's Not There (Yet) (numbered as in #868)
- [**1**](https://github.com/atlas-engineer/nyxt/issues/868#issue-666172472): There's no `mode-symbol` type yet, because I've seen no strict necessity in it while making these changes — the existing set of functions is comfortable enough. I don't deny the possible necessity of `mode-symbol` though. We need to discuss it a bit more, because now the advantages and implementation are unclear to me.
- [**5**](https://github.com/atlas-engineer/nyxt/issues/868#issuecomment-664332178): There's no mode confirmation dialog, because it's still unclear to me what should trigger this dialog and why should it be there. Once I understand the value of this dialog (possibly due to discussion with use cases and examples), I'll be glad to implement it!

### Caveats and Workarounds

Storage format have changed significantly. Now, If you want to use your old `auto-mode` rules with new `auto-mode`, you need to make some changes to your auto-mode-rules.lisp:
- Replace `:modes` keyword with `:included` keyword.
- Add `:exact-p t` phrase to the end of every rule.

These changes will reproduce the same behavior as previous version of `auto-mode`.

However, if you want to use new features, like  dynamic mode control, you'll need to either delete/rewrite some of the rules by browsing (I'm not sure it's going to be smooth...), or fix them manually:
- Replace `:modes` keyword with `:included` keyword. Delete modes you already have in your `default-modes`, from the list. 
  - E.g., if your rule was `("foo.bar" :modes (emacs-mode blocker-mode proxy-mode))`, but `emacs-mode` and `blocker-mode` are already in your defaults, then your rule can be shortened to `("foo.bar" :included (proxy-mode))`!
- (optional) Add `:excluded` keyword with a list of modes you don't want to ever see enabled for a given rule.
- (optional) Add `:exact-p t` if you want the rule to enable exactly the `:included` modes and nothing else.

### How Has This Been Tested

- I've loaded Nyxt to a fresh REPL and ran it for an hour, creating rules and testing edge-cases discussed in #868. It seems to work pretty well. Some behaviors have changed, so feedback on usability and/or bugs is welcome!

Possibly closes #868. Look Caveats for something to discuss before merging and closing the issue.

EDIT: add link to the possibly solved issue.