### PR TITLE
Internal buffer support/example usage

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -556,7 +556,7 @@ Deal with REQUEST-DATA with the following rules:
       (declare (type quri:uri url))
       (cond
         ((internal-buffer-p buffer)
-         (evaluate (quri:url-decode (quri:uri-domain url)))
+         (evaluate (quri:url-decode (schemeless-url url)))
          nil)
         (bound-function
          (log:debug "Resource request key sequence ~a" (keyspecs-with-optional-keycode keys))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -555,6 +555,9 @@ Deal with REQUEST-DATA with the following rules:
                                 (keymap:lookup-key keys keymap))))
       (declare (type quri:uri url))
       (cond
+        ((internal-buffer-p buffer)
+         (evaluate (quri:url-decode (quri:uri-domain url)))
+         nil)
         (bound-function
          (log:debug "Resource request key sequence ~a" (keyspecs-with-optional-keycode keys))
          (funcall-safely bound-function :url url)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -261,6 +261,12 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                   :documentation "The symbols of the modes to instantiate on buffer creation.
 The mode instances are stored in the `modes' slot.")))
 
+(defmethod internal-buffer-p ((buffer buffer))
+  nil)
+
+(defmethod internal-buffer-p ((internal-buffer internal-buffer))
+  t)
+
 (defmethod proxy ((buffer buffer))
   (slot-value buffer 'proxy))
 

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -365,13 +365,14 @@ The version number is stored in the clipboard."
                          (buffer-list))))
     (unless buffer
       (setf buffer (nyxt/help-mode:help-mode :activate t
-                                             :buffer (make-buffer :title "*Messages*"))))
+                                             :buffer (make-internal-buffer :title "*Messages*"))))
     (let* ((content
-             (apply #'markup:markup*
-                    '(:h1 "Messages")
-                    (mapcar (lambda (message)
-                              (list :p message))
-                            (reverse (messages-content *browser*)))))
+             (markup:markup
+              (:h1 "Messages")
+              (:a :href (lisp-url "(clear-messages)(messages)") "Clear Messages")
+              (:ul
+               (loop for message in (reverse (messages-content *browser*))
+                     collect (markup:markup (:li message))))))
            (insert-content (ps:ps (setf (ps:@ document body |innerHTML|)
                                         (ps:lisp content)))))
       (ffi-buffer-evaluate-javascript buffer insert-content))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -369,7 +369,7 @@ The version number is stored in the clipboard."
     (let* ((content
              (markup:markup
               (:h1 "Messages")
-              (:a :href (lisp-url "(clear-messages)(messages)") "Clear Messages")
+              (:a :href (lisp-url "(nyxt::clear-messages)(nyxt::messages)") "Clear Messages")
               (:ul
                (loop for message in (reverse (messages-content *browser*))
                      collect (markup:markup (:li message))))))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -369,7 +369,7 @@ The version number is stored in the clipboard."
     (let* ((content
              (markup:markup
               (:h1 "Messages")
-              (:a :href (lisp-url "(nyxt::clear-messages)(nyxt::messages)") "Clear Messages")
+              (:a :href (lisp-url "(nyxt:clear-messages)(nyxt:messages)") "Clear messages")
               (:ul
                (loop for message in (reverse (messages-content *browser*))
                      collect (markup:markup (:li message))))))

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -138,8 +138,9 @@ there is none."
             search-engines :test #'string= :key #'shortcut)
       (first search-engines)))
 
-(defun lisp-url (data)
+(declaim (ftype (function (string)) lisp-url))
+(defun lisp-url (lisp-data)
   "Generate a Lisp URL from a string. This is useful for encoding
 functionality into internal-buffers."
-  (str:concat "lisp://" (quri:url-encode data)))
+  (str:concat "lisp://" (quri:url-encode lisp-data)))
 

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -130,3 +130,16 @@ Otherwise, build a search query with the default search engine."
             (t (match (default-search-engine search-engines)
                  (nil (quri:uri input-url))
                  (default (quri:uri (generate-search-query input-url (search-url default)))))))))))
+
+(defun default-search-engine (&optional (search-engines (all-search-engines)))
+  "Return the search engine with the 'default' shortcut, or the first one if
+there is none."
+  (or (find "default"
+            search-engines :test #'string= :key #'shortcut)
+      (first search-engines)))
+
+(defun lisp-url (data)
+  "Generate a Lisp URL from a string. This is useful for encoding
+functionality into internal-buffers."
+  (str:concat "lisp://" (quri:url-encode data)))
+


### PR DESCRIPTION
Please try the MESSAGES command to see an example of usage.

Summary:

+ we have internal buffers
+ if there is an internal buffer resource request, evaluate it assuming it is a Lisp form
+ the Lisp forms of internal buffers take the above form as embedded HREFs with the target lisp://(some-lisp-code-to-evaluate)

Should you desire to navigate to a URL on the WWW from an internal buffer, you will have to use code that creates a new buffer or otherwise sets the URL of the internal buffer manually. This is intentional as a security measure.

I think this will do a fair bit in lowering the barrier to entry for Nyxt users :-)