### PR TITLE
Composite search

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -79,6 +79,7 @@
                (:file "auto-mode")
                (:file "external-editor")
                (:file "url-group")
+               (:file "minibuffer-composite")
                ;; Core Modes
                (:file "base-mode")
                (:file "repl-mode")

--- a/source/minibuffer-composite.lisp
+++ b/source/minibuffer-composite.lisp
@@ -1,11 +1,11 @@
 (in-package :nyxt)
 
 (defclass meta-result ()
-  ((display :accessor display :initarg :display)
+  ((result :accessor result :initarg :result)
    (source-minibuffer :accessor source-minibuffer :initarg :source)))
 
 (defmethod object-display ((meta-result meta-result))
-  (format nil "~a" (object-display (display meta-result))))
+  (format nil "~a" (object-display (result meta-result))))
 
 (defun meta-search (minibuffers)
   "Search a composite set of sources simultaneously."
@@ -21,7 +21,7 @@
                                              (funcall (suggestion-function i)
                                                       (input-buffer minibuffer))
                                           collect (make-instance 'meta-result
-                                                                 :display result
+                                                                 :result result
                                                                  :source i))))))))
     (funcall (slot-value (source-minibuffer selection) 'callback) selection)))
 
@@ -32,11 +32,11 @@
     (make-minibuffer
      :suggestion-function
      (lambda (i) (fuzzy-match i (list "Carp" "Goldfish" "Salmon")))
-     :callback (lambda (i) (format t "Hello ~a" (display i))))
+     :callback (lambda (i) (format t "Hello ~a" (result i))))
     (make-minibuffer
      :suggestion-function
      (lambda (i) (fuzzy-match i (list "Turtle" "Box Turtle" "Sea Water Turtle")))
-     :callback (lambda (i) (print (display i)))))))
+     :callback (lambda (i) (print (result i)))))))
 
 (defun intertwine (&rest lists)
   (let ((heads (copy-list lists))

--- a/source/minibuffer-composite.lisp
+++ b/source/minibuffer-composite.lisp
@@ -1,0 +1,39 @@
+(in-package :nyxt)
+
+(defstruct minibuffer-source
+  (suggestion-function)
+  (result-function))
+
+(define-command meta-search ()
+  "Search a composite set of sources simultaneously."
+  (let ((minibuffers (list
+                      (make-minibuffer-source
+                       :suggestion-function (lambda (i) (fuzzy-match i (list "Turtle" "Sea Turtle" "Box Turtle")))
+                       :result-function (lambda (i)
+                                          (print i)))
+                      (make-minibuffer-source
+                       :suggestion-function (lambda (i) (fuzzy-match i (list "Salmon" "Carp" "Swordfish")))
+                       :result-function (lambda (i)
+                                          (print i))))))
+    (with-result (selection (read-from-minibuffer
+                             (make-minibuffer
+                              :input-prompt "Open bookmarks in new buffers"
+                              :default-modes '(minibuffer-tag-mode minibuffer-mode)
+                              :suggestion-function
+                              (lambda (minibuffer)
+                                (apply #'intertwine
+                                       (mapcar (lambda (i)
+                                                 (funcall (minibuffer-source-suggestion-function i)
+                                                          (input-buffer minibuffer)))
+                                               minibuffers))))))
+      (print selection))))
+
+(defun intertwine (&rest lists)
+  (let ((heads (copy-list lists))
+        (result '()))
+    (loop (loop for list on heads do
+                   (when (car list)
+                     (push (pop (car list)) result))
+                   (when (every #'null heads)
+                     (return-from intertwine (nreverse result)))))))
+

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -36,7 +36,8 @@
 string and returns a list of suggestion strings.
 Example: `buffer-suggestion-filter'.")
    (callback :initform nil
-             :documentation "Function to call over the selected suggestion.")
+             :documentation "Function to call over the selected suggestion."
+             :initarg :callback)
    (callback-buffer :initarg :callback-buffer
                     :accessor callback-buffer
                     :initform (when *browser* (current-buffer))
@@ -182,6 +183,7 @@ A minibuffer query is typically done as follows:
     (&key (default-modes nil explicit-default-modes)
        (suggestion-function nil explicit-suggestion-function)
        (callback-buffer nil explicit-callback-buffer)
+       (callback nil explicit-callback)
        (setup-function nil explicit-setup-function)
        (cleanup-function nil explicit-cleanup-function)
        (changed-callback nil explicit-changed-callback)
@@ -209,6 +211,9 @@ A minibuffer query is typically done as follows:
                    '())
              ,@(if explicit-callback-buffer
                    `(:callback-buffer ,callback-buffer)
+                   '())
+             ,@(if explicit-callback
+                   `(:callback ,callback)
                    '())
              ,@(if explicit-setup-function
                    `(:setup-function ,setup-function)


### PR DESCRIPTION
This is a demonstration of the composite search behavior we have spoken about. A single minibuffer shows the result from several mini buffers. Each result can have different behavior upon selection. This allows us to compose the results from buffer switch, bookmark select etc into one cohesive minibuffer, and still perform the appropriate action with the selection.