### PR TITLE
Add per-buffer data storage

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -11,7 +11,7 @@
 (export-always '*prompt-on-mode-toggle*)
 (defvar *prompt-on-mode-toggle* nil
   "Whether user will be asked about adding the mode to included/excluded modes
-in `auto-mode-rules' on mode activation/deactivation.")
+in the auto-mode rules on mode activation/deactivation.")
 
 (export-always '*non-rememberable-modes*)
 (defvar *non-rememberable-modes*
@@ -53,9 +53,9 @@ Enable INCLUDED modes plus the already present ones, and disable EXCLUDED modes,
   (:export-accessor-names-p t)
   (:accessor-name-transformer #'class*:name-identity))
 
-(declaim (ftype (function (quri:uri) (or auto-mode-rule null))
+(declaim (ftype (function (quri:uri buffer) (or auto-mode-rule null))
                 matching-auto-mode-rule))
-(defun matching-auto-mode-rule (url)
+(defun matching-auto-mode-rule (url buffer)
   (flet ((priority (test1 test2)
            (let ((priority-list '(match-regex match-url match-host match-domain)))
              (< (or (position (first test1) priority-list) 4)
@@ -64,12 +64,13 @@ Enable INCLUDED modes plus the already present ones, and disable EXCLUDED modes,
                   #'(lambda (rule)
                       (funcall-safely
                        (apply (first (test rule)) (rest (test rule))) url))
-                  (or (auto-mode-rules *browser*) (restore-auto-mode-rules)))
+                  (or (get-data (auto-mode-rules-path buffer))
+                      (restore (data-profile buffer) (auto-mode-rules-path buffer))))
                  #'priority :key #'test))))
 
 (declaim (ftype (function (quri:uri buffer)) enable-matching-modes))
 (defun enable-matching-modes (url buffer)
-  (let ((rule (matching-auto-mode-rule url)))
+  (let ((rule (matching-auto-mode-rule url buffer)))
     (enable-modes (set-difference
                    (included rule)
                    (rememberable-of (mapcar #'mode-name (modes buffer)))
@@ -82,16 +83,16 @@ Enable INCLUDED modes plus the already present ones, and disable EXCLUDED modes,
                        (excluded rule))
                    buffer)))
 
-(defun can-store-last-active-modes (auto-mode url)
+(defun can-save-last-active-modes (auto-mode url)
   (or (null (last-active-modes-url auto-mode))
       (not (quri:uri= url (last-active-modes-url auto-mode)))))
 
-(defun store-last-active-modes (auto-mode url)
-  (when (can-store-last-active-modes auto-mode url)
+(defun save-last-active-modes (auto-mode url)
+  (when (can-save-last-active-modes auto-mode url)
       (setf (last-active-modes auto-mode) (modes (buffer auto-mode))
             (last-active-modes-url auto-mode) url)))
 
-(defun restore-last-active-modes (auto-mode)
+(defun reapply-last-active-modes (auto-mode)
   (disable-modes
    (mapcar #'maybe-mode-name
            (set-difference (modes (buffer auto-mode))
@@ -126,21 +127,22 @@ non-new-page requests, buffer URL is not altered."
            (unless (history-empty-p (history web-mode))
              (url (htree:data
                    (htree:parent (htree:current (history web-mode)))))))
-         (rule (matching-auto-mode-rule (url request-data)))
-         (previous-rule (when previous-url (matching-auto-mode-rule previous-url))))
+         (rule (matching-auto-mode-rule (url request-data) (buffer request-data)))
+         (previous-rule (when previous-url (matching-auto-mode-rule previous-url (buffer request-data)))))
     (when (and rule previous-url (not previous-rule))
-      (store-last-active-modes auto-mode previous-url))
+      (save-last-active-modes auto-mode previous-url))
     (cond
       ((and (not rule) (new-page-request-p request-data))
-       (restore-last-active-modes auto-mode))
-      ((and rule (not (equal rule previous-rule)))
+       (reapply-last-active-modes auto-mode))
+      ((and rule (not (equalp rule previous-rule)))
        (enable-matching-modes (url request-data) (buffer request-data)))))
   request-data)
 
 (defun mode-covered-by-auto-mode-p (mode auto-mode enable-p)
   (or (non-rememberable-mode-p mode)
       (let ((matching-rule (matching-auto-mode-rule
-                            (url (buffer auto-mode)))))
+                            (url (buffer auto-mode))
+                            (buffer auto-mode))))
         (member mode (or (and matching-rule (union (included matching-rule)
                                                    (excluded matching-rule)))
                          ;; Mode is covered by auto-mode only if it is
@@ -232,7 +234,7 @@ on the last URL not covered by `auto-mode'.")
 (define-command save-non-default-modes-for-future-visits ()
   "Save the modes present in `default-modes' and not present in current modes as :excluded,
 and modes that are present in mode list but not in `default-modes' as :included,
-to one of `auto-mode-rules'. Apply the resulting rule for all the future visits to this URL,
+to one of auto-mode rules. Apply the resulting rule for all the future visits to this URL,
 inferring the matching condition with `url-infer-match'.
 
 For the storage format see the comment in the head of your `auto-mode-rules-data-path' file."
@@ -258,7 +260,7 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
                               :test #'mode-equal))))
 
 (define-command save-exact-modes-for-future-visits ()
-  "Store the exact list of enabled modes to `auto-mode-rules' for all the future visits of this
+  "Store the exact list of enabled modes to auto-mode rules for all the future visits of this
 domain/host/URL/group of websites inferring the suitable matching condition by user input.
 Uses `url-infer-match', see its documentation for matching rules.
 
@@ -286,26 +288,25 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
                           (values list &optional))
                 add-modes-to-auto-mode-rules))
 (defun add-modes-to-auto-mode-rules (test &key (append-p nil) exclude include (exact-p nil))
-  (let* ((rule (or (find test (auto-mode-rules *browser*) :key #'test :test #'equal)
-                   (make-instance 'auto-mode-rule :test test)))
-         (include  (rememberable-of (mapcar #'maybe-mode-name include)))
-         (exclude  (rememberable-of (mapcar #'maybe-mode-name exclude))))
-    (setf (exact-p rule) exact-p
-          (included rule) (union include
-                                 (when append-p
-                                   (set-difference (included rule) exclude)))
-          (excluded rule) (union exclude
-                                 (when append-p
-                                   (set-difference (excluded rule) include)))
-          (auto-mode-rules *browser*) (delete-duplicates
-                                       (append (when (or (included rule) (excluded rule))
-                                                 (list rule))
-                                               (auto-mode-rules *browser*))
-                                       :key #'test :test #'equal))
-    (if (or (included rule) (excluded rule))
-        (store-auto-mode-rules)
-        (echo "Only default modes are enabled in this buffer, there's nothing to save."))
-    (auto-mode-rules *browser*)))
+  (with-data-access rules (auto-mode-rules-path (current-buffer))
+    (let* ((rule (or (find test rules
+                           :key #'test :test #'equal)
+                     (make-instance 'auto-mode-rule :test test)))
+           (include  (rememberable-of (mapcar #'maybe-mode-name include)))
+           (exclude  (rememberable-of (mapcar #'maybe-mode-name exclude))))
+      (setf (exact-p rule) exact-p
+            (included rule) (union include
+                                   (when append-p
+                                     (set-difference (included rule) exclude)))
+            (excluded rule) (union exclude
+                                   (when append-p
+                                     (set-difference (excluded rule) include)))
+            rules (delete-duplicates
+                   (append (when (or (included rule) (excluded rule))
+                             (list rule))
+                           rules)
+                   :key #'test :test #'equal)))
+    rules))
 
 (defmethod serialize-object ((rule auto-mode-rule) stream)
   (flet ((write-if-present (slot)
@@ -339,8 +340,8 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
       (log:error "During auto-mode rules deserialization: ~a" c)
       nil)))
 
-(defun store-auto-mode-rules ()
-  (with-data-file (file (auto-mode-rules-data-path *browser*)
+(defmethod store ((profile data-profile) (path auto-mode-rules-data-path))
+  (with-data-file (file path
                         :direction :output
                         :if-does-not-exist :create
                         :if-exists :supersede)
@@ -372,27 +373,23 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
 ;; You can write additional URLs in the bracketed conditions, to reuse the rule for other URL
 ;; Example: (match-host \"reddit.com\" \"old.reddit.com\" \"www6.reddit.com\")
 " file)
-      (write-string "(" file)
-      (dolist (rule (slot-value nyxt:*browser* 'nyxt:auto-mode-rules))
-        (write-char #\newline file)
-        (serialize-object rule file))
-      (format file "~%)~%"))
-    (echo "Saved ~a auto-mode rules to ~s."
-          (length (slot-value *browser* 'auto-mode-rules))
-          (expand-path (auto-mode-rules-data-path *browser*)))))
+    (write-string "(" file)
+    (dolist (rule (get-data path))
+      (write-char #\newline file)
+      (serialize-object rule file))
+    (format file "~%)~%")
+    (echo "Saved ~a auto-mode rules to ~s." (length (get-data path)) (expand-path path)))))
 
-(defun restore-auto-mode-rules ()
+(defmethod restore ((profile data-profile) (path auto-mode-rules-data-path))
   (handler-case
-      (let ((data (with-data-file (file (auto-mode-rules-data-path *browser*)
+      (let ((data (with-data-file (file path
                                         :direction :input
                                         :if-does-not-exist nil)
                     (when file
                       (let ((*package* (find-package :nyxt/auto-mode)))
                         (deserialize-auto-mode-rules file))))))
         (when data
-          (echo "Loading ~a auto-mode rules from ~s."
-                (length data) (expand-path (auto-mode-rules-data-path *browser*)))
-          (setf (slot-value *browser* 'auto-mode-rules) data)))
+          (echo "Loading ~a auto-mode rules from ~s." (length data) (expand-path path))
+          (setf (get-data path) data)))
     (error (c)
-      (echo-warning "Failed to load auto-mode-rules from ~s: ~a"
-                    (expand-path (auto-mode-rules-data-path *browser*)) c))))
+      (echo-warning "Failed to load auto-mode-rules from ~s: ~a" (expand-path path) c))))

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -143,31 +143,3 @@ Initialization file use case:
     (error ()
       ;; Improper list.
       list)))
-
-(export-always 'expand-path)
-(declaim (ftype (function ((or null data-path)) (or string null)) expand-path))
-(defun expand-path (data-path)
-  "Return the expanded path of DATA-PATH or nil if there is none.
-`expand-data-path' is dispatched against `data-path' and `*browser*'s
-`data-profile' if `*browser*' is instantiated, `+default-data-profile+'
-otherwise.
-This function can be used on browser-less globals like `*init-file-path*'."
-  (when data-path
-    (the (values (or string null) &optional)
-         (match (if *browser*
-                    (expand-data-path (data-profile *browser*) data-path)
-                    (expand-data-path +default-data-profile+ data-path))
-           ("" nil)
-           (m (uiop:native-namestring m))))))
-
-(export-always 'with-data-file)
-(defmacro with-data-file ((stream data-path &rest options) &body body)
-  "Evaluate BODY with STREAM bound to DATA-PATH.
-DATA-PATH can be a GPG-encrypted file if it ends with a .gpg extension.
-If DATA-PATH expands to NIL or the empty string, do nothing.
-OPTIONS are as for `open'.
-Parent directories are created if necessary."
-  `(let ((path (expand-path ,data-path)))
-     (when path
-       (with-maybe-gpg-file (,stream path ,@options)
-         ,@body))))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -177,23 +177,27 @@ GnuPG documentation for how to set it up.")
     (:p "Example to create a development data-profile that stores all data in "
         (:code "/tmp/nyxt") " and stores bookmark in an encrypted file:")
     (:pre (:code "
-\(defvar +dev-data-profile+ (make-instance 'data-profile :name \"dev\")
-  \"Development profile.\")
+\(define-class dev-data-profile (data-profile)
+   ((name :initform \"dev\"))
+   (:export-class-name-p t)
+   (:export-accessor-names-p t)
+   (:accessor-name-transformer #'class*:name-identity)
+   (:documentation \"Development profile.\"))
 
-\(defmethod nyxt:expand-data-path ((profile (eql +dev-data-profile+)) (path data-path))
+\(defmethod nyxt:expand-data-path ((profile dev-data-profile) (path data-path))
   \"Persist data to /tmp/nyxt/.\"
   (expand-default-path (make-instance (class-name (class-of path))
                                       :basename (basename path)
                                       :dirname \"/tmp/nyxt/\")))
 
-\(defmethod nyxt:expand-data-path ((profile (eql +dev-data-profile+)) (path session-data-path))
+\(defmethod nyxt:expand-data-path ((profile dev-data-profile) (path session-data-path))
   \"Persist session to default location.\"
-  (expand-data-path +default-data-profile+ path))
+  (expand-data-path *global-data-profile* path))
 
 ;; Make new profile the default:
-\(define-configuration browser
-  ((data-profile (or (find-data-profile (getf *options* :data-profile))
-                     +dev-data-profile+))
+\(define-configuration buffer
+  ((data-profile (make-instance (or (find-data-profile (getf *options* :data-profile))
+                                    'dev-data-profile)))
    (bookmarks-path (make-instance 'bookmarks-data-path
                                   :basename \"~/personal/bookmarks/bookmarks.lisp.gpg\"))))"))
     (:p "Then you can start an instance of Nyxt using this profile

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -36,7 +36,8 @@ the empty string."))
           (make-string (max 0 (- 10 (length (shortcut engine)))) :initial-element #\no-break_space)
           (search-url engine)))
 
-(defun bookmark-search-engines (&optional (bookmarks (bookmarks-data *browser*)))
+(defun bookmark-search-engines (&optional (bookmarks (get-data (bookmarks-path
+                                                                (current-buffer)))))
   (mapcar (lambda (b)
             (make-instance 'search-engine
                            :shortcut (shortcut b)

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -139,8 +139,8 @@ place rather than having to jump around on a buffer (or multiple buffers).")
     (:li (command-markup 'nyxt/web-mode:remove-search-hints) ": Remove the highlighting around the search hits."))
    (:h3 "Bookmarks")
    (:p "The bookmark file "
-       (:code (expand-path (bookmarks-path (or *browser*
-                                               (make-instance 'browser)))))
+       (:code (let ((buffer (make-instance 'buffer)))
+                (expand-path (bookmarks-path buffer))))
        " is made to be human readable and editable.
 Bookmarks can have the following settings:")
    (:ul

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -416,10 +416,10 @@ Otherwise go forward to the only child."
                      (history mode)
                      :test #'equals)
 
-    (history-add url :title (title (buffer mode))))
+    (with-current-buffer (buffer mode)
+      (history-add url :title (title (buffer mode)))))
 
-  (match (session-store-function *browser*)
-    ((guard f f) (funcall-safely f)))
+  (store (data-profile (buffer mode)) (session-path (buffer mode)))
   url)
 
 (defmethod nyxt:on-signal-notify-title ((mode web-mode) title)


### PR DESCRIPTION
This moves all the storage-related data to buffers and makes for a flexible per-buffer storage settings.

### Motivation
It's necessary to separate some data (e.g., cookies, local-storage) for different buffers to preserve users privacy, when necessary. Nyxt had no such mechanism, except for rebinding browser-based `(history|download|bookmarks)-path` slots, which is awkward. Another alternative, the `data-profile`s, was good for disabling all the storage, but was inflexible and uncomfortable to work with (however, it just can be my subjective repulsion from signatures like `(defmethod expand-data-path ((profile (eql +default-data-profile+)) (path session-data-path))...)` — it just doesn't look right).

This patch aims to make it easier to customize storage settings and isolate them for certain buffers. This opens the way for per-domain data storage settings and private mode (outlined below in "What's Not There (Yet)") and, possibly, some other conveniences I can't even imagine yet!

### What's New
- `data-profile` is now the place for some data-storing slots:
  - `downloads`,
  - `download-watcher`,
  - `history-data`,
  - `bookmarks-data`,
  - `auto-mode-rules`
- `buffer` is the home for previously `browser`-based slots:
  - `download-path`,
  - `history-path`,
  - `bookmarks-path`,
  - `session-path`,
  - `auto-mode-rules-path`,
  - `cookies-path`,
  - `standard-output-path`,
  - `error-output-path`.
- `buffer`s now have a `data-profile` slot, so storage can be adjusted on a per-buffer basis.
- `restore` and `store` generic functions to (re)store the data from the given paths, depending on the paths themselves.
- `expand-path` and, consequently, `with-data-file` now require additional buffer argument. Several functions/commands changed their signatures to match this change.
- `default-data-profile` and `private-data-profile` classes with (respectively) class-allocated data and instance-allocated data. In other words: now all the data of the buffers with default profiles will be shared, while buffers with private profile will be isolated even from each other.
- `*global-data-profile` comes as an alternative to the `+default-data-profile+`, because the latter had two use cases:
  - providing default data-management behavior;
  - dispatching the path on browser-less paths (e.g., `*init-file-path*`);
  While the first goal is now covered by `default-data-profile` class, the second needs some handling, and global variable seems to be necessary here, as something neither `browser`- nor `buffer`-based.
- data-storage.lisp is now less dependent on other files and it's easier to extract to a separate library. Some work still needs to be done though.
- Manual and documentation are adjusted to the changes.
- Some typo and syntax fixes.

### What's Not There (Yet)
- The per-buffer `data-profile`-conscious `*Downloads*` buffer is not there yet, because it's better to implement it together with #909.
- Ephemeral/private/nodata buffers (#247) -- these can be built on top of `private-data-profile`, path redefinition, and `is-ephemeral` `WebKitWebView` property, but this is somewhat out of scope of this patch.
- Per-domain cookies (and whatever else) isolation (#837) -- this can be implemented with introduction of several `isolate-(downloads|history|bookmarks|cookies)-mode` modes that will alter the buffer-local `data-profile` (introduce `isolate-cookies-data-profile`?) and with `auto-mode` to toggle them. Doesn't seem hard, but it's outside the scope of this pull request too.

I've assigned to implement the latter two, but I won't be able to do this properly, so this pull request is my best shot at making #247 and #837 implementable.

### Caveats
- The look of data-concerned (`buffer`, `data-profile`) class definition asks for new `defclass` (#889) — the number and similarity of slots is horrible xD
- It's currently hard to know what profile is used by the browser at browser startup. Inspecting the `buffer` class with the help of MOP seems to be the only solid option, but it's not perfect either.
- Race conditions can happen on file access and we don't have any safety mechanism against it yet.

### Possible Future Directions
- `:read-only`/`:readonly` storage keyword. It can be useful for obvious reasons of reading what's stored on disk without persisting the changes. However, it would require non-obvious changes and, possibly, even more strict storage policy.
- Ability to store data in browser instance to duplicate less data (although it's solved by `*global-data-profile*` already)?
- Lock file access while `restore`-ing and `store`-ing data separately?
- Maybe making alias methods for data-storing slots specialized on buffers (`bookmarks-data` and friends), so that `(bookmarks-data buffer) = (bookmarks-data (data-profile buffer))`? I think it's faulty to use such aliases, but it looks prettier and somewhat more intuitive (alternative: actually move data-storing slots to `buffer`, instead of creating aliases -- not really useful though).
- Make the storage safe from race conditions. I've sketched it, but it needs more thought and redesign. Here's the macro I came up with and that should be used to wrap the bodies of the data-altering functions (and it's a pattern you can see in the current code of the functions referred to in the docstring). Importantly, it's unclear where should we store locks and what operations should be blocking.
``` lisp
(export-always 'with-parallel-data-access)
(defmacro with-parallel-data-access (path buffer &body body)
  "Macro to conveniently access persisted data in the data-altering functions.
Exemplary applications are `history-add', `add-modes-to-auto-mode-rules'.
This macro spawns a thread that locks the data, restores the fresh data,
and stores the (possibly) altered data back to the BUFFER's PATH-NAME."
  (alex:once-only (buffer path)
    (alex:with-gensyms (profile path-type lock)
      `(let* ((,profile (if ,buffer (data-profile ,buffer) *global-data-profile*))
              (,path-type (serapeum:class-name-of ,path))
              ;; Locks are stored in a slot of `data-profile' in the 
              ;; initial design iteration, but it's not perfect
              (,lock (gethash ,path-type (locks ,profile)
                              (setf (gethash ,path-type (locks ,profile))
                                    (bt:make-lock)))))
         (bt:join-thread
          (bt:make-thread
           (lambda ()
             (bt:with-lock-held (,lock)
               (restore ,path ,profile ,buffer)
               ;; Returning result of the body is better than implicit `store' result.
               (prog1
                   (progn ,@body)
                 (store ,path ,profile ,buffer))))))))))
```

### How Has This Been Tested

I've created a toy-mode for bookmarks isolation (don't take it serious, it has some faulty pieces but was sufficient for feature testing):
``` lisp 
(uiop:define-package :nyxt/isolate-bookmarks-mode
  (:use :common-lisp :nyxt)
  (:import-from #:serapeum #:export-always)
  (:documentation "Mode for per-buffer bookmark isolation."))
(in-package :nyxt/isolate-bookmarks-mode)

(defclass isolate-bookmarks-profile (default-data-profile)
  ((name :initform "isolate-bookmarks")
   (bookmarks-data :allocation :instance)))

(define-mode isolate-bookmarks-mode ()
  "Isolate bookmarks for one buffer and persist them to a separate file."
  ((previous-bookmarks-path :accessor previous-bookmarks-path
                            :type (or null data-path)
                            :initform nil
                            :documentation "The path that bookmarks were stored to
before `isolate-bookmarks-mode' was activated.")
   (previous-data-profile :accessor previous-data-profile
                          :type (or null data-profile)
                          :initform nil
                          :documentation "The profile that the buffer had
before `isolate-bookmarks-mode' was activated.")
   (constructor
    :initform #'(lambda (mode)
                  (let ((buffer (buffer mode)))
                    (setf (previous-bookmarks-path mode) (bookmarks-path buffer)
                          (previous-data-profile mode) (data-profile buffer)
                          (data-profile buffer) (make-instance
                                                 'isolate-bookmarks-profile)
                          (bookmarks-path buffer) (make-instance
                                                   'nyxt:bookmarks-data-path
                                                   :basename (format nil "bookmarks-~a"
                                                                     (gensym "isolate")))
                          (bookmarks-data (data-profile buffer)) nil)
                    (store (bookmarks-path buffer) (data-profile buffer) buffer))))
   (destructor
    :initform #'(lambda (mode)
                  (let ((buffer (buffer mode)))
                    (uiop:delete-file-if-exists (expand-path (bookmarks-path buffer) buffer))
                    (setf (bookmarks-path buffer) (previous-bookmarks-path mode)
                          (data-profile buffer) (previous-data-profile mode)
                          (bookmarks-data (data-profile buffer)) nil)
                    (restore (bookmarks-path buffer) (data-profile buffer) buffer))))))

```
and ran Nyxt with it. Bookmarks were isolated and saved to a dedicated file! 

I've also ran Nyxt for some time to test whether the changes could have broken anything. Doesn't seem like so.

Additional testing is welcome though, because I may not notice some bugs due to my Nyxt use-style.

I'll be glad to know what you think of it!
