### PR TITLE
auto-mode.lisp: stop persisting empty auto-mode rules

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -303,9 +303,13 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
                                  (when append-p
                                    (set-difference (excluded rule) include)))
           (auto-mode-rules *browser*) (delete-duplicates
-                                       (push rule (auto-mode-rules *browser*))
+                                       (append (when (or (included rule) (excluded rule))
+                                                 (list rule))
+                                               (auto-mode-rules *browser*))
                                        :key #'test :test #'equal))
-    (store-auto-mode-rules)
+    (if (or (included rule) (excluded rule))
+        (store-auto-mode-rules)
+        (echo "You have only default-modes enabled in this buffer. There's nothing to save."))
     (auto-mode-rules *browser*)))
 
 (defmethod serialize-object ((rule auto-mode-rule) stream)


### PR DESCRIPTION
This stops empty `auto-mode` rules (i.e. the ones where neither `included` nor `excluded` modes are present) from being saved and notifies the user that they are trying to save their own `default-modes` as mode setup for a given URL.

Related to [9](https://github.com/atlas-engineer/nyxt/issues/868#issuecomment-670918838) in #868.

EDIT: Add reference to issue.