### PR TITLE
start.lisp: use CLI utilities on macOS instead of osicat

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -21,6 +21,7 @@
                :log4cl
                :lparallel
                :mk-string-metrics
+               #-darwin
                :osicat
                :parenscript
                :quri


### PR DESCRIPTION
Currently, osicat has problems with compilation in pkg files, this helps temporarily work around them.