### PR TITLE
terminology: change to allow/deny-list terminology

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -82,7 +82,7 @@
                (:file "application-mode")
                (:file "web-mode")
                (:file "reading-line-mode")
-               (:file "certificate-allowlist-mode")
+               (:file "certificate-exception-mode")
                (:file "emacs-mode")
                (:file "vi-mode")
                (:file "blocker-mode")

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -82,7 +82,7 @@
                (:file "application-mode")
                (:file "web-mode")
                (:file "reading-line-mode")
-               (:file "certificate-whitelist-mode")
+               (:file "certificate-allowlist-mode")
                (:file "emacs-mode")
                (:file "vi-mode")
                (:file "blocker-mode")

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -154,7 +154,7 @@ Example:
              :combination #'combine-composed-hook-until-nil
              :handlers (list #'request-resource-block)))))))
 
-(defmethod denylisted-host-p ((mode blocker-mode) host)
+(defmethod blocklisted-host-p ((mode blocker-mode) host)
   "Return non-nil of HOST if found in the hostlists of MODE.
 Return nil if MODE's hostlist cannot be parsed."
   (when host
@@ -162,11 +162,11 @@ Return nil if MODE's hostlist cannot be parsed."
                never (member-string host (parse hostlist))))))
 
 (defun request-resource-block (request-data)
-  "Block resource queries from denylisted hosts.
+  "Block resource queries from blocklisted hosts.
 This is an acceptable handler for `request-resource-hook'."
   (let ((mode (find-submode (buffer request-data) 'blocker-mode)))
     (if (and mode
-             (denylisted-host-p
+             (blocklisted-host-p
               mode
               (quri:uri-host (url request-data))))
         (progn

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -1,6 +1,6 @@
 (uiop:define-package :nyxt/blocker-mode
   (:use :common-lisp :trivia :nyxt)
-  (:documentation "Block resource queries blacklisted hosts."))
+  (:documentation "Block resource queries for listed hosts."))
 (in-package :nyxt/blocker-mode)
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
@@ -119,7 +119,7 @@ Return nil if hostlist cannot be parsed."
   "Default hostlist for `blocker-mode'.")
 
 (define-mode blocker-mode ()
-    "Enable blocking of blacklisted hosts.
+    "Enable blocking of listed hosts.
 To customize the list of blocked hosts, set the `hostlists' slot.
 See the `hostlist' class documentation.
 
@@ -154,7 +154,7 @@ Example:
              :combination #'combine-composed-hook-until-nil
              :handlers (list #'request-resource-block)))))))
 
-(defmethod blacklisted-host-p ((mode blocker-mode) host)
+(defmethod denylisted-host-p ((mode blocker-mode) host)
   "Return non-nil of HOST if found in the hostlists of MODE.
 Return nil if MODE's hostlist cannot be parsed."
   (when host
@@ -162,11 +162,11 @@ Return nil if MODE's hostlist cannot be parsed."
                never (member-string host (parse hostlist))))))
 
 (defun request-resource-block (request-data)
-  "Block resource queries from blacklisted hosts.
+  "Block resource queries from denylisted hosts.
 This is an acceptable handler for `request-resource-hook'."
   (let ((mode (find-submode (buffer request-data) 'blocker-mode)))
     (if (and mode
-             (blacklisted-host-p
+             (denylisted-host-p
               mode
               (quri:uri-host (url request-data))))
         (progn

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -53,7 +53,7 @@ Parent directories are created if necessary."
                    :documentation "The address of the proxy server.
 It's made of three components: protocol, host and port.
 Example: \"http://192.168.1.254:8080\".")
-   (whitelist :accessor whitelist :initarg :whitelist
+   (allowlist :accessor allowlist :initarg :allowlist
               :initform '("localhost" "localhost:8080")
               :type list-of-strings
               :documentation "A list of URIs not to forward to the proxy.")

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -31,7 +31,7 @@
      box-style
      highlighted-box-style
      proxy
-     certificate-allowlist
+     certificate-exception
      buffer-delete-hook
      default-cookie-policy)))
 (defclass buffer ()
@@ -71,7 +71,7 @@ initialized buffer.")
    (default-modes :accessor default-modes
                   :initarg :default-modes
                   :type list-of-symbols
-                  :initform '(certificate-allowlist-mode web-mode base-mode)
+                  :initform '(certificate-exception-mode web-mode base-mode)
                   :documentation "The symbols of the modes to instantiate on buffer creation.
 The mode instances are stored in the `modes' slot.")
    (enable-mode-hook :accessor enable-mode-hook
@@ -214,7 +214,7 @@ renderers might support this.")
    (proxy :initform nil
           :type (or proxy null)
           :documentation "Proxy for buffer.")
-   (certificate-allowlist :accessor certificate-allowlist
+   (certificate-exception :accessor certificate-exception
                           :initform '()
                           :type list-of-strings
                           :documentation  "A list of hostnames for which certificate errors shall be ignored.")

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -31,7 +31,7 @@
      box-style
      highlighted-box-style
      proxy
-     certificate-whitelist
+     certificate-allowlist
      buffer-delete-hook
      default-cookie-policy)))
 (defclass buffer ()
@@ -71,7 +71,7 @@ initialized buffer.")
    (default-modes :accessor default-modes
                   :initarg :default-modes
                   :type list-of-symbols
-                  :initform '(certificate-whitelist-mode web-mode base-mode)
+                  :initform '(certificate-allowlist-mode web-mode base-mode)
                   :documentation "The symbols of the modes to instantiate on buffer creation.
 The mode instances are stored in the `modes' slot.")
    (enable-mode-hook :accessor enable-mode-hook
@@ -214,7 +214,7 @@ renderers might support this.")
    (proxy :initform nil
           :type (or proxy null)
           :documentation "Proxy for buffer.")
-   (certificate-whitelist :accessor certificate-whitelist
+   (certificate-allowlist :accessor certificate-allowlist
                           :initform '()
                           :type list-of-strings
                           :documentation  "A list of hostnames for which certificate errors shall be ignored.")
@@ -246,7 +246,7 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
   (if proxy
       (ffi-buffer-set-proxy buffer
                             (server-address proxy)
-                            (whitelist proxy))
+                            (allowlist proxy))
       (ffi-buffer-set-proxy buffer
                             (quri:uri "")
                             nil)))

--- a/source/certificate-allowlist-mode.lisp
+++ b/source/certificate-allowlist-mode.lisp
@@ -1,32 +1,32 @@
-(uiop:define-package :nyxt/certificate-whitelist-mode
+(uiop:define-package :nyxt/certificate-allowlist-mode
   (:use :common-lisp :trivia :nyxt)
-  (:documentation "Certificate whitelist mode"))
-(in-package :nyxt/certificate-whitelist-mode)
+  (:documentation "Certificate allowlist mode"))
+(in-package :nyxt/certificate-allowlist-mode)
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum))
 
-(sera:export-always '*default-certificate-whitelist*)
-(defparameter *default-certificate-whitelist* '()
+(sera:export-always '*default-certificate-allowlist*)
+(defparameter *default-certificate-allowlist* '()
   "List of hostnames for which to ignore certificate errors.
-See the `add-domain-to-certificate-whitelist' command.")
+See the `add-domain-to-certificate-allowlist' command.")
 
-(define-mode certificate-whitelist-mode ()
+(define-mode certificate-allowlist-mode ()
   "Enable ignoring of certificate errors.
 This can apply to specific buffers.
-See the `add-domain-to-certificate-whitelist' command."
-  ((certificate-whitelist :initarg :certificate-whitelist
-                          :accessor certificate-whitelist
+See the `add-domain-to-certificate-allowlist' command."
+  ((certificate-allowlist :initarg :certificate-allowlist
+                          :accessor certificate-allowlist
                           :type list-of-strings
-                          :initform *default-certificate-whitelist*)
+                          :initform *default-certificate-allowlist*)
    (destructor
     :initform
     (lambda (mode)
-      (setf (certificate-whitelist (buffer mode)) nil)))
+      (setf (certificate-allowlist (buffer mode)) nil)))
    (constructor
     :initform
     (lambda (mode)
-      (setf (certificate-whitelist (buffer mode)) (certificate-whitelist mode))))))
+      (setf (certificate-allowlist (buffer mode)) (certificate-allowlist mode))))))
 
 (defun previous-history-urls-suggestion-filter (&optional (mode (find-submode
                                                             (current-buffer)
@@ -41,25 +41,25 @@ See the `add-domain-to-certificate-whitelist' command."
           (fuzzy-match (input-buffer minibuffer) parents)
           '()))))
 
-(define-command add-domain-to-certificate-whitelist (&optional (buffer (current-buffer)))
-  "Add the current hostname to the buffer's certificate whitelist.
-This is only effective if `certificate-whitelist-mode' is enabled.
+(define-command add-domain-to-certificate-allowlist (&optional (buffer (current-buffer)))
+  "Add the current hostname to the buffer's certificate allowlist.
+This is only effective if `certificate-allowlist-mode' is enabled.
 
 To make this change permanent, you can customize
-`*default-certificate-whitelist*' in your init file:
+`*default-certificate-allowlist*' in your init file:
 
-\(setf nyxt/certificate-whitelist-mode:*default-certificate-whitelist*
+\(setf nyxt/certificate-allowlist-mode:*default-certificate-allowlist*
       '(\"nyxt.atlas.engineer\" \"example.org\"))"
-  (if (find-submode buffer 'certificate-whitelist-mode)
+  (if (find-submode buffer 'certificate-allowlist-mode)
       (with-result (input (read-from-minibuffer
                            (make-minibuffer
-                            :input-prompt "URL host to whitelist"
+                            :input-prompt "URL host to allowlist:"
                             :suggestion-function (previous-history-urls-suggestion-filter))))
         (unless (url-empty-p (url (htree:data input)))
           (let ((host (quri:uri-host (url (htree:data input)))))
-            (echo "Whitelisted ~s." host)
-            (pushnew host (certificate-whitelist buffer) :test #'string=))))
-      (echo "Enable certificate-whitelist-mode first.")))
+            (echo "Allowlisted ~s." host)
+            (pushnew host (certificate-allowlist buffer) :test #'string=))))
+      (echo "Enable certificate-allowlist-mode first.")))
 
-;; TODO: Implement command remove-domain-from-certificate-whitelist.
+;; TODO: Implement command remove-domain-from-certificate-allowlist.
 ;;       Currently it is not possible due to WebKit limitations.

--- a/source/certificate-exception-mode.lisp
+++ b/source/certificate-exception-mode.lisp
@@ -1,32 +1,32 @@
-(uiop:define-package :nyxt/certificate-allowlist-mode
+(uiop:define-package :nyxt/certificate-exception-mode
   (:use :common-lisp :trivia :nyxt)
-  (:documentation "Certificate allowlist mode"))
-(in-package :nyxt/certificate-allowlist-mode)
+  (:documentation "Certificate excetption mode"))
+(in-package :nyxt/certificate-exception-mode)
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum))
 
-(sera:export-always '*default-certificate-allowlist*)
-(defparameter *default-certificate-allowlist* '()
+(sera:export-always '*default-certificate-exception*)
+(defparameter *default-certificate-exception* '()
   "List of hostnames for which to ignore certificate errors.
-See the `add-domain-to-certificate-allowlist' command.")
+See the `add-domain-to-certificate-exception' command.")
 
-(define-mode certificate-allowlist-mode ()
+(define-mode certificate-exception-mode ()
   "Enable ignoring of certificate errors.
 This can apply to specific buffers.
-See the `add-domain-to-certificate-allowlist' command."
-  ((certificate-allowlist :initarg :certificate-allowlist
-                          :accessor certificate-allowlist
+See the `add-domain-to-certificate-exception' command."
+  ((certificate-exception :initarg :certificate-exception
+                          :accessor certificate-exception
                           :type list-of-strings
-                          :initform *default-certificate-allowlist*)
+                          :initform *default-certificate-exception*)
    (destructor
     :initform
     (lambda (mode)
-      (setf (certificate-allowlist (buffer mode)) nil)))
+      (setf (certificate-exception (buffer mode)) nil)))
    (constructor
     :initform
     (lambda (mode)
-      (setf (certificate-allowlist (buffer mode)) (certificate-allowlist mode))))))
+      (setf (certificate-exception (buffer mode)) (certificate-exception mode))))))
 
 (defun previous-history-urls-suggestion-filter (&optional (mode (find-submode
                                                             (current-buffer)
@@ -41,25 +41,25 @@ See the `add-domain-to-certificate-allowlist' command."
           (fuzzy-match (input-buffer minibuffer) parents)
           '()))))
 
-(define-command add-domain-to-certificate-allowlist (&optional (buffer (current-buffer)))
-  "Add the current hostname to the buffer's certificate allowlist.
-This is only effective if `certificate-allowlist-mode' is enabled.
+(define-command add-domain-to-certificate-exception (&optional (buffer (current-buffer)))
+  "Add the current hostname to the buffer's certificate exception list.
+This is only effective if `certificate-exception-mode' is enabled.
 
 To make this change permanent, you can customize
-`*default-certificate-allowlist*' in your init file:
+`*default-certificate-exception*' in your init file:
 
-\(setf nyxt/certificate-allowlist-mode:*default-certificate-allowlist*
+\(setf nyxt/certificate-exception-mode:*default-certificate-exception*
       '(\"nyxt.atlas.engineer\" \"example.org\"))"
-  (if (find-submode buffer 'certificate-allowlist-mode)
+  (if (find-submode buffer 'certificate-exception-mode)
       (with-result (input (read-from-minibuffer
                            (make-minibuffer
-                            :input-prompt "URL host to allowlist:"
+                            :input-prompt "URL host to exception list:"
                             :suggestion-function (previous-history-urls-suggestion-filter))))
         (unless (url-empty-p (url (htree:data input)))
           (let ((host (quri:uri-host (url (htree:data input)))))
-            (echo "Allowlisted ~s." host)
-            (pushnew host (certificate-allowlist buffer) :test #'string=))))
-      (echo "Enable certificate-allowlist-mode first.")))
+            (echo "Added exception for ~s." host)
+            (pushnew host (certificate-exception buffer) :test #'string=))))
+      (echo "Enable certificate-exception-mode first.")))
 
-;; TODO: Implement command remove-domain-from-certificate-allowlist.
+;; TODO: Implement command remove-domain-from-certificate-exception.
 ;;       Currently it is not possible due to WebKit limitations.

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -21,7 +21,7 @@ Use at your own risk -- it can break websites whose certificates are not known
 and websites that still don't have HTTPS version (shame on them!).
 
 To permanently bypass the \"Unacceptable TLS Certificate\" error:
-\(setf nyxt/certificate-whitelist-mode:*default-certificate-whitelist*
+\(setf nyxt/certificate-allowlist-mode:*default-certificate-allowlist*
        '(\"your.unacceptable.cert.website\"))
 
 Example:

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -21,7 +21,7 @@ Use at your own risk -- it can break websites whose certificates are not known
 and websites that still don't have HTTPS version (shame on them!).
 
 To permanently bypass the \"Unacceptable TLS Certificate\" error:
-\(setf nyxt/certificate-allowlist-mode:*default-certificate-allowlist*
+\(setf nyxt/certificate-exception-mode:*default-certificate-exception*
        '(\"your.unacceptable.cert.website\"))
 
 Example:

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -262,14 +262,14 @@ could mean that the address you are attempting the access is
 compromised.")
             (:p "If you trust the address nonetheless, you can add an exception
 for the current hostname with the "
-                (:code "add-domain-to-certificate-allowlist")
+                (:code "add-domain-to-certificate-exception")
                 " command.  The "
-                (:code "certificate-allowlist-mode")
+                (:code "certificate-exception-mode")
                 " must be active for the current buffer (which is the
 default).")
             (:p "To persist hostname exceptions in your initialization
 file, see the "
-                (:code "add-domain-to-certificate-allowlist")
+                (:code "add-domain-to-certificate-exception")
                 " documentation.")))
          (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
                                    (ps:lisp help-contents)))))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -262,14 +262,14 @@ could mean that the address you are attempting the access is
 compromised.")
             (:p "If you trust the address nonetheless, you can add an exception
 for the current hostname with the "
-                (:code "add-domain-to-certificate-whitelist")
+                (:code "add-domain-to-certificate-allowlist")
                 " command.  The "
-                (:code "certificate-whitelist-mode")
+                (:code "certificate-allowlist-mode")
                 " must be active for the current buffer (which is the
 default).")
             (:p "To persist hostname exceptions in your initialization
 file, see the "
-                (:code "add-domain-to-certificate-whitelist")
+                (:code "add-domain-to-certificate-allowlist")
                 " documentation.")))
          (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
                                    (ps:lisp help-contents)))))

--- a/source/proxy-mode.lisp
+++ b/source/proxy-mode.lisp
@@ -9,7 +9,7 @@
 (defparameter *default-proxy*
   (make-instance *proxy-class*
                  :server-address (quri:uri "socks5://localhost:9050")
-                 :whitelist '("localhost" "localhost:8080")
+                 :allowlist '("localhost" "localhost:8080")
                  :proxied-downloads-p t))
 
 (define-mode proxy-mode ()
@@ -22,7 +22,7 @@ Example to use Tor as a proxy both for browsing and downloading:
 \(setf nyxt/proxy-mode:*default-proxy*
   (make-instance *proxy-class*
                  :server-address (quri:uri \"socks5://localhost:9050\")
-                 :whitelist '(\"localhost\" \"localhost:8080\")
+                 :allowlist '(\"localhost\" \"localhost:8080\")
                  :proxied-downloads-p t))
 
 \(define-configuration buffer
@@ -39,6 +39,6 @@ Example to use Tor as a proxy both for browsing and downloading:
     :initform
     (lambda (mode)
       (setf (proxy (buffer mode)) (proxy mode))
-      (echo "Proxy set to ~a (whitelisting ~a)."
+      (echo "Proxy set to ~a (allowlisting ~a)."
             (object-display (server-address (proxy mode)))
-            (whitelist (proxy mode)))))))
+            (allowlist (proxy mode)))))))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -454,8 +454,8 @@ Warning: This behaviour may change in the future."
   "Return nil to propagate further (i.e. raise load-failed signal), T otherwise."
   (let* ((context (webkit:webkit-web-view-web-context (gtk-object buffer)))
          (host (quri:uri-host url)))
-    (if (and (certificate-allowlist buffer)
-             (member-string host (certificate-allowlist buffer)))
+    (if (and (certificate-exception buffer)
+             (member-string host (certificate-exception buffer)))
         (progn
           (webkit:webkit-web-context-allow-tls-certificate-for-host
            context

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -454,8 +454,8 @@ Warning: This behaviour may change in the future."
   "Return nil to propagate further (i.e. raise load-failed signal), T otherwise."
   (let* ((context (webkit:webkit-web-view-web-context (gtk-object buffer)))
          (host (quri:uri-host url)))
-    (if (and (certificate-whitelist buffer)
-             (member-string host (certificate-whitelist buffer)))
+    (if (and (certificate-allowlist buffer)
+             (member-string host (certificate-allowlist buffer)))
         (progn
           (webkit:webkit-web-context-allow-tls-certificate-for-host
            context

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -27,7 +27,7 @@ instance of Nyxt."
 Currently we store the list of current URLs of all buffers."
   ;; TODO: Should we persist keymaps, constructors, etc.?  For instance, should
   ;; we restore the proxy value?  It may be wiser to let the user configure
-  ;; whitelitss / blacklists instead.  It's also easier
+  ;; allow/deny lists instead.  It's also easier
   (with-data-file (file (session-path *browser*)
                         :direction :output
                         :if-does-not-exist :create

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -19,9 +19,9 @@
             :type htree:history-tree
             :initarg :history
             :initform (htree:make))
-   (history-denylist :accessor history-denylist
+   (history-blocklist :accessor history-blocklist
                       :type list-of-strings
-                      :initarg :history-denylist
+                      :initarg :history-blocklist
                       ;; TODO: Find a more automated way to do it.  WebKitGTK
                       ;; automatically removes such redirections from its
                       ;; history.  How?
@@ -400,7 +400,7 @@ Otherwise go forward to the only child."
   (declare (type quri:uri url))
   (unless (or (url-empty-p url)
               (find-if (alex:rcurry #'str:starts-with? (object-string url))
-                       (history-denylist mode)))
+                       (history-blocklist mode)))
     (htree:add-child (make-instance 'buffer-description
                                     :url url
                                     :title (title (buffer mode)))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -19,9 +19,9 @@
             :type htree:history-tree
             :initarg :history
             :initform (htree:make))
-   (history-blacklist :accessor history-blacklist
+   (history-denylist :accessor history-denylist
                       :type list-of-strings
-                      :initarg :history-blacklist
+                      :initarg :history-denylist
                       ;; TODO: Find a more automated way to do it.  WebKitGTK
                       ;; automatically removes such redirections from its
                       ;; history.  How?
@@ -400,7 +400,7 @@ Otherwise go forward to the only child."
   (declare (type quri:uri url))
   (unless (or (url-empty-p url)
               (find-if (alex:rcurry #'str:starts-with? (object-string url))
-                       (history-blacklist mode)))
+                       (history-denylist mode)))
     (htree:add-child (make-instance 'buffer-description
                                     :url url
                                     :title (title (buffer mode)))


### PR DESCRIPTION
Following a conversation on IRC yesterday, I went ahead and made a relatively trivial change to use allow/deny terminally in appropriate contexts. 

I think the cost/risk of this change is pretty minimal, the impact to the interface is small, and I think the potential for impact may be worthwhile. I'm particularly thinking about: 
- potential contributors who might struggle the legacy language for any number of reasons, who's contribution we'd miss as a result. 
- potential confusion, particularly across language barriers. The new language is clear and explicit, and consistent with the way that other projects are thinking about these constructs (e.g. the linux kernel made a similar change to its language earlier this year.)