### PR TITLE
Add session-dumping commands

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -66,6 +66,7 @@ Most recent messages are first.")
    (minibuffer-generic-history (make-ring))
    (minibuffer-search-history (make-ring))
    (minibuffer-set-url-history (make-ring))
+   (minibuffer-session-restore-history (make-ring))
    (recent-buffers (make-ring :size 50)
                    :export nil
                    :documentation "A ring that keeps track of deleted buffers.")

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -255,15 +255,10 @@ To change the default buffer, e.g. set it to a given URL:
       ;; will be overwritten because if-confirm is asynchronous.
       ;; Implement synchronous minibuffer to fix this.
       (when (expand-path (session-path buffer))
-        (flet ((restore-session ()
-                 (when (uiop:file-exists-p (expand-path (session-path buffer)))
-                   (log:info "Restoring session ~s." (expand-path (session-path buffer)))
-                   (restore (data-profile buffer) (session-path buffer)))))
-          (match (session-restore-prompt *browser*)
-            (:always-ask (if-confirm ("Restore previous session?")
-                                     (restore-session)))
-            (:always-restore (restore-session))
-            (:never-restore (log:info "Not restoring session.")))))
+        (match (session-restore-prompt *browser*)
+               (:always-ask (restore-session-by-name))
+               (:always-restore (restore (data-profile buffer) (session-path buffer)))
+               (:never-restore (log:info "Not restoring session."))))
       (if urls
           (open-urls urls)
           (window-set-active-buffer window (funcall-safely buffer-fn))))


### PR DESCRIPTION
This adds two commands (`store-session-by-name` and `restore-session-by-name`, namely) to store/restore session data to/from a dedicated user-named file.

### Motivation

As said in #934, It'd be nice to have an  ability to have `profile`-like (as used in GNU Guix) buffer collections that one can store and restore at arbitrary moment.

### Caveats

- A `;; Delete the old buffers?` commentary from session-specified `restore` would fit this changeset perfectly, although such a radical thing needs some discussion.
- Should we add some name suggestions for sessions, if there are no sessions but default one?
- Should we even list default session as option for storage/restoration?
- Name clash with `store` and `restore` generic functions. Is it harmful? I think it's okay, given that `(re)store-session-by-name` and `(re)store` are connected.

### Future directions:

- Maybe make session serialization more readable.

I'll be glad to know what you think of it :)

Closes: #934.