### PR TITLE
Easy Configuration

### DIFF
--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -3,6 +3,10 @@
 
 (in-package :nyxt)
 
+(export-always '*autoconfig-file-path*)
+(defvar *autoconfig-file-path* (make-instance 'data-path :basename "autoconfig")
+  "The path of the generated configuration file.")
+
 (export-always 'funcall-safely)
 (defun funcall-safely (f &rest args)
   "Like `funcall' except that if `*keep-alive*' is nil (e.g. the program is run

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -3,8 +3,8 @@
 
 (in-package :nyxt)
 
-(export-always '*autoconfig-file-path*)
-(defvar *autoconfig-file-path* (make-instance 'data-path :basename "autoconfig")
+(export-always '*auto-config-file-path*)
+(defvar *auto-config-file-path* (make-instance 'data-path :basename "auto-config")
   "The path of the generated configuration file.")
 
 (export-always 'funcall-safely)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -217,8 +217,9 @@ A command is a special kind of function that can be called with
   (with-result (input (read-from-minibuffer
                        (make-minibuffer
                         :input-prompt (format nil "Configure slot value ~a" slot))))
-    (eval `(define-configuration ,class
-             ((,slot (read-from-string ,input)))))))
+    (let ((configuration-form `(define-configuration ,class
+                                 ((,slot (read-from-string ,input))))))
+      (eval configuration-form))))
 
 (define-command describe-slot ()
   "Inspect a slot and show it in a help buffer."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -217,7 +217,7 @@ A command is a special kind of function that can be called with
       (set-current-buffer help-buffer))))
 
 (defun configure-slot (slot class)
-  "Set the value of a slot in a users config.lisp."
+  "Set the value of a slot in a users autoconfig.lisp."
   (with-result (input (read-from-minibuffer
                        (make-minibuffer
                         :input-prompt (format nil "Configure slot value ~a" slot))))
@@ -227,11 +227,11 @@ A command is a special kind of function that can be called with
                              ((,slot ,input))))))
 
 (defun append-configuration (form)
-  (with-data-file (file *config-file-path*
+  (with-data-file (file *autoconfig-file-path*
                         :direction :output
                         :if-does-not-exist :create
                         :if-exists :append)
-    (log:info "Appending configuration form ~a to ~s." form (expand-path *config-file-path*))
+    (log:info "Appending configuration form ~a to ~s." form (expand-path *autoconfig-file-path*))
     (format file "~&~a~%" form)))
 
 (define-command describe-slot ()

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -217,7 +217,7 @@ A command is a special kind of function that can be called with
       (set-current-buffer help-buffer))))
 
 (defun configure-slot (slot class)
-  "Set the value of a slot in a users autoconfig.lisp."
+  "Set the value of a slot in a users auto-config.lisp."
   (with-result (input (read-from-minibuffer
                        (make-minibuffer
                         :input-prompt (format nil "Configure slot value ~a" slot))))
@@ -227,11 +227,11 @@ A command is a special kind of function that can be called with
                              ((,slot ,input))))))
 
 (defun append-configuration (form)
-  (with-data-file (file *autoconfig-file-path*
+  (with-data-file (file *auto-config-file-path*
                         :direction :output
                         :if-does-not-exist :create
                         :if-exists :append)
-    (log:info "Appending configuration form ~a to ~s." form (expand-path *autoconfig-file-path*))
+    (log:info "Appending configuration form ~a to ~s." form (expand-path *auto-config-file-path*))
     (format file "~&~a~%" form)))
 
 (define-command describe-slot ()

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -217,7 +217,8 @@ A command is a special kind of function that can be called with
   (with-result (input (read-from-minibuffer
                        (make-minibuffer
                         :input-prompt (format nil "Configure slot value ~a" slot))))
-    (print input)))
+    (eval `(define-configuration ,class
+             ((,slot (read-from-string ,input)))))))
 
 (define-command describe-slot ()
   "Inspect a slot and show it in a help buffer."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -183,7 +183,7 @@ A command is a special kind of function that can be called with
          ;; We use :pre for documentation so that code samples get formatted properly.
          ;; TODO: Parse docstrings and highlight code samples.
          (list (markup:markup (:li "Documentation: " (:pre (getf props :documentation))))))
-       (:li (:a :class "button" :href (lisp-url '(nyxt::list-messages)) "Configure")))))))
+       (:li (:a :class "button" :href (lisp-url `(nyxt::configure-slot ',slot ',class)) "Configure")))))))
 
 (define-command describe-class ()
   "Inspect a class and show it in a help buffer."
@@ -211,6 +211,13 @@ A command is a special kind of function that can be called with
                                      (ps:lisp help-contents)))))
       (ffi-buffer-evaluate-javascript help-buffer insert-help)
       (set-current-buffer help-buffer))))
+
+(define-command configure-slot (slot class)
+  "Set the value of a slot in a users config.lisp"
+  (with-result (input (read-from-minibuffer
+                       (make-minibuffer
+                        :input-prompt (format nil "Configure slot value ~a" slot))))
+    (print input)))
 
 (define-command describe-slot ()
   "Inspect a slot and show it in a help buffer."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -182,7 +182,8 @@ A command is a special kind of function that can be called with
        (when (getf props :documentation)
          ;; We use :pre for documentation so that code samples get formatted properly.
          ;; TODO: Parse docstrings and highlight code samples.
-         (list (markup:markup (:li "Documentation: " (:pre (getf props :documentation)))))))))))
+         (list (markup:markup (:li "Documentation: " (:pre (getf props :documentation))))))
+       (:li (:a :class "button" :href (lisp-url '(nyxt::list-messages)) "Configure")))))))
 
 (define-command describe-class ()
   "Inspect a class and show it in a help buffer."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -183,7 +183,11 @@ A command is a special kind of function that can be called with
          ;; We use :pre for documentation so that code samples get formatted properly.
          ;; TODO: Parse docstrings and highlight code samples.
          (list (markup:markup (:li "Documentation: " (:pre (getf props :documentation))))))
-       (:li (:a :class "button" :href (lisp-url `(nyxt::configure-slot ',slot ',class)) "Configure")))))))
+       (unless (user-class-p class)
+         (list (markup:markup
+                (:li (:a :class "button"
+                         :href (lisp-url `(nyxt::configure-slot ',slot ',class))
+                         "Configure"))))))))))
 
 (define-command describe-class ()
   "Inspect a class and show it in a help buffer."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -221,6 +221,7 @@ A command is a special kind of function that can be called with
   (with-result (input (read-from-minibuffer
                        (make-minibuffer
                         :input-prompt (format nil "Configure slot value ~a" slot))))
+    (echo "Slot ~a updated with value ~a." slot input)
     (eval `(define-configuration ,class
              ((,slot (read-from-string ,input)))))
     (append-configuration `(define-configuration ,class

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -217,7 +217,7 @@ A command is a special kind of function that can be called with
       (set-current-buffer help-buffer))))
 
 (defun configure-slot (slot class)
-  "Set the value of a slot in a users config.lisp"
+  "Set the value of a slot in a users config.lisp."
   (with-result (input (read-from-minibuffer
                        (make-minibuffer
                         :input-prompt (format nil "Configure slot value ~a" slot))))
@@ -232,7 +232,7 @@ A command is a special kind of function that can be called with
                         :if-does-not-exist :create
                         :if-exists :append)
     (log:info "Appending configuration form ~a to ~s." form (expand-path *config-file-path*))
-    (format file "~%~a" form)))
+    (format file "~&~a~%" form)))
 
 (define-command describe-slot ()
   "Inspect a slot and show it in a help buffer."

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -22,7 +22,7 @@ You can press the button marked 'Configure' to change the value of a
 setting. The settings will be applied immediately and saved for future
 sessions.")
     (:p "Settings created by Nyxt are stored in "
-        (:code (expand-path *config-file-path*)) ".")
+        (:code (expand-path *autoconfig-file-path*)) ".")
     (:p "Any settings can be overridden manually by "
         (:code (expand-path *init-file-path*)) ".")
     (:p "The following section assumes that you know some basic Common Lisp or a

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -16,14 +16,14 @@ of Nyxt."))
 great perk: everything in the browser can be customized by the user, even while
 it's running!")
     (:p "Nyxt provides a mechanism for new users unfamiliar with Lisp
-to customize Nyxt. To begin, start by invoking the
+to customize Nyxt. Start by invoking the
 commands " (:code "describe-class") " or " (:code "describe-slot") ".
-When you find a value that you would like to change, you can press the
-button marked 'Configure' to change it. The settings will be applied
-immediately and saved for future sessions.")
+You can press the button marked 'Configure' to change the value of a
+setting. The settings will be applied immediately and saved for future
+sessions.")
     (:p "Settings created by Nyxt are stored in "
         (:code (expand-path *config-file-path*)) ".")
-    (:p "Any settings can be overridden by users manually via "
+    (:p "Any settings can be overridden manually by "
         (:code (expand-path *init-file-path*)) ".")
     (:p "The following section assumes that you know some basic Common Lisp or a
 similar programming language.")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -22,7 +22,7 @@ You can press the button marked 'Configure' to change the value of a
 setting. The settings will be applied immediately and saved for future
 sessions.")
     (:p "Settings created by Nyxt are stored in "
-        (:code (expand-path *autoconfig-file-path*)) ".")
+        (:code (expand-path *auto-config-file-path*)) ".")
     (:p "Any settings can be overridden manually by "
         (:code (expand-path *init-file-path*)) ".")
     (:p "The following section assumes that you know some basic Common Lisp or a

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -23,7 +23,7 @@ button marked 'Configure' to change it. The settings will be applied
 immediately and saved for future sessions.")
     (:p "Settings created by Nyxt are stored in "
         (:code (expand-path *config-file-path*)) ".")
-    (:p "Any settings can be overriden by users manually via "
+    (:p "Any settings can be overridden by users manually via "
         (:code (expand-path *init-file-path*)) ".")
     (:p "The following section assumes that you know some basic Common Lisp or a
 similar programming language.")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -15,6 +15,16 @@ of Nyxt."))
     (:p "Nyxt is written in the Common Lisp programming language which offers a
 great perk: everything in the browser can be customized by the user, even while
 it's running!")
+    (:p "Nyxt provides a mechanism for new users unfamiliar with Lisp
+to customize Nyxt. To begin, start by invoking the
+commands " (:code "describe-class") " or " (:code "describe-slot") ".
+When you find a value that you would like to change, you can press the
+button marked 'Configure' to change it. The settings will be applied
+immediately and saved for future sessions.")
+    (:p "Settings created by Nyxt are stored in "
+        (:code (expand-path *config-file-path*)) ".")
+    (:p "Any settings can be overriden by users manually via "
+        (:code (expand-path *init-file-path*)) ".")
     (:p "The following section assumes that you know some basic Common Lisp or a
 similar programming language.")
     (:p "Nyxt configuration can be persisted in the user

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -7,6 +7,10 @@
 (defvar *init-file-path* (make-instance 'data-path :basename "init")
   "The path of the initialization file.")
 
+(export-always '*config-file-path*)
+(defvar *config-file-path* (make-instance 'data-path :basename "config")
+  "The path of the generated configuration file.")
+
 (export-always '*socket-path*)
 (defvar *socket-path* (make-instance 'data-path :basename "nyxt.socket")
   "Path string of the Unix socket used to communicate between different

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -27,15 +27,15 @@ use the socket without parsing any init file.")
                                            ;; at compile-time.
                                            :dirname (uiop:xdg-config-home +data-root+)))))))
 
-(defmethod expand-data-path ((profile data-profile) (path (eql *autoconfig-file-path*)))
+(defmethod expand-data-path ((profile data-profile) (path (eql *auto-config-file-path*)))
   "Return path of the init file."
-  (unless (getf *options* :no-autoconfig)
-    (match (getf *options* :autoconfig)
+  (unless (getf *options* :no-auto-config)
+    (match (getf *options* :auto-config)
       (new-path
        (expand-default-path (make-instance 'data-path
                                            :basename (or new-path (basename path))
                                            ;; Specify `dirname' here since
-                                           ;; *autoconfig-file-path* is evaluated
+                                           ;; *auto-config-file-path* is evaluated
                                            ;; at compile-time.
                                            :dirname (uiop:xdg-config-home +data-root+)))))))
 
@@ -67,15 +67,15 @@ use the socket without parsing any init file.")
            :short #\I
            :long "no-init"
            :description "Do not load the user init file.")
-    (:name :autoconfig
+    (:name :auto-config
            :short #\c
-           :long "autoconfig"
+           :long "auto-config"
            :arg-parser #'identity
-           :description "Set path to autoconfig file.")
-    (:name :no-autoconfig
+           :description "Set path to auto-config file.")
+    (:name :no-auto-config
            :short #\C
-           :long "no-autoconfig"
-           :description "Do not load the user autoconfig file.")
+           :long "no-auto-config"
+           :description "Do not load the user auto-config file.")
     (:name :socket
            :short #\s
            :long "socket"
@@ -474,16 +474,16 @@ REPL examples:
 (defun start-load-or-eval ()
   "Evaluate Lisp.
 The evaluation may happen on its own instance or on an already running instance."
-  (unless (or (getf *options* :no-autoconfig)
-              (not (expand-path *autoconfig-file-path*)))
-    (load-lisp (expand-path *autoconfig-file-path*) :package (find-package :nyxt-user)))
+  (unless (or (getf *options* :no-auto-config)
+              (not (expand-path *auto-config-file-path*)))
+    (load-lisp (expand-path *auto-config-file-path*) :package (find-package :nyxt-user)))
   (unless (or (getf *options* :no-init)
               (not (expand-path *init-file-path*)))
     (load-lisp (expand-path *init-file-path*) :package (find-package :nyxt-user)))
   (load-or-eval :remote (getf *options* :remote)))
 
 (defun start-browser (free-args)
-  "Load AUTOCONFIG-FILE.
+  "Load AUTO-CONFIG-FILE.
 Load INIT-FILE if non-nil.
 Instantiate `*browser*'.
 Start Nyxt and load URLS if any.
@@ -491,9 +491,9 @@ Finally,run the `*after-init-hook*'."
   (let ((startup-timestamp (local-time:now))
         (startup-error-reporter nil))
     (format t "Nyxt version ~a~&" +version+)
-    (unless (or (getf *options* :no-autoconfig)
-                (not (expand-path *autoconfig-file-path*)))
-      (load-lisp (expand-path *autoconfig-file-path*)
+    (unless (or (getf *options* :no-auto-config)
+                (not (expand-path *auto-config-file-path*)))
+      (load-lisp (expand-path *auto-config-file-path*)
                  :package (find-package :nyxt-user)))
     (unless (or (getf *options* :no-init)
                 (not (expand-path *init-file-path*)))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -241,10 +241,6 @@ Return the short error message and the full error message as second value."
   "Load or reload the init file."
   (load-lisp init-file :package (find-package :nyxt-user)))
 
-(define-command load-config-file (&key (config-file (expand-path *config-file-path*)))
-  "Load or reload the config file."
-  (load-lisp config-file :package (find-package :nyxt-user)))
-
 (defun eval-expr (expr)
   "Evaluate the form EXPR (string) and print the result of the last expresion."
   (handler-case

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -7,8 +7,8 @@
 (defvar *init-file-path* (make-instance 'data-path :basename "init")
   "The path of the initialization file.")
 
-(export-always '*config-file-path*)
-(defvar *config-file-path* (make-instance 'data-path :basename "config")
+(export-always '*autoconfig-file-path*)
+(defvar *autoconfig-file-path* (make-instance 'data-path :basename "autoconfig")
   "The path of the generated configuration file.")
 
 (export-always '*socket-path*)
@@ -31,15 +31,15 @@ use the socket without parsing any init file.")
                                            ;; at compile-time.
                                            :dirname (uiop:xdg-config-home +data-root+)))))))
 
-(defmethod expand-data-path ((profile data-profile) (path (eql *config-file-path*)))
+(defmethod expand-data-path ((profile data-profile) (path (eql *autoconfig-file-path*)))
   "Return path of the init file."
-  (unless (getf *options* :no-config)
-    (match (getf *options* :config)
+  (unless (getf *options* :no-autoconfig)
+    (match (getf *options* :autoconfig)
       (new-path
        (expand-default-path (make-instance 'data-path
                                            :basename (or new-path (basename path))
                                            ;; Specify `dirname' here since
-                                           ;; *config-file-path* is evaluated
+                                           ;; *autoconfig-file-path* is evaluated
                                            ;; at compile-time.
                                            :dirname (uiop:xdg-config-home +data-root+)))))))
 
@@ -71,15 +71,15 @@ use the socket without parsing any init file.")
            :short #\I
            :long "no-init"
            :description "Do not load the user init file.")
-    (:name :config
+    (:name :autoconfig
            :short #\c
-           :long "config"
+           :long "autoconfig"
            :arg-parser #'identity
-           :description "Set path to config file.")
-    (:name :no-config
+           :description "Set path to autoconfig file.")
+    (:name :no-autoconfig
            :short #\C
-           :long "no-config"
-           :description "Do not load the user config file.")
+           :long "no-autoconfig"
+           :description "Do not load the user autoconfig file.")
     (:name :socket
            :short #\s
            :long "socket"
@@ -478,16 +478,16 @@ REPL examples:
 (defun start-load-or-eval ()
   "Evaluate Lisp.
 The evaluation may happen on its own instance or on an already running instance."
-  (unless (or (getf *options* :no-config)
-              (not (expand-path *config-file-path*)))
-    (load-lisp (expand-path *config-file-path*) :package (find-package :nyxt-user)))
+  (unless (or (getf *options* :no-autoconfig)
+              (not (expand-path *autoconfig-file-path*)))
+    (load-lisp (expand-path *autoconfig-file-path*) :package (find-package :nyxt-user)))
   (unless (or (getf *options* :no-init)
               (not (expand-path *init-file-path*)))
     (load-lisp (expand-path *init-file-path*) :package (find-package :nyxt-user)))
   (load-or-eval :remote (getf *options* :remote)))
 
 (defun start-browser (free-args)
-  "Load CONFIG-FILE.
+  "Load AUTOCONFIG-FILE.
 Load INIT-FILE if non-nil.
 Instantiate `*browser*'.
 Start Nyxt and load URLS if any.
@@ -495,9 +495,9 @@ Finally,run the `*after-init-hook*'."
   (let ((startup-timestamp (local-time:now))
         (startup-error-reporter nil))
     (format t "Nyxt version ~a~&" +version+)
-    (unless (or (getf *options* :no-config)
-                (not (expand-path *config-file-path*)))
-      (load-lisp (expand-path *config-file-path*)
+    (unless (or (getf *options* :no-autoconfig)
+                (not (expand-path *autoconfig-file-path*)))
+      (load-lisp (expand-path *autoconfig-file-path*)
                  :package (find-package :nyxt-user)))
     (unless (or (getf *options* :no-init)
                 (not (expand-path *init-file-path*)))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -71,12 +71,12 @@ use the socket without parsing any init file.")
            :short #\I
            :long "no-init"
            :description "Do not load the user init file.")
-    (:name :init
+    (:name :config
            :short #\c
            :long "config"
            :arg-parser #'identity
            :description "Set path to config file.")
-    (:name :no-init
+    (:name :no-config
            :short #\C
            :long "no-config"
            :description "Do not load the user config file.")

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -68,6 +68,15 @@ use the socket without parsing any init file.")
            :short #\I
            :long "no-init"
            :description "Do not load the user init file.")
+    (:name :init
+           :short #\c
+           :long "config"
+           :arg-parser #'identity
+           :description "Set path to config file.")
+    (:name :no-init
+           :short #\C
+           :long "no-config"
+           :description "Do not load the user config file.")
     (:name :socket
            :short #\s
            :long "socket"

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -487,8 +487,8 @@ The evaluation may happen on its own instance or on an already running instance.
   (load-or-eval :remote (getf *options* :remote)))
 
 (defun start-browser (free-args)
-  "Load INIT-FILE if non-nil.
-Load CONFIG-FILE.
+  "Load CONFIG-FILE.
+Load INIT-FILE if non-nil.
 Instantiate `*browser*'.
 Start Nyxt and load URLS if any.
 Finally,run the `*after-init-hook*'."

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -7,10 +7,6 @@
 (defvar *init-file-path* (make-instance 'data-path :basename "init")
   "The path of the initialization file.")
 
-(export-always '*autoconfig-file-path*)
-(defvar *autoconfig-file-path* (make-instance 'data-path :basename "autoconfig")
-  "The path of the generated configuration file.")
-
 (export-always '*socket-path*)
 (defvar *socket-path* (make-instance 'data-path :basename "nyxt.socket")
   "Path string of the Unix socket used to communicate between different


### PR DESCRIPTION
This allows describe-slot/describe-class to set configuration. When the user types in describe-slot or describe-class there is a button appearing that says "Configure". The user can click on that to set the value. The value will also be persisted in a config.lisp file. This config.lisp file, like the init.lisp file can be controlled via command line flags.

This is the first draft implementation. The second implementation will feature:

+ type checking
+ more efficient usage of define-configuration in config.lisp, instead of appending new define-configuration forms, it will only persist define-configuration forms with all slots that are different than the default

Type checking is waiting on the new synchronous minibuffer (it will loop querying the user until the result satisfies the type information).