### PR TITLE
Synchronous minibuffer: Proof of concept

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -5,6 +5,7 @@
   :serial t
   :depends-on (:alexandria
                :bordeaux-threads
+               :chanl
                :cl-css
                :cl-json
                :cl-markup

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -620,6 +620,7 @@ sometimes yields the wrong reasult."
 (define-ffi-method ffi-buffer-delete (buffer))
 (define-ffi-method ffi-buffer-load (buffer uri))
 (define-ffi-method ffi-buffer-evaluate-javascript (buffer javascript))
+(define-ffi-method ffi-buffer-evaluate-javascript-SYNC (buffer javascript))
 (define-ffi-method ffi-minibuffer-evaluate-javascript (window javascript))
 (define-ffi-method ffi-buffer-enable-javascript (buffer value))
 (define-ffi-method ffi-buffer-enable-javascript-markup (buffer value))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -284,7 +284,8 @@ This function can be `funcall'ed."
 
 (defmethod run ((command command) &rest args)
   "Run COMMAND over ARGS."
-  (apply #'funcall-safely (command-function command) args))
+  (chanl:pexec ()
+    (apply #'funcall-safely (command-function command) args)))
 
 (define-command noop ()                 ; TODO: Replace with ESCAPE special command that allows dispatched to cancel current key stack.
   "A command that does nothing.

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -7,6 +7,120 @@
   (defun qs (context selector)
     "Alias of document.querySelector"
     (ps:chain context (query-selector selector)))
+
+  (defun qsa (context selector)
+    "Alias of document.querySelectorAll"
+    (ps:chain context (query-selector-all selector)))
+
+  (defun code-char (n)
+    "Alias of String.fromCharCode"
+    (ps:chain -string (from-char-code n)))
+
+  (defun add-stylesheet ()
+    (unless (qs document "#nyxt-stylesheet")
+      (ps:try
+       (ps:let* ((style-element (ps:chain document (create-element "style")))
+                 (box-style (ps:lisp (box-style (current-buffer))))
+                 (highlighted-style (ps:lisp (highlighted-box-style (current-buffer)))))
+         (setf (ps:@ style-element id) "nyxt-stylesheet")
+         (ps:chain document head (append-child style-element))
+         (ps:chain style-element sheet (insert-rule box-style 0))
+         (ps:chain style-element sheet (insert-rule highlighted-style 1)))
+       (:catch (error)))))
+
+  (defun hint-determine-position (rect)
+    "Determines the position of a hint according to the element"
+    (ps:create :top  (+ (ps:@ window page-y-offset) (ps:@ rect top))
+               :left (+ (ps:@ window page-x-offset) (- (ps:@ rect left) 20))))
+
+  (defun hint-create-element (element hint)
+    "Creates a DOM element to be used as a hint"
+    (ps:let* ((rect (ps:chain element (get-bounding-client-rect)))
+              (position (hint-determine-position rect))
+              (element (ps:chain document (create-element "span"))))
+      (setf (ps:@ element class-name) "nyxt-hint")
+      (setf (ps:@ element style position) "absolute")
+      (setf (ps:@ element style left) (+ (ps:@ position left) "px"))
+      (setf (ps:@ element style top) (+ (ps:@ position top) "px"))
+      (setf (ps:@ element id) (+ "nyxt-hint-" hint))
+      (setf (ps:@ element text-content) hint)
+      element))
+
+  (defun hint-add (element hint)
+    "Adds a hint on a single element. Additionally sets a unique
+identifier for every hinted element."
+    (ps:chain element (set-attribute "nyxt-identifier" hint))
+    (ps:let ((hint-element (hint-create-element element hint)))
+      (ps:chain document body (append-child hint-element))))
+
+  (defun element-drawable-p (element)
+    (if (or (ps:chain element offset-width)
+            (ps:chain element offset-height)
+            (ps:chain element (get-client-rects) length))
+        t nil))
+
+  (defun element-in-view-port-p (element)
+    (ps:let* ((rect (ps:chain element (get-bounding-client-rect))))
+      (if (and (>= (ps:chain rect top) 0)
+               (>= (ps:chain rect left) 0)
+               (<= (ps:chain rect right) (ps:chain window inner-width))
+               (<= (ps:chain rect bottom) (ps:chain window inner-height)))
+          t nil)))
+
+  (defun object-create (element hint)
+    (cond ((equal "A" (ps:@ element tag-name))
+           (ps:create "type" "link" "hint" hint "href" (ps:@ element href) "body" (ps:@ element |innerHTML|)))
+          ((equal "BUTTON" (ps:@ element tag-name))
+           (ps:create "type" "button" "hint" hint "identifier" hint "body" (ps:@ element |innerHTML|)))
+          ((equal "INPUT" (ps:@ element tag-name))
+           (ps:create "type" "input" "hint" hint "identifier" hint))
+          ((equal "TEXTAREA" (ps:@ element tag-name))
+           (ps:create "type" "textarea" "hint" hint "identifier" hint))))
+
+  (defun hints-add (elements)
+    "Adds hints on elements"
+    (ps:let* ((elements-length (length elements))
+              (hints (hints-generate elements-length)))
+      (ps:chain |json|
+                (stringify
+                 (loop for i from 0 to (- elements-length 1)
+                       when (and (element-drawable-p (elt elements i))
+                                 (element-in-view-port-p (elt elements i)))
+                       do (hint-add (elt elements i) (elt hints i))
+                       when (or (and (element-drawable-p (elt elements i))
+                                     (ps:lisp annotate-full-document))
+                                (and (element-drawable-p (elt elements i))
+                                     (element-in-view-port-p (elt elements i))))
+                       collect (object-create (elt elements i) (elt hints i)))))))
+
+  (defun hints-determine-chars-length (length)
+    "Finds out how many chars long the hints must be"
+    (floor (+ 1 (/ (log length) (log 26)))))
+
+  (defun hints-generate (length)
+    "Generates hints that will appear on the elements"
+    (strings-generate length (hints-determine-chars-length length)))
+
+  (defun strings-generate (length chars-length)
+    "Generates strings of specified length"
+    (ps:let ((minimum (1+ (ps:chain -math (pow 26 (- chars-length 1))))))
+      (loop for i from minimum to (+ minimum length)
+            collect (string-generate i))))
+
+  (defun string-generate (n)
+    "Generates a string from a number"
+    (if (>= n 0)
+        (+ (string-generate (floor (- (/ n 26) 1)))
+           (code-char (+ 65
+                         (rem n 26)))) ""))
+
+  (add-stylesheet)
+  (hints-add (qsa document (list "a" "button" "input" "textarea"))))
+
+(define-parenscript-SYNC add-element-hints-SYNC (&key annotate-full-document)
+  (defun qs (context selector)
+    "Alias of document.querySelector"
+    (ps:chain context (query-selector selector)))
   
   (defun qsa (context selector)
     "Alias of document.querySelectorAll"
@@ -355,24 +469,24 @@ visible active buffer."
 
 (define-command bookmark-hint ()
   "Show link hints on screen, and allow the user to bookmark one"
-  (with-result* ((elements-json (add-element-hints))
-                 (result (read-from-minibuffer
-                          (make-minibuffer
-                           :input-prompt "Bookmark hint"
-                           :history nil
-                           :suggestion-function
-                           (hint-suggestion-filter (elements-from-json elements-json))
-                           :cleanup-function
-                           (lambda ()
-                             (remove-element-hints)))))
-                 (tags (read-from-minibuffer
-                        (make-minibuffer
-                         :input-prompt "Space-separated tag(s)"
-                         :default-modes '(set-tag-mode minibuffer-mode)
-                         :input-buffer (url-bookmark-tags (quri:uri (url result)))
-                         :suggestion-function (tag-suggestion-filter)))))
-    (when result
-      (bookmark-add (quri:uri (url result)) :tags tags))))
+  (let* ((elements-json (add-element-hints-SYNC)))
+    (log:info "elements" elements-json)
+    (let* ((result (prompt-minibuffer
+                    :input-prompt "Bookmark hint"
+                    :history nil
+                    :suggestion-function
+                    (hint-suggestion-filter (elements-from-json elements-json))
+                    :cleanup-function (lambda ()
+                                        (remove-element-hints)))))
+      (log:info "RESULT" result)
+      (let ((tags (prompt-minibuffer
+                   :input-prompt "Space-separated tag(s)"
+                   :default-modes '(set-tag-mode minibuffer-mode)
+                   :input-buffer (url-bookmark-tags (quri:uri (url result)))
+                   :suggestion-function (tag-suggestion-filter))))
+
+        (when result
+          (bookmark-add (quri:uri (url result)) :tags tags))))))
 
 (define-command download-hint-url ()
   "Download the file under the URL hinted by the user."

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -113,7 +113,7 @@ Return nil to forward to renderer or non-nil otherwise."
              ((typep bound-function 'function-symbol)
               (log:debug "Found key binding ~a" (keyspecs key-stack translated-key))
               (unwind-protect
-                   (funcall-safely bound-function)
+                   (funcall-safely bound-function) ; TODO: Use (run bound-function) instead?
                 ;; We must reset the key-stack on errors or else all subsequent
                 ;; keypresses will keep triggering the same erroring command.
                 (setf key-stack nil))

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -474,26 +474,14 @@ completion count."
   (mapcar #'object-string (marked-suggestions minibuffer)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defun prompt-minibuffer (&key input-prompt
-                            input-buffer
-                            default-modes
-                            suggestion-function
-                            history
-                            must-match-p)
+(export-always 'prompt-minibuffer)
+(defun prompt-minibuffer (&rest args)
   ""
   (let ((channel (make-instance 'chanl:channel)))
     (ffi-within-renderer-thread
      *browser*
      (lambda ()
-       (let ((minibuffer (make-minibuffer
-                          :channel channel
-                          :input-prompt input-prompt
-                          :input-buffer input-buffer
-                          :default-modes default-modes
-                          :suggestion-function suggestion-function
-                          :history history
-                          :must-match-p must-match-p)))
+       (let ((minibuffer (apply #'make-minibuffer (append (list :channel channel)  args))))
          (if *keep-alive*
              (match (setup-function minibuffer)
                ((guard f f) (funcall f minibuffer)))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -717,6 +717,18 @@ requested a reload."
                                                %callback
                                                #'javascript-error-handler))
 
+(defmethod ffi-buffer-evaluate-javascript-SYNC ((buffer gtk-buffer) javascript)
+  (let ((channel (make-instance 'chanl:channel)))
+    (ffi-within-renderer-thread
+     *browser*
+     (lambda ()
+       (webkit2:webkit-web-view-evaluate-javascript (gtk-object buffer)
+                                                    javascript
+                                                    (lambda (result)
+                                                      (chanl:send channel result :blockp nil))
+                                                    #'javascript-error-handler)))
+    (chanl:recv channel)))
+
 (defmethod ffi-minibuffer-evaluate-javascript ((window gtk-window) javascript)
   (webkit2:webkit-web-view-evaluate-javascript (minibuffer-view window) javascript))
 

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -37,6 +37,14 @@ buffer."
                                             (ps:ps ,@function-body))))
      ,@body))
 
+(export-always 'pflet-SYNC)
+(defmacro pflet-SYNC (((function function-arguments &body function-body)) &body body)
+  "Define single parenscript function in a flet body."
+  `(flet ((,function ,function-arguments
+            (ffi-buffer-evaluate-javascript-SYNC (current-buffer)
+                                            (ps:ps ,@function-body))))
+     ,@body))
+
 (define-parenscript document-get-body (&key (limit 100000))
   (ps:chain document body |innerHTML| (slice 0 (ps:lisp limit))))
 

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -16,6 +16,19 @@ buffer."
        (ffi-buffer-evaluate-javascript (current-buffer)
                                        (ps:ps ,@script-body)))))
 
+(export-always 'define-parenscript-SYNC)
+(defmacro define-parenscript-SYNC (script-name args &body script-body)
+  "Define parenscript function SCRIPT-NAME.
+SCRIPT-BODY must be a valid parenscript and will be wrapped in (PS:PS ...).
+Any Lisp expression must be wrapped in (PS:LISP ...).
+
+The returned function is called with the ARGS lambda-list over the current
+buffer."
+  `(progn
+     (defun ,script-name ,args
+       (ffi-buffer-evaluate-javascript-SYNC (current-buffer)
+                                            (ps:ps ,@script-body)))))
+
 (export-always 'pflet)
 (defmacro pflet (((function function-arguments &body function-body)) &body body)
   "Define single parenscript function in a flet body."

--- a/source/zoom.lisp
+++ b/source/zoom.lisp
@@ -30,7 +30,7 @@
 (define-command unzoom-page (&key (buffer (current-buffer))
                              (ratio (zoom-ratio-default (current-buffer))))
   "Unzoom the page."
-  (pflet ((unzoom ()
+  (pflet-SYNC ((unzoom ()
             (ps:lisp (setf (current-zoom-ratio (current-buffer)) ratio))
             (setf (ps:chain document body style zoom) (ps:lisp ratio))))
     (with-current-buffer buffer


### PR DESCRIPTION
This is what `set-url2` looks like:

```lisp
(let ((url (prompt-minibuffer
                :input-prompt (format nil "Open URL in ~A buffer"
                                      (if new-buffer-p
                                          "new"
                                          "current"))
                :input-buffer (if prefill-current-url-p
                                  (object-string (url (current-buffer))) "")
                :default-modes '(set-url-mode minibuffer-mode)
                :suggestion-function (history-suggestion-filter
                                      :prefix-urls (list (object-string
                                                          (url (current-buffer)))))
                :history history
                :must-match-p nil)))

      (when (typep url 'history-entry)
        ;; In case read-from-minibuffer returned a string upon
        ;; must-match-p.
        (setf url (url url)))
      (ffi-within-renderer-thread       ; TODO: Wrap all ffi-* method content with ffi-within-renderer-thread.
       *browser*
       (lambda ()
         (buffer-load url :buffer (if new-buffer-p
                                      (make-buffer-focus)
                                      (current-buffer))))))
```

No more `with-result` or `with-result*` or `%callback`, just a regular `let`! :)

To test, you need to press `C-return` on the URL.  It won't work with `return` in this demo because I didn't want to break other commands.

The new `prompt-minibuffer` takes all minibuffer args directly, no need to call `make-minibuffer` anymore.

`chanl` is great!  After merging this, I propose we use ChanL instead of lparallel everywhere (it's used by the download manager).

The user (or the devs) should not need to bother with `ffi-within-renderer-thread`.  I suggest we move it inside all `ffi-*` methods.
Example:

```lisp
(defmethod initialize-instance :after ((buffer status-buffer) &key)
  (ffi-within-renderer-thread
   *browser*
    (lambda ()
  (with-slots (gtk-object) buffer
    (setf gtk-object (make-web-view buffer))
    (gobject:g-signal-connect
     gtk-object "decide-policy"
     (lambda (web-view response-policy-decision policy-decision-type-response)
       (declare (ignore web-view))
       (on-signal-decide-policy buffer response-policy-decision policy-decision-type-response))))))
```

Maybe make a macro. 

Once set up, we can remove all `ffi-within-renderer-thread` calls in the program as well as `within-renderer-thread`.
A great benefit is that this approach guarantees us that calling functions from the REPL will never hang Nyxt anymore!

Waiting for #910 before proceeding.