### PR TITLE
Synchronous minibuffer cleanup

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -133,6 +133,7 @@
      ;; See https://github.com/atlas-engineer/nyxt/issues/680.
      `(("alexandria" ,cl-alexandria)
        ("bordeaux-threads" ,cl-bordeaux-threads)
+       ("cl-chanl" ,cl-chanl)
        ("cl-containers" ,cl-containers)
        ("cl-css" ,cl-css)
        ("cl-json" ,cl-json)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -72,6 +72,7 @@
                (:file "message")
                (:file "input")
                (:file "minibuffer")
+               (:file "minibuffer-prompt")
                (:file "minibuffer-mode")
                (:file "command-commands")
                (:file "recent-buffers")

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -5,6 +5,7 @@
   :serial t
   :depends-on (:alexandria
                :bordeaux-threads
+               :chanl
                :cl-css
                :cl-json
                :cl-markup

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -180,11 +180,10 @@ The rules are:
                  *prompt-on-mode-toggle*)
         (if-confirm ("Permanently ~:[disable~;enable~] ~a for this URL?"
                        enable-p (mode-name mode))
-          (with-result (url (read-from-minibuffer
-                             (make-minibuffer
-                              :input-prompt "URL:"
-                              :input-buffer (object-display (url (buffer mode)))
-                              :must-match-p nil)))
+                    (let ((url (prompt-minibuffer
+                                :input-prompt "URL:"
+                                :input-buffer (object-display (url (buffer mode)))
+                                :must-match-p nil)))
             (add-modes-to-auto-mode-rules (url-infer-match url)
                                           :append-p t
                                           :include (when enable-p (list mode))
@@ -240,16 +239,15 @@ to one of auto-mode rules. Apply the resulting rule for all the future visits to
 inferring the matching condition with `url-infer-match'.
 
 For the storage format see the comment in the head of your `auto-mode-rules-data-path' file."
-  (with-result (url (read-from-minibuffer
-                     (make-minibuffer
-                      :input-prompt "URL:"
-                      :input-buffer (object-string (url (current-buffer)))
-                      :suggestion-function (nyxt::history-suggestion-filter
-                                            :prefix-urls (list
-                                                          (object-string
-                                                           (url (current-buffer)))))
-                      :history (minibuffer-set-url-history *browser*)
-                      :must-match-p nil)))
+  (let ((url (prompt-minibuffer
+              :input-prompt "URL:"
+              :input-buffer (object-string (url (current-buffer)))
+              :suggestion-function (nyxt::history-suggestion-filter
+                                    :prefix-urls (list
+                                                  (object-string
+                                                   (url (current-buffer)))))
+              :history (minibuffer-set-url-history *browser*)
+              :must-match-p nil)))
     (when (typep url 'nyxt::history-entry)
       (setf url (url url)))
     (add-modes-to-auto-mode-rules
@@ -269,16 +267,15 @@ Uses `url-infer-match', see its documentation for matching rules.
 For the storage format see the comment in the head of your `auto-mode-rules-data-path' file."
   ;; TODO: Should it prompt for modes to save?
   ;; One may want to adjust the modes before persisting them as :exact-p rule.
-  (with-result (url (read-from-minibuffer
-                     (make-minibuffer
-                      :input-prompt "URL:"
-                      :input-buffer (object-string (url (current-buffer)))
-                      :suggestion-function (nyxt::history-suggestion-filter
-                                            :prefix-urls (list
-                                                          (object-string
-                                                           (url (current-buffer)))))
-                      :history (minibuffer-set-url-history *browser*)
-                      :must-match-p nil)))
+  (let ((url (prompt-minibuffer
+              :input-prompt "URL:"
+              :input-buffer (object-string (url (current-buffer)))
+              :suggestion-function (nyxt::history-suggestion-filter
+                                    :prefix-urls (list
+                                                  (object-string
+                                                   (url (current-buffer)))))
+              :history (minibuffer-set-url-history *browser*)
+              :must-match-p nil)))
     (when (typep url 'nyxt::history-entry)
       (setf url (url url)))
     (add-modes-to-auto-mode-rules (url-infer-match url)

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -214,15 +214,14 @@ URL."
                    name-list)))
     (if (url-empty-p (url buffer))
         (echo "Buffer has no URL.")
-        (with-result* ((body (with-current-buffer buffer
-                               (document-get-body)))
-                       (tags (read-from-minibuffer
-                              (make-minibuffer
-                               :input-prompt "Space-separated tag(s)"
-                               :default-modes '(set-tag-mode minibuffer-mode)
-                               :input-buffer (url-bookmark-tags (url buffer))
-                               :suggestion-function (tag-suggestion-filter
-                                                     :extra-tags (make-tags (extract-keywords body 5)))))))
+        (let* ((body (with-current-buffer buffer
+                       (document-get-body)))
+               (tags (prompt-minibuffer
+                      :input-prompt "Space-separated tag(s)"
+                      :default-modes '(set-tag-mode minibuffer-mode)
+                      :input-buffer (url-bookmark-tags (url buffer))
+                      :suggestion-function (tag-suggestion-filter
+                                            :extra-tags (make-tags (extract-keywords body 5))))))
           (bookmark-add (url buffer)
                         :title (title buffer)
                         :tags tags)
@@ -230,38 +229,34 @@ URL."
 
 (define-command bookmark-page ()
   "Bookmark the currently opened page(s) in the active buffer."
-  (with-result (buffers (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Bookmark URL from buffer(s)"
-                          :multi-selection-p t
-                          :suggestion-function (buffer-suggestion-filter))))
+  (let ((buffers (prompt-minibuffer
+                  :input-prompt "Bookmark URL from buffer(s)"
+                  :multi-selection-p t
+                  :suggestion-function (buffer-suggestion-filter))))
     (mapcar #'bookmark-current-page buffers)))
 
 (define-command bookmark-url ()
   "Allow the user to bookmark a URL via minibuffer input."
-  (with-result (url (read-from-minibuffer
-                     (make-minibuffer
-                      :input-prompt "Bookmark URL")))
+  (let ((url (prompt-minibuffer
+              :input-prompt "Bookmark URL")))
     (if (not (valid-url-p url))
         (echo "Invalid URL")
-        (let ((url (quri:uri url)))
-          (with-result (tags (read-from-minibuffer
-                              (make-minibuffer
-                               :input-prompt "Space-separated tag(s)"
-                               :default-modes '(set-tag-mode minibuffer-mode)
-                               :input-buffer (url-bookmark-tags url)
-                               :suggestion-function (tag-suggestion-filter))))
-            (bookmark-add url :tags tags))))))
+        (let* ((url (quri:uri url))
+               (tags (prompt-minibuffer
+                      :input-prompt "Space-separated tag(s)"
+                      :default-modes '(set-tag-mode minibuffer-mode)
+                      :input-buffer (url-bookmark-tags url)
+                      :suggestion-function (tag-suggestion-filter))))
+          (bookmark-add url :tags tags)))))
 
 (define-command bookmark-delete ()
   "Delete bookmark(s)."
   (with-data-access bookmarks (bookmarks-path (current-buffer))
-    (with-result (entries (read-from-minibuffer
-                           (make-minibuffer
-                            :input-prompt "Delete bookmark(s)"
-                            :multi-selection-p t
-                            :default-modes '(minibuffer-tag-mode minibuffer-mode)
-                            :suggestion-function (bookmark-suggestion-filter))))
+    (let ((entries (prompt-minibuffer
+                    :input-prompt "Delete bookmark(s)"
+                    :multi-selection-p t
+                    :default-modes '(minibuffer-tag-mode minibuffer-mode)
+                    :suggestion-function (bookmark-suggestion-filter))))
       (setf bookmarks
             (set-difference bookmarks
                             entries :test #'equals)))))
@@ -273,11 +268,10 @@ If character before cursor is '+' or '-' complete against tag."
          (operand? (unless (str:emptyp current-word) (subseq current-word 0 1))))
     (if (or (equal "-" operand?)
             (equal "+" operand?))
-        (with-result (tag (read-from-minibuffer
-                           (make-minibuffer
-                            :input-prompt "Tag"
-                            :input-buffer (subseq current-word 1)
-                            :suggestion-function (tag-suggestion-filter))))
+        (let ((tag (prompt-minibuffer
+                    :input-prompt "Tag"
+                    :input-buffer (subseq current-word 1)
+                    :suggestion-function (tag-suggestion-filter))))
           (when tag
             (text-buffer::replace-word-at-cursor
              (input-cursor minibuffer)
@@ -296,24 +290,22 @@ If character before cursor is '+' or '-' complete against tag."
   "Set the URL for the current buffer from a bookmark.
 With multiple selections, open the first bookmark in the current buffer, the
 rest in background buffers."
-  (with-result (entries (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Open bookmark(s)"
-                          :default-modes '(minibuffer-tag-mode minibuffer-mode)
-                          :suggestion-function (bookmark-suggestion-filter)
-                          :multi-selection-p t)))
+  (let ((entries (prompt-minibuffer
+                  :input-prompt "Open bookmark(s)"
+                  :default-modes '(minibuffer-tag-mode minibuffer-mode)
+                  :suggestion-function (bookmark-suggestion-filter)
+                  :multi-selection-p t)))
     (dolist (entry (rest entries))
       (make-buffer :url (object-string (url entry))))
     (buffer-load (url (first entries)))))
 
 (define-command set-url-from-bookmark-new-buffer ()
   "Open selected bookmarks in new buffers."
-  (with-result (entries (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Open bookmarks in new buffers"
-                          :default-modes '(minibuffer-tag-mode minibuffer-mode)
-                          :suggestion-function (bookmark-suggestion-filter)
-                          :multi-selection-p t)))
+  (let ((entries (prompt-minibuffer
+                  :input-prompt "Open bookmarks in new buffers"
+                  :default-modes '(minibuffer-tag-mode minibuffer-mode)
+                  :suggestion-function (bookmark-suggestion-filter)
+                  :multi-selection-p t)))
     (dolist (entry (rest entries))
       (make-buffer :url (object-string (url entry))))
     (buffer-load (url (first entries))

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -233,7 +233,7 @@ URL."
                   :input-prompt "Bookmark URL from buffer(s)"
                   :multi-selection-p t
                   :suggestion-function (buffer-suggestion-filter))))
-    (mapcar #'bookmark-current-page buffers)))
+    (mapc #'bookmark-current-page buffers)))
 
 (define-command bookmark-url ()
   "Allow the user to bookmark a URL via minibuffer input."

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -640,11 +640,3 @@ sometimes yields the wrong reasult."
 (define-ffi-method ffi-print-message (window message))
 (define-ffi-method ffi-display-uri (text))
 (define-ffi-method ffi-buffer-cookie-policy (buffer value))
-
-(defmacro within-renderer-thread (&body body)
-  "Convenience macro to run FFI-calling code from the REPL.
-It should not be used to write code."
-  `(ffi-within-renderer-thread
-    *browser*
-    (lambda ()
-      ,@body)))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -217,11 +217,12 @@ editor executable."))
       (hooks:run-hook *after-init-hook*)
     (error (c)
       (log:error "In *after-init-hook*: ~a" c)))
-  (funcall-safely (startup-function browser) urls)
-  ;; Set 'init-time at the end of finalize to take the complete startup time
-  ;; into account.
-  (setf (slot-value *browser* 'init-time)
-        (local-time:timestamp-difference (local-time:now) startup-timestamp)))
+  (chanl:pexec ()
+    (funcall-safely (startup-function browser) urls)
+    ;; Set 'init-time at the end of finalize to take the complete startup time
+    ;; into account.
+    (setf (slot-value *browser* 'init-time)
+          (local-time:timestamp-difference (local-time:now) startup-timestamp))))
 
 ;; Catch a common case for a better error message.
 (defmethod buffers :before ((browser t))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -640,22 +640,20 @@ proceeding."
   "Switch the active buffer in the current window."
   (if id
       (set-current-buffer (gethash id (slot-value *browser* 'buffers)))
-      (with-result (buffer (read-from-minibuffer
-                            (make-minibuffer
-                             :input-prompt "Switch to buffer"
-                             ;; For commodity, the current buffer shouldn't be the first one on the list.
-                             :suggestion-function (buffer-suggestion-filter :current-is-last-p t))))
+      (let ((buffer (prompt-minibuffer
+                     :input-prompt "Switch to buffer"
+                     ;; For commodity, the current buffer shouldn't be the first one on the list.
+                     :suggestion-function (buffer-suggestion-filter :current-is-last-p t))))
         (set-current-buffer buffer))))
 
 (define-command switch-buffer-domain (&optional (buffer (current-buffer)))
   "Switch the active buffer in the current window from the current domain."
   (let ((domain (quri:uri-domain (url buffer))))
-    (with-result (buffer (read-from-minibuffer
-                          (make-minibuffer
-                           :input-prompt "Switch to buffer in current domain:"
-                           :suggestion-function (buffer-suggestion-filter
-                                                 :domain domain
-                                                 :current-is-last-p t))))
+    (let ((buffer (prompt-minibuffer
+                   :input-prompt "Switch to buffer in current domain:"
+                   :suggestion-function (buffer-suggestion-filter
+                                         :domain domain
+                                         :current-is-last-p t))))
       (set-current-buffer buffer))))
 
 (define-command make-buffer-focus (&key (url :default))
@@ -669,11 +667,10 @@ See `make-buffer'."
   "Delete the buffer(s) via minibuffer input."
   (if id
       (buffer-delete (gethash id (slot-value *browser* 'buffers)))
-      (with-result (buffers (read-from-minibuffer
-                             (make-minibuffer
-                              :input-prompt "Delete buffer(s)"
-                              :multi-selection-p t
-                              :suggestion-function (buffer-suggestion-filter))))
+      (let ((buffers (prompt-minibuffer
+                      :input-prompt "Delete buffer(s)"
+                      :multi-selection-p t
+                      :suggestion-function (buffer-suggestion-filter))))
         (mapcar #'buffer-delete buffers))))
 
 (defun delete-buffers ()
@@ -739,7 +736,7 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
                 :must-match-p nil)))
 
       (when (typep url 'history-entry)
-        ;; In case read-from-minibuffer returned a string upon
+        ;; In case prompt-minibuffer returned a string upon
         ;; must-match-p.
         (setf url (url url)))
       (ffi-within-renderer-thread       ; TODO: Wrap the buffer-load FFI method content with ffi-within-renderer-thread.
@@ -763,11 +760,10 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
 
 (define-command reload-buffer ()
   "Reload queried buffer(s)."
-  (with-result (buffers (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Reload buffer(s)"
-                          :multi-selection-p t
-                          :suggestion-function (buffer-suggestion-filter))))
+  (let ((buffers (prompt-minibuffer
+                  :input-prompt "Reload buffer(s)"
+                  :multi-selection-p t
+                  :suggestion-function (buffer-suggestion-filter))))
     (mapcar #'reload-current-buffer buffers)))
 
 (define-command switch-buffer-previous ()
@@ -844,40 +840,36 @@ MODES should be a list of symbols, each possibly returned by `mode-name'."
 
 (define-command disable-mode-for-current-buffer (&key (buffers (list (current-buffer))))
   "Disable queried mode(s)."
-  (with-result (modes (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Disable mode(s)"
-                        :multi-selection-p t
-                        :suggestion-function (active-mode-suggestion-filter buffers))))
+  (let ((modes (prompt-minibuffer
+                :input-prompt "Disable mode(s)"
+                :multi-selection-p t
+                :suggestion-function (active-mode-suggestion-filter buffers))))
     (dolist (buffer buffers)
       (disable-modes modes buffer))))
 
 (define-command disable-mode-for-buffer ()
   "Disable queried mode(s) for select buffer(s)."
-  (with-result (buffers (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Disable mode(s) for buffer(s)"
-                          :multi-selection-p t
-                          :suggestion-function (buffer-suggestion-filter))))
+  (let ((buffers (prompt-minibuffer
+                  :input-prompt "Disable mode(s) for buffer(s)"
+                  :multi-selection-p t
+                  :suggestion-function (buffer-suggestion-filter))))
     (disable-mode-for-current-buffer :buffers buffers)))
 
 (define-command enable-mode-for-current-buffer (&key (buffers (list (current-buffer))))
   "Enable queried mode(s)."
-  (with-result (modes (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Enable mode(s)"
-                        :multi-selection-p t
-                        :suggestion-function (inactive-mode-suggestion-filter buffers))))
+  (let ((modes (prompt-minibuffer
+                :input-prompt "Enable mode(s)"
+                :multi-selection-p t
+                :suggestion-function (inactive-mode-suggestion-filter buffers))))
     (dolist (buffer buffers)
       (enable-modes modes buffer))))
 
 (define-command enable-mode-for-buffer ()
   "Enable queried mode(s) for select buffer(s)."
-  (with-result (buffers (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Enable mode(s) for buffer(s)"
-                          :multi-selection-p t
-                          :suggestion-function (buffer-suggestion-filter))))
+  (let ((buffers (prompt-minibuffer
+                  :input-prompt "Enable mode(s) for buffer(s)"
+                  :multi-selection-p t
+                  :suggestion-function (buffer-suggestion-filter))))
     (enable-mode-for-current-buffer :buffers buffers)))
 
 (define-command open-inspector ()

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -724,27 +724,30 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
   (let ((history (minibuffer-set-url-history *browser*)))
     (when history
       (containers:insert-item history (url (current-buffer))))
-    (with-result (url (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt (format nil "Open URL in ~A buffer"
-                                              (if new-buffer-p
-                                                  "new"
-                                                  "current"))
-                        :input-buffer (if prefill-current-url-p
-                                          (object-string (url (current-buffer))) "")
-                        :default-modes '(set-url-mode minibuffer-mode)
-                        :suggestion-function (history-suggestion-filter
-                                              :prefix-urls (list (object-string
-                                                                  (url (current-buffer)))))
-                        :history history
-                        :must-match-p nil)))
+    (let ((url (prompt-minibuffer
+                :input-prompt (format nil "Open URL in ~A buffer"
+                                      (if new-buffer-p
+                                          "new"
+                                          "current"))
+                :input-buffer (if prefill-current-url-p
+                                  (object-string (url (current-buffer))) "")
+                :default-modes '(set-url-mode minibuffer-mode)
+                :suggestion-function (history-suggestion-filter
+                                      :prefix-urls (list (object-string
+                                                          (url (current-buffer)))))
+                :history history
+                :must-match-p nil)))
+
       (when (typep url 'history-entry)
         ;; In case read-from-minibuffer returned a string upon
         ;; must-match-p.
         (setf url (url url)))
-      (buffer-load url :buffer (if new-buffer-p
-                                   (make-buffer-focus)
-                                   (current-buffer))))))
+      (ffi-within-renderer-thread       ; TODO: Wrap the buffer-load FFI method content with ffi-within-renderer-thread.
+       *browser*
+       (lambda ()
+         (buffer-load url :buffer (if new-buffer-p
+                                      (make-buffer-focus)
+                                      (current-buffer))))))))
 
 (define-command set-url-from-current-url ()
   "Set the URL for the current buffer, pre-filling in the current URL."

--- a/source/certificate-exception-mode.lisp
+++ b/source/certificate-exception-mode.lisp
@@ -50,10 +50,9 @@ To make this change permanent, you can customize
 \(setf nyxt/certificate-exception-mode:*default-certificate-exceptions*
       '(\"nyxt.atlas.engineer\" \"example.org\"))"
   (if (find-submode buffer 'certificate-exception-mode)
-      (with-result (input (read-from-minibuffer
-                           (make-minibuffer
-                            :input-prompt "URL host to exception list:"
-                            :suggestion-function (previous-history-urls-suggestion-filter))))
+      (let ((input (prompt-minibuffer
+                    :input-prompt "URL host to exception list:"
+                    :suggestion-function (previous-history-urls-suggestion-filter))))
         (unless (url-empty-p (url (htree:data input)))
           (let ((host (quri:uri-host (url (htree:data input)))))
             (echo "Added exception for ~s." host)

--- a/source/command-commands.lisp
+++ b/source/command-commands.lisp
@@ -31,13 +31,12 @@
 (define-command execute-command ()
   "Execute a command by name."
   (unless (active-minibuffers (current-window))
-    (with-result (command (read-from-minibuffer
-                           (make-minibuffer
-                            :input-prompt "Execute command"
-                            :suggestion-function (command-suggestion-filter
-                                                  (mapcar #'mode-name
-                                                          (modes (current-buffer))))
-                            :hide-suggestion-count-p t)))
+    (let ((command (prompt-minibuffer
+                    :input-prompt "Execute command"
+                    :suggestion-function (command-suggestion-filter
+                                          (mapcar #'mode-name
+                                                  (modes (current-buffer))))
+                    :hide-suggestion-count-p t)))
       (setf (access-time command) (get-internal-real-time))
       (run command))))
 
@@ -75,26 +74,20 @@
 
 (define-command disable-hook-handler ()
   "Remove handler(s) from a hook."
-  (with-result (hook-desc (read-from-minibuffer
-                           (make-minibuffer
-                            :input-prompt "Hook where to disable handler"
-                            :suggestion-function (hook-suggestion-filter))))
-    (with-result (handler
-                  (read-from-minibuffer
-                   (make-minibuffer
-                    :input-prompt (format nil "Disable handler from ~a" (name hook-desc))
-                    :suggestion-function (handler-suggestion-filter (value hook-desc)))))
-      (hooks:disable-hook (value hook-desc) handler))))
+  (let* ((hook-desc (prompt-minibuffer
+                     :input-prompt "Hook where to disable handler"
+                     :suggestion-function (hook-suggestion-filter)))
+         (handler (prompt-minibuffer
+                   :input-prompt (format nil "Disable handler from ~a" (name hook-desc))
+                   :suggestion-function (handler-suggestion-filter (value hook-desc)))))
+    (hooks:disable-hook (value hook-desc) handler)))
 
 (define-command enable-hook-handler ()
   "Remove handler(s) from a hook."
-  (with-result (hook-desc (read-from-minibuffer
-                           (make-minibuffer
-                            :input-prompt "Hook where to enable handler"
-                            :suggestion-function (hook-suggestion-filter))))
-    (with-result (handler
-                  (read-from-minibuffer
-                   (make-minibuffer
-                    :input-prompt (format nil "Enable handler from ~a" (name hook-desc))
-                    :suggestion-function (disabled-handler-suggestion-filter (value hook-desc)))))
-      (hooks:enable-hook (value hook-desc) handler))))
+  (let* ((hook-desc (prompt-minibuffer
+                     :input-prompt "Hook where to enable handler"
+                     :suggestion-function (hook-suggestion-filter)))
+         (handler (prompt-minibuffer
+                   :input-prompt (format nil "Enable handler from ~a" (name hook-desc))
+                   :suggestion-function (disabled-handler-suggestion-filter (value hook-desc)))))
+    (hooks:enable-hook (value hook-desc) handler)))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -284,7 +284,8 @@ This function can be `funcall'ed."
 
 (defmethod run ((command command) &rest args)
   "Run COMMAND over ARGS."
-  (apply #'funcall-safely (command-function command) args))
+  (chanl:pexec ()
+    (apply #'funcall-safely (command-function command) args)))
 
 (define-command noop ()                 ; TODO: Replace with ESCAPE special command that allows dispatched to cancel current key stack.
   "A command that does nothing.

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -388,11 +388,10 @@ nothing is done if file is missing."
                (with-input-from-string (,in (with-output-to-string (,stream)
                                               (setf ,result (progn ,@body))))
                  (gpg-write ,in ,gpg-file ,recipient))
-               (with-result (,recipient (read-from-minibuffer
-                                        (make-minibuffer
-                                         :input-prompt "Recipient:"
-                                         :suggestion-function (gpg-key-suggestion-filter)
-                                         :must-match-p nil)))
+               (let ((,recipient (prompt-minibuffer
+                                  :input-prompt "Recipient:"
+                                  :suggestion-function (gpg-key-suggestion-filter)
+                                  :must-match-p nil)))
                  (with-input-from-string (,in (with-output-to-string (,stream)
                                                 (setf ,result (progn ,@body))))
                    (gpg-write ,in ,gpg-file (gpg-key-key-id ,recipient)))))

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -104,9 +104,11 @@ No data should be shared with other buffers either."))
   "If `%buffer' is non-nil, return its data-profile.
 Return `*global-data-profile*' otherwise."
   ;; TODO: %BUFFER is not defined yet. Move %BUFFER there?
-  (let ((buffer (current-buffer)))
-    (or (and buffer (data-profile buffer))
-        *global-data-profile*)))
+  (if *renderer-thread* ; This function may be called before renderer has started.
+      (let ((buffer (current-buffer)))
+        (or (and buffer (data-profile buffer))
+            *global-data-profile*))
+      *global-data-profile*))
 
 (defun package-data-profiles ()
   "Return the list of data profiles as a (DATA-PROFILE-SYM NAME DOCSTRING) tuples."

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -82,8 +82,7 @@
 (define-command download-open-file ()
   "Open a downloaded file.
 See also `open-file'."
-  (with-result (filename (read-from-minibuffer
-                          (make-minibuffer
-                           :input-prompt "Open file"
-                           :suggestion-function (downloaded-files-suggestion-filter))))
+  (let ((filename (prompt-minibuffer
+                   :input-prompt "Open file"
+                   :suggestion-function (downloaded-files-suggestion-filter))))
     (nyxt/file-manager-mode:open-file-function filename)))

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -165,29 +165,28 @@ identifier for every hinted element."
   (let* ((buffer (current-buffer))
          minibuffer)
     (let ((elements-json (add-element-hints :annotate-full-document annotate-full-document)))
-      (setf minibuffer (make-minibuffer
-                        :input-prompt prompt
-                        :history nil
-                        :multi-selection-p multi-selection-p
-                        :suggestion-function
-                        (hint-suggestion-filter (elements-from-json elements-json))
-                        :changed-callback
-                        (let ((subsequent-call nil))
-                          (lambda ()
-                            ;; when the minibuffer initially appears, we don't
-                            ;; want update-selection-highlight-hint to scroll
-                            ;; but on subsequent calls, it should scroll
-                            (update-selection-highlight-hint
-                             :scroll subsequent-call
-                             :buffer buffer
-                             :minibuffer minibuffer)
-                            (setf subsequent-call t)))
-                        :cleanup-function
-                        (lambda ()
-                          (with-current-buffer buffer
-                            (remove-element-hints)))))
       ;; TODO: Add offscreen hints in background from full document annotation
-      (let ((result (prompt-minibuffer :minibuffer minibuffer)))
+      (let ((result (prompt-minibuffer
+                     :input-prompt prompt
+                     :history nil
+                     :multi-selection-p multi-selection-p
+                     :suggestion-function
+                     (hint-suggestion-filter (elements-from-json elements-json))
+                     :changed-callback
+                     (let ((subsequent-call nil))
+                       (lambda ()
+                         ;; when the minibuffer initially appears, we don't
+                         ;; want update-selection-highlight-hint to scroll
+                         ;; but on subsequent calls, it should scroll
+                         (update-selection-highlight-hint
+                          :scroll subsequent-call
+                          :buffer buffer
+                          :minibuffer minibuffer)
+                         (setf subsequent-call t)))
+                     :cleanup-function
+                     (lambda ()
+                       (with-current-buffer buffer
+                         (remove-element-hints))))))
         (funcall-safely function result)))))
 
 (defun hint-suggestion-filter (hints)

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -186,8 +186,8 @@ identifier for every hinted element."
                         (lambda ()
                           (with-current-buffer buffer
                             (remove-element-hints)))))
-      ;; TODO: ADD offscreen hints in background from full document annotation
-      (let ((result (prompt-minibuffer minibuffer)))
+      ;; TODO: Add offscreen hints in background from full document annotation
+      (let ((result (prompt-minibuffer :minibuffer minibuffer)))
         (funcall-safely function result)))))
 
 (defun hint-suggestion-filter (hints)

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -175,10 +175,9 @@ Note: this feature is alpha, get in touch for more!"
   ;; TODO: How do we set the current directory permanently?
   (uiop:with-current-directory ((uiop:getcwd))
     ;; Allow the current minibuffer to recognize our keybindings.
-    (with-result (filename (read-from-minibuffer
-                            (make-minibuffer
-                             :default-modes '(nyxt/file-manager-mode::file-manager-mode minibuffer-mode)
-                             :input-prompt (file-namestring (uiop:getcwd))
-                             :suggestion-function #'nyxt/file-manager-mode::open-file-from-directory-suggestion-filter)))
+    (let ((filename (prompt-minibuffer
+                     :default-modes '(nyxt/file-manager-mode::file-manager-mode minibuffer-mode)
+                     :input-prompt (file-namestring (uiop:getcwd))
+                     :suggestion-function #'nyxt/file-manager-mode::open-file-from-directory-suggestion-filter)))
 
       (funcall nyxt/file-manager-mode::*open-file-function* (namestring filename)))))

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -13,6 +13,8 @@
 This is useful when the browser is run from a REPL so that quitting does not
 close the connection.")
 
+(defvar *renderer-thread* nil)
+
 (export-always '*browser*)
 (defvar *browser* nil
   "The entry-point object to a complete instance of Nyxt.

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -326,10 +326,11 @@ This function can be used as a `window' `input-dispatcher'."
 (defun evaluate (string)
   "Evaluate all expressions in string and return a list of values.
 This does not use an implicit PROGN to allow evaluating top-level expressions."
-  (with-input-from-string (input string)
-    (loop for object = (read input nil :eof)
-          until (eq object :eof)
-          collect (eval object))))
+  (chanl:pexec ()
+    (with-input-from-string (input string)
+      (loop for object = (read input nil :eof)
+            until (eq object :eof)
+            collect (eval object)))))
 
 (defun error-buffer (title text)
   "Print some help."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -49,26 +49,25 @@
 
 (define-command describe-variable ()
   "Inspect a variable and show it in a help buffer."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :suggestion-function (variable-suggestion-filter)
-                        :input-prompt "Describe variable")))
-    (let* ((input (variable-suggestion-name input))
-           (help-buffer (nyxt/help-mode:help-mode
-                         :activate t
-                         :buffer (make-internal-buffer
-                                  :title (str:concat "*Help-"
-                                                     (symbol-name input)
-                                                     "*"))))
-           (help-contents (markup:markup
-                           (:h1 (format nil "~s" input)) ; Use FORMAT to keep package prefix.
-                           (:pre (documentation input 'variable))
-                           (:h2 "Current Value:")
-                           (:pre (object-display (symbol-value input)))))
-           (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                     (ps:lisp help-contents)))))
-      (ffi-buffer-evaluate-javascript help-buffer insert-help)
-      (set-current-buffer help-buffer))))
+  (let* ((input (variable-suggestion-name
+                 (prompt-minibuffer
+                  :suggestion-function (variable-suggestion-filter)
+                  :input-prompt "Describe variable")))
+         (help-buffer (nyxt/help-mode:help-mode
+                       :activate t
+                       :buffer (make-internal-buffer
+                                :title (str:concat "*Help-"
+                                                   (symbol-name input)
+                                                   "*"))))
+         (help-contents (markup:markup
+                         (:h1 (format nil "~s" input)) ; Use FORMAT to keep package prefix.
+                         (:pre (documentation input 'variable))
+                         (:h2 "Current Value:")
+                         (:pre (object-display (symbol-value input)))))
+         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
+                                   (ps:lisp help-contents)))))
+    (ffi-buffer-evaluate-javascript help-buffer insert-help)
+    (set-current-buffer help-buffer)))
 
 (declaim (ftype (function (command)) describe-command*))
 (defun describe-command* (command)
@@ -111,10 +110,9 @@
 (define-command describe-function ()
   "Inspect a function and show it in a help buffer.
 For generic functions, describe all the methods."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Describe function"
-                        :suggestion-function (function-suggestion-filter))))
+  (let ((input (prompt-minibuffer
+                :input-prompt "Describe function"
+                :suggestion-function (function-suggestion-filter))))
     (setf input (function-suggestion-name input))
     (flet ((method-desc (method)
              (markup:markup
@@ -153,10 +151,9 @@ For generic functions, describe all the methods."
   "Inspect a command and show it in a help buffer.
 A command is a special kind of function that can be called with
 `execute-command' and can be bound to a key."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Describe command"
-                        :suggestion-function (command-suggestion-filter))))
+  (let ((input (prompt-minibuffer
+                :input-prompt "Describe command"
+                :suggestion-function (command-suggestion-filter))))
     (describe-command* input)))
 
 (defun describe-slot* (slot class &key mention-class-p)      ; TODO: Adapt HTML sections / lists to describe-slot and describe-class.
@@ -183,49 +180,47 @@ A command is a special kind of function that can be called with
 
 (define-command describe-class ()
   "Inspect a class and show it in a help buffer."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Describe class"
-                        :suggestion-function (class-suggestion-filter))))
-    (let* ((input (class-suggestion-name input))
-           (help-buffer (nyxt/help-mode:help-mode
-                         :activate t
-                         :buffer (make-internal-buffer
-                                  :title (str:concat "*Help-"
-                                                     (symbol-name input)
-                                                     "*"))))
-           (slots (class-public-slots input))
-           (slot-descs (apply #'str:concat (mapcar (alex:rcurry #'describe-slot* input) slots)))
-           (help-contents (str:concat
-                           (markup:markup
-                            (:h1 (symbol-name input))
-                            (:p (:pre (documentation input 'type)))
-                            (:h2 "Slots:"))
-                           slot-descs))
-           (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                     (ps:lisp help-contents)))))
-      (ffi-buffer-evaluate-javascript help-buffer insert-help)
-      (set-current-buffer help-buffer))))
+  (let* ((input (class-suggestion-name
+                 (prompt-minibuffer
+                  :input-prompt "Describe class"
+                  :suggestion-function (class-suggestion-filter))))
+         (help-buffer (nyxt/help-mode:help-mode
+                       :activate t
+                       :buffer (make-internal-buffer
+                                :title (str:concat "*Help-"
+                                                   (symbol-name input)
+                                                   "*"))))
+         (slots (class-public-slots input))
+         (slot-descs (apply #'str:concat (mapcar (alex:rcurry #'describe-slot* input) slots)))
+         (help-contents (str:concat
+                         (markup:markup
+                          (:h1 (symbol-name input))
+                          (:p (:pre (documentation input 'type)))
+                          (:h2 "Slots:"))
+                         slot-descs))
+         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
+                                   (ps:lisp help-contents)))))
+    (ffi-buffer-evaluate-javascript help-buffer insert-help)
+    (set-current-buffer help-buffer)))
 
 (define-command describe-slot ()
   "Inspect a slot and show it in a help buffer."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Describe slot"
-                        :suggestion-function (slot-suggestion-filter))))
-    (let* ((help-buffer (nyxt/help-mode:help-mode
-                         :activate t
-                         :buffer (make-internal-buffer
-                                  :title (str:concat "*Help-"
-                                                     (symbol-name (name input))
-                                                     "*"))))
+  (let* ((input (prompt-minibuffer
+                 :input-prompt "Describe slot"
+                 :suggestion-function (slot-suggestion-filter)))
+         (help-buffer (nyxt/help-mode:help-mode
+                       :activate t
+                       :buffer (make-internal-buffer
+                                :title (str:concat "*Help-"
+                                                   (symbol-name (name input))
+                                                   "*"))))
 
-           (help-contents (describe-slot* (name input) (class-sym input)
-                                          :mention-class-p t))
-           (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                     (ps:lisp help-contents)))))
-      (ffi-buffer-evaluate-javascript help-buffer insert-help)
-      (set-current-buffer help-buffer))))
+         (help-contents (describe-slot* (name input) (class-sym input)
+                                        :mention-class-p t))
+         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
+                                   (ps:lisp help-contents)))))
+    (ffi-buffer-evaluate-javascript help-buffer insert-help)
+    (set-current-buffer help-buffer)))
 
 (define-command describe-bindings ()
   "Show a buffer with the list of all known bindings for the current buffer."

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -61,12 +61,11 @@ The history is sorted by last access."
 (define-command delete-history-entry ()
   "Delete queried history entries."
   (with-data-access history (history-path (current-buffer))
-    (with-result (entries (read-from-minibuffer
-                           (make-minibuffer
-                            :input-prompt "Delete entries"
-                            :suggestion-function (history-suggestion-filter)
-                            :history (minibuffer-set-url-history *browser*)
-                            :multi-selection-p t)))
+    (let ((entries (prompt-minibuffer
+                    :input-prompt "Delete entries"
+                    :suggestion-function (history-suggestion-filter)
+                    :history (minibuffer-set-url-history *browser*)
+                    :multi-selection-p t)))
       (dolist (entry entries)
         (remhash (object-string (url entry)) history)))))
 

--- a/source/input-edit.lisp
+++ b/source/input-edit.lisp
@@ -34,19 +34,19 @@
      ,@body))
 
 (defmacro with-input-area ((contents cursor-position) &body body)
-  `(with-result* ((,contents (active-input-area-content))
+  `(let* ((,contents (active-input-area-content))
                   (,cursor-position (active-input-area-cursor)))
      ,@body))
 
 (define-command cursor-forwards ()
   "Move cursor forward by one element."
-  (with-result* ((cursor-position (active-input-area-cursor)))
+  (let* ((cursor-position (active-input-area-cursor)))
     (let ((new-position (+ (parse-integer cursor-position) 1)))
       (set-active-input-area-cursor new-position new-position))))
 
 (define-command cursor-backwards ()
   "Move cursor backwards by one element."
-  (with-result* ((cursor-position (active-input-area-cursor)))
+  (let* ((cursor-position (active-input-area-cursor)))
     (let ((new-position (- (parse-integer cursor-position) 1)))
       (set-active-input-area-cursor new-position new-position))))
 

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -113,7 +113,7 @@ Return nil to forward to renderer or non-nil otherwise."
              ((typep bound-function 'function-symbol)
               (log:debug "Found key binding ~a" (keyspecs key-stack translated-key))
               (unwind-protect
-                   (funcall-safely bound-function)
+                   (funcall-safely bound-function) ; TODO: Use (run bound-function) instead?
                 ;; We must reset the key-stack on errors or else all subsequent
                 ;; keypresses will keep triggering the same erroring command.
                 (setf key-stack nil))

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -111,7 +111,11 @@ Return nil to forward to renderer or non-nil otherwise."
               t)
 
              ((typep bound-function 'function-symbol)
-              (log:debug "Found key binding ~a" (keyspecs key-stack translated-key))
+              (log:debug "Found key binding ~a to ~a" (keyspecs key-stack translated-key) bound-function)
+              ;; We save the last key separately to keep it available to the
+              ;; command even after key-stack has been reset in the other
+              ;; thread.
+              (setf (last-key window) (first key-stack))
               (unwind-protect
                    (run (function-command (symbol-function bound-function)))
                 ;; We must reset the key-stack on errors or else all subsequent

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -113,7 +113,7 @@ Return nil to forward to renderer or non-nil otherwise."
              ((typep bound-function 'function-symbol)
               (log:debug "Found key binding ~a" (keyspecs key-stack translated-key))
               (unwind-protect
-                   (funcall-safely bound-function) ; TODO: Use (run bound-function) instead?
+                   (run (function-command (symbol-function bound-function)))
                 ;; We must reset the key-stack on errors or else all subsequent
                 ;; keypresses will keep triggering the same erroring command.
                 (setf key-stack nil))

--- a/source/jump-heading.lisp
+++ b/source/jump-heading.lisp
@@ -45,12 +45,11 @@ For example, Wikipedia ones end with '[edit]'. We strip what comes after the fir
 
 (define-command jump-to-heading ()
   "Jump to a particular heading, of type h1, h2, h3, h4, h5, or h6."
-  (with-result* ((headings (get-headings))
-                 (heading (read-from-minibuffer
-                           (make-minibuffer
-                            :input-prompt "Jump to heading"
-                            :suggestion-function (lambda (minibuffer)
-                                                   (fuzzy-match
-                                                    (input-buffer minibuffer)
-                                                    (make-headings (cl-json:decode-json-from-string headings))))))))
+  (let* ((headings (get-headings))
+         (heading (prompt-minibuffer
+                   :input-prompt "Jump to heading"
+                   :suggestion-function (lambda (minibuffer)
+                                          (fuzzy-match
+                                           (input-buffer minibuffer)
+                                           (make-headings (cl-json:decode-json-from-string headings)))))))
     (paren-jump-to-heading :heading-inner-text (inner-text heading))))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -97,9 +97,8 @@ Lisp function, except the form is " (:code "define-command") " instead of "
     (:pre (:code
            "(define-command bookmark-url ()
   \"Allow the user to bookmark a URL via minibuffer input.\"
-  (with-result (url (read-from-minibuffer
-                     (make-minibuffer
-                      :input-prompt \"Bookmark URL\")))
+  (let ((url (prompt-minibuffer
+              :input-prompt \"Bookmark URL\")))
     (bookmark-add url)))"))
     (:p "See the " (:code "minibuffer") " class documentation for how to write
 write custom minibuffers.")

--- a/source/minibuffer-composite.lisp
+++ b/source/minibuffer-composite.lisp
@@ -13,20 +13,18 @@
 
 (defun meta-search (minibuffers)
   "Search a composite set of sources simultaneously."
-  (let ((selection
-          (prompt-minibuffer
-           :input-prompt "Meta Search"
-           :suggestion-function
-           (lambda (minibuffer)
-             (apply #'intertwine
-                    (loop for i in minibuffers
-                          collect
-                          (loop for result in (funcall (suggestion-function i)
-                                                       minibuffer)
-                                collect (make-instance 'meta-result
-                                                       :result result
-                                                       :source i))))))))
-    (funcall (slot-value (source-minibuffer selection) 'callback) (result selection))))
+  (prompt-minibuffer
+   :input-prompt "Meta Search"
+   :suggestion-function
+   (lambda (minibuffer)
+     (apply #'intertwine
+            (loop for i in minibuffers
+                  collect
+                  (loop for result in (funcall (suggestion-function i)
+                                               minibuffer)
+                        collect (make-instance 'meta-result
+                                               :result result
+                                               :source i)))))))
 
 (defun intertwine (&rest lists)
   (let ((heads (copy-list lists))

--- a/source/minibuffer-composite.lisp
+++ b/source/minibuffer-composite.lisp
@@ -13,20 +13,19 @@
 
 (defun meta-search (minibuffers)
   "Search a composite set of sources simultaneously."
-  (with-result (selection
-                (read-from-minibuffer
-                 (make-minibuffer
-                  :input-prompt "Meta Search"
-                  :suggestion-function
-                  (lambda (minibuffer)
-                    (apply #'intertwine
-                           (loop for i in minibuffers collect
-                                    (loop for result in
-                                             (funcall (suggestion-function i)
-                                                      minibuffer)
-                                          collect (make-instance 'meta-result
-                                                                 :result result
-                                                                 :source i))))))))
+  (let ((selection
+          (prompt-minibuffer
+           :input-prompt "Meta Search"
+           :suggestion-function
+           (lambda (minibuffer)
+             (apply #'intertwine
+                    (loop for i in minibuffers
+                          collect
+                          (loop for result in (funcall (suggestion-function i)
+                                                       minibuffer)
+                                collect (make-instance 'meta-result
+                                                       :result result
+                                                       :source i))))))))
     (funcall (slot-value (source-minibuffer selection) 'callback) (result selection))))
 
 (defun intertwine (&rest lists)

--- a/source/minibuffer-helper.lisp
+++ b/source/minibuffer-helper.lisp
@@ -3,46 +3,6 @@
 
 (in-package :nyxt)
 
-(defparameter %callback nil)            ; TODO: Make a monad?
-
-(export-always 'use-empty-result)
-(defun use-empty-result ()
-  (funcall-safely %callback nil))
-
-(export-always 'with-result)
-(defmacro with-result ((symbol async-form) &body body)
-  "Call ASYNC-FORM and lexically bind `%callback' to BODY.
-SYMBOL is bound to the result of ASYNC-FORM in the lexical context of BODY.
-
-If ASYNC-FORM does not funcall `%callback', BODY won't be called.
-Call `use-empty-result' without argument in ASYNC-FORM to force a call to BODY.
-
-Example:
-
-  (with-result (url (read-from-minibuffer
-                     (make-minibuffer
-                      :input-prompt \"Bookmark URL\"))
-    (bookmark-add url))"
-  `(let ((%callback (lambda (,symbol) ,@body)))
-     ,async-form))
-
-(export-always 'with-result*)
-(defmacro with-result* (bindings &body body)
-  "Like WITH-RESULT but allows for chained asynchronous bindings.
-
-Example:
-
-  (with-result* ((links-json (add-link-hints))
-                 (selected-hint (read-from-minibuffer
-                                 (make-minibuffer
-                                  :input-prompt \"Bookmark hint\"
-                                  :cleanup-function #'remove-link-hints))))
-    ...)"
-  (if (null bindings)
-    `(progn ,@body)
-    `(with-result ,(first bindings)
-       (with-result* ,(rest bindings) ,@body))))
-
 (export-always '*yes-no-choices*)
 (defparameter *yes-no-choices* '(:yes "yes" :no "no")
   "The suggestions when asking the user for a yes/no choice.
@@ -67,11 +27,10 @@ Example usage defaulting to \"no\":
 \(let ((*yes-no-choices* '(:no \"no\" :yes \"yes\")))
   (if-confirm (\"Are you sure to kill ~a buffers?\" count)
      (delete-buffers)))"
-  `(with-result (answer (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt (format nil ,@prompt)
-                          :suggestion-function (yes-no-suggestion-filter)
-                          :hide-suggestion-count-p t)))
+  `(let ((answer (prompt-minibuffer
+                  :input-prompt (format nil ,@prompt)
+                  :suggestion-function (yes-no-suggestion-filter)
+                  :hide-suggestion-count-p t)))
      (if (confirmed-p answer)
          ,yes-form
          ,no-form)))

--- a/source/minibuffer-mode.lisp
+++ b/source/minibuffer-mode.lisp
@@ -141,13 +141,13 @@ complete against a search engine."
     ((guard f f) (funcall-safely f)))
   (hide minibuffer))
 
-(defun self-insert-minibuffer ()
+(define-command self-insert-minibuffer ()
   "Self insert with the current minibuffer."
   (self-insert (nyxt:current-minibuffer)))
 
 (define-command self-insert (receiver)
-  "Insert first key from current window `key-stack' to the receiver."
-  (let ((key-string (keymap:key-value (first (nyxt::key-stack (current-window)))))
+  "Insert last key from current window to the receiver."
+  (let ((key-string (keymap:key-value (nyxt::last-key (current-window))))
         (translation-table '(("hyphen" "-")
                              ;; Regular spaces are concatenated into a single
                              ;; one by HTML rendering, so we use a non-breaking

--- a/source/minibuffer-mode.lisp
+++ b/source/minibuffer-mode.lisp
@@ -32,7 +32,7 @@
        "C-e" 'cursor-end
        "end" 'cursor-end
        "C-k" 'kill-line
-       "return" 'return-input
+       "return" 'return-selection
        "C-return" 'return-immediate
        "C-g" 'cancel-input
        "escape" 'cancel-input
@@ -97,9 +97,9 @@ complete against a search engine."
     (t
      (insert-suggestion minibuffer))))
 
-(define-command return-input (&optional (minibuffer (current-minibuffer)))
+(define-command return-selection (&optional (minibuffer (current-minibuffer)))
   "Return with minibuffer selection."
-  (with-slots (nyxt::callback must-match-p nyxt::suggestions nyxt::suggestion-cursor
+  (with-slots (must-match-p nyxt::suggestions nyxt::suggestion-cursor
                invisible-input-p
                multi-selection-p nyxt::marked-suggestions)
       minibuffer
@@ -115,11 +115,13 @@ complete against a search engine."
                                               (str:replace-all " " " " suggestion)
                                               suggestion))
                      nyxt::suggestions))
-       (funcall-safely nyxt::callback (if multi-selection-p
-                                    nyxt::suggestions
-                                    (first nyxt::suggestions))))
+       (chanl:send (channel minibuffer) (if multi-selection-p
+                                          nyxt::suggestions
+                                          (first nyxt::suggestions))
+                   :blockp nil))
       (nil (when invisible-input-p
-             (funcall-safely nyxt::callback (input-buffer minibuffer))))))
+             (chanl:send (channel minibuffer) (input-buffer minibuffer)
+                         :blockp nil)))))
   (quit-minibuffer minibuffer))
 
 (define-command return-immediate (&optional (minibuffer (current-minibuffer)))

--- a/source/minibuffer-mode.lisp
+++ b/source/minibuffer-mode.lisp
@@ -86,11 +86,10 @@ complete against a search engine."
           (kill-whole-line minibuffer)
           (insert minibuffer (str:concat (shortcut (first matching-engines)) " ")))
          (match-count
-          (with-result (engine (read-from-minibuffer
-                                (make-minibuffer
-                                 :input-prompt "Search engine"
-                                 :input-buffer (if (zerop match-count) "" (input-buffer minibuffer))
-                                 :suggestion-function #'nyxt:search-engine-suggestion-filter)))
+          (let ((engine (prompt-minibuffer
+                         :input-prompt "Search engine"
+                         :input-buffer (if (zerop match-count) "" (input-buffer minibuffer))
+                         :suggestion-function #'nyxt:search-engine-suggestion-filter)))
             (when engine
               (kill-whole-line minibuffer)
               (insert minibuffer (str:concat (shortcut engine) " "))))))))
@@ -302,11 +301,10 @@ readable."
 (define-command minibuffer-history (&optional (minibuffer (current-minibuffer)))
   "Choose a minibuffer input history entry to insert as input."
   (when (history minibuffer)
-    (with-result (input (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Input history"
-                          :history nil
-                          :suggestion-function (minibuffer-history-suggestion-filter (history minibuffer)))))
+    (let ((input (prompt-minibuffer
+                  :input-prompt "Input history"
+                  :history nil
+                  :suggestion-function (minibuffer-history-suggestion-filter (history minibuffer)))))
       (unless (str:empty? input)
         (log:debug input minibuffer)
         (text-buffer::kill-line (input-cursor minibuffer))

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -11,13 +11,6 @@
                         :documentation "
 Take the input string and returns a list of suggestion strings.
 Example: `buffer-suggestion-filter'.")
-   (callback-buffer (when *browser* (current-buffer))
-                    :type (or buffer null)
-                    :export nil
-                    :documentation "The active buffer when the minibuffer was
-brought up.
-This can be useful to know which was the original buffer in the `callback' in
-case the buffer was changed.")
    (setup-function #'setup-default
                    :type (or function null)
                    :documentation "Fills the `content' on when the minibuffer is created.

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -270,7 +270,7 @@ See the documentation of `minibuffer' to know more about the minibuffer options.
   "Evaluate SCRIPT into MINIBUFFER's webview.
 The new webview HTML content it set as the MINIBUFFER's `content'."
   (when minibuffer
-    (let ((new-content
+    (let ((new-content                  ; TODO: Is new-content used at all?
             (ffi-minibuffer-evaluate-javascript
              (current-window)
              (str:concat script (ps:ps (ps:chain document body |outerHTML|))))))

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -35,15 +35,13 @@
     ((and (password-interface *browser*)
           (has-method-p (password-interface *browser*)
                         #'password:save-password))
-     (with-result* ((password-name (read-from-minibuffer
-                                    (make-minibuffer
-                                     :input-prompt "Name for new password"
-                                     :input-buffer (or (quri:uri-domain (url (current-buffer)))
-                                                       ""))))
-                    (new-password (read-from-minibuffer
-                                   (make-minibuffer
-                                    :invisible-input-p t
-                                    :input-prompt "New password (leave empty to generate)"))))
+     (let* ((password-name (prompt-minibuffer
+                            :input-prompt "Name for new password"
+                            :input-buffer (or (quri:uri-domain (url (current-buffer)))
+                                              "")))
+            (new-password (prompt-minibuffer
+                           :invisible-input-p t
+                           :input-prompt "New password (leave empty to generate)")))
        (password:save-password (password-interface *browser*)
                                :password-name password-name
                                :password new-password)))
@@ -61,12 +59,10 @@
   "Copy password prompting for all the details without suggestion."
   (password-debug-info)
   (if (password-interface *browser*)
-      (with-result* ((password-name (read-from-minibuffer
-                                     (make-minibuffer
-                                      :input-prompt "Name of password")))
-                     (service (read-from-minibuffer
-                               (make-minibuffer
-                                :input-prompt "Service"))))
+      (let* ((password-name (prompt-minibuffer
+                             :input-prompt "Name of password"))
+             (service (prompt-minibuffer
+                       :input-prompt "Service")))
         (handler-case
             (password:clip-password (password-interface *browser*)
                                     :password-name password-name
@@ -80,12 +76,10 @@
   (password-debug-info)
   (if (password-interface *browser*)
       (with-password (password-interface *browser*)
-        (with-result (password-name
-                      (read-from-minibuffer
-                       (make-minibuffer
-                        :suggestion-function
-                        (password-suggestion-filter
-                         (password-interface *browser*)))))
+        (let ((password-name (prompt-minibuffer
+                              :suggestion-function
+                              (password-suggestion-filter
+                               (password-interface *browser*)))))
           (password:clip-password (password-interface *browser*) :password-name password-name)
           (echo "Password saved to clipboard for ~a seconds." password:*sleep-timer*)))
       (echo-warning "No password manager found.")))

--- a/source/recent-buffers.lisp
+++ b/source/recent-buffers.lisp
@@ -17,11 +17,10 @@
 
 (define-command reopen-buffer ()
   "Reopen queried deleted buffer(s)."
-  (with-result (buffers (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Reopen buffer(s)"
-                          :multi-selection-p t
-                          :suggestion-function (recent-buffer-suggestion-filter))))
+  (let ((buffers (prompt-minibuffer
+                  :input-prompt "Reopen buffer(s)"
+                  :multi-selection-p t
+                  :suggestion-function (recent-buffer-suggestion-filter))))
     (dolist (buffer buffers)
       (containers:delete-item-if (recent-buffers *browser*) (buffer-match-predicate buffer))
       (reload-current-buffer (buffer-make *browser* :dead-buffer buffer))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -75,7 +75,7 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
   "Make a window."
   (let* ((docstring (when (stringp (first body))
                       (prog1
-                          (first body)
+                          (list (first body))
                         (setf body (rest body)))))
          (declares (when (and (listp (first body))
                               (eq 'declare (first (first body))))
@@ -83,7 +83,7 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
                          (first body)
                        (setf body (rest body))))))
     `(defmethod ,name ,args
-       ,docstring
+       ,@docstring
        ,declares
        (if (renderer-thread-p)
            (progn
@@ -510,7 +510,7 @@ Warning: This behaviour may change in the future."
 (define-ffi-method ffi-buffer-title ((buffer gtk-buffer))
   (or (webkit:webkit-web-view-title (gtk-object buffer)) ""))
 
-(defmethod on-signal-load-failed-with-tls-errors ((buffer gtk-buffer) certificate url)
+(define-ffi-method on-signal-load-failed-with-tls-errors ((buffer gtk-buffer) certificate url)
   "Return nil to propagate further (i.e. raise load-failed signal), T otherwise."
   (let* ((context (webkit:webkit-web-view-web-context (gtk-object buffer)))
          (host (quri:uri-host url)))
@@ -527,7 +527,7 @@ Warning: This behaviour may change in the future."
           (tls-help buffer url)
           t))))
 
-(defmethod on-signal-decide-policy ((buffer gtk-buffer) response-policy-decision policy-decision-type-response)
+(define-ffi-method on-signal-decide-policy ((buffer gtk-buffer) response-policy-decision policy-decision-type-response)
   (let ((is-new-window nil) (is-known-type t) (event-type :other)
         (navigation-action nil) (navigation-type nil)
         (mouse-button nil) (modifiers ())
@@ -602,7 +602,7 @@ Warning: This behaviour may change in the future."
              (webkit:webkit-web-view-load-request (gtk-object buffer) request)
              nil))))))
 
-(defmethod on-signal-load-changed ((buffer gtk-buffer) load-event)
+(define-ffi-method on-signal-load-changed ((buffer gtk-buffer) load-event)
   (sera:and-let* ((url (webkit:webkit-web-view-uri (gtk-object buffer)))
                   ;; `url' can be nil if buffer didn't have any URL associated
                   ;; to the web view, e.g. the start page.
@@ -621,7 +621,7 @@ Warning: This behaviour may change in the future."
            (print-status nil (get-containing-window-for-buffer buffer *browser*))
            (echo "Finished loading ~s." (object-display url))))))
 
-(defmethod on-signal-mouse-target-changed ((buffer gtk-buffer) hit-test-result modifiers)
+(define-ffi-method on-signal-mouse-target-changed ((buffer gtk-buffer) hit-test-result modifiers)
   (declare (ignore modifiers))
   (match (cond ((webkit:webkit-hit-test-result-link-uri hit-test-result)
                 (webkit:webkit-hit-test-result-link-uri hit-test-result))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -69,6 +69,18 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
     (funcall thunk)))
 
 (defun PREFIX-within-renderer-thread (thunk)
+  "If the current thread is the renderer thread, execute THUNK with `funcall'.
+Otherwise run the THINK on the renderer thread by passing it a channel and wait on the channel's result."
+  (if (renderer-thread-p)
+      (funcall thunk)
+      (let ((channel (make-instance 'chanl:channel)))
+        (gtk:within-gtk-thread
+          (funcall thunk channel))
+        (chanl:recv channel))))
+
+(defun PREFIX-within-renderer-thread-async (thunk)
+  "Same as `PREFIX-within-renderer-thread' but THUNK is not blocking and does
+not return."
   (if (renderer-thread-p)
       (funcall thunk)
       (gtk:within-gtk-thread
@@ -164,7 +176,7 @@ data-manager will store the data separately for each buffer."))
                  :web-context (make-context buffer)))
 
 (defmethod initialize-instance :after ((buffer status-buffer) &key)
-  (PREFIX-within-renderer-thread
+  (PREFIX-within-renderer-thread-async
    (lambda ()
      (with-slots (gtk-object) buffer
        (setf gtk-object (make-web-view buffer))
@@ -175,7 +187,7 @@ data-manager will store the data separately for each buffer."))
           (on-signal-decide-policy buffer response-policy-decision policy-decision-type-response)))))))
 
 (defmethod initialize-instance :after ((window gtk-window) &key)
-  (PREFIX-within-renderer-thread
+  (PREFIX-within-renderer-thread-async
    (lambda ()
      (with-slots (gtk-object box-layout active-buffer
                   minibuffer-container minibuffer-view
@@ -757,16 +769,26 @@ requested a reload."
           (load-webkit-history-entry buffer entry))
         (webkit:webkit-web-view-load-uri (gtk-object buffer) (object-string uri)))))
 
+(defmethod ffi-buffer-evaluate-javascript-sync ((buffer gtk-buffer) javascript)
+  (PREFIX-within-renderer-thread
+   (lambda (&optional channel)
+     (webkit2:webkit-web-view-evaluate-javascript
+      (gtk-object buffer)
+      javascript
+      (when channel
+        (lambda (result)
+          (chanl:send channel result :blockp nil)))
+      #'javascript-error-handler))))
+
+;; TODO: Exchange async/sync names.
 (defmethod ffi-buffer-evaluate-javascript ((buffer gtk-buffer) javascript)
-  (let ((channel (make-instance 'chanl:channel)))
-    (PREFIX-within-renderer-thread
-     (lambda ()
-       (webkit2:webkit-web-view-evaluate-javascript (gtk-object buffer)
-                                                    javascript
-                                                    (lambda (result)
-                                                      (chanl:send channel result :blockp nil))
-                                                    #'javascript-error-handler)))
-    (chanl:recv channel)))
+  (PREFIX-within-renderer-thread-async
+   (lambda ()
+     (webkit2:webkit-web-view-evaluate-javascript
+      (gtk-object buffer)
+      javascript
+      nil
+      #'javascript-error-handler))))
 
 (define-ffi-method ffi-minibuffer-evaluate-javascript ((window gtk-window) javascript)
   (webkit2:webkit-web-view-evaluate-javascript (minibuffer-view window) javascript))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -58,6 +58,9 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
 
 (defun renderer-thread-p ()
   ;; (eq *renderer-thread* (bt:current-thread))
+  #+darwin
+  (string= "main thread" (bt:thread-name (bt:current-thread)))
+  #-darwin
   (string= "cl-cffi-gtk main thread" (bt:thread-name (bt:current-thread))))
 
 (defmethod ffi-within-renderer-thread ((browser gtk-browser) thunk)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -712,10 +712,16 @@ requested a reload."
         (webkit:webkit-web-view-load-uri (gtk-object buffer) (object-string uri)))))
 
 (defmethod ffi-buffer-evaluate-javascript ((buffer gtk-buffer) javascript)
-  (webkit2:webkit-web-view-evaluate-javascript (gtk-object buffer)
-                                               javascript
-                                               %callback
-                                               #'javascript-error-handler))
+  (let ((channel (make-instance 'chanl:channel)))
+    (ffi-within-renderer-thread
+     *browser*
+     (lambda ()
+       (webkit2:webkit-web-view-evaluate-javascript (gtk-object buffer)
+                                                    javascript
+                                                    (lambda (result)
+                                                      (chanl:send channel result :blockp nil))
+                                                    #'javascript-error-handler)))
+    (chanl:recv channel)))
 
 (defmethod ffi-minibuffer-evaluate-javascript ((window gtk-window) javascript)
   (webkit2:webkit-web-view-evaluate-javascript (minibuffer-view window) javascript))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -90,12 +90,11 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
              ,@body)
            (let ((channel (make-instance 'chanl:channel)))
              (gtk:within-gtk-thread
-               (lambda ()
-                 (chanl:send
-                  channel
-                  (progn
-                    ,@body)
-                  :blockp nil)))
+               (chanl:send
+                channel
+                (progn
+                  ,@body)
+                :blockp nil))
              (chanl:recv channel))))))
 
 (defmethod ffi-initialize ((browser gtk-browser) urls startup-timestamp)
@@ -108,8 +107,7 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
   (log:debug "Initializing GTK Interface")
   (if gtk-running-p
       (gtk:within-gtk-thread
-       (lambda ()
-         (finalize browser urls startup-timestamp)))
+        (finalize browser urls startup-timestamp))
       #-darwin
       (progn
         (setf gtk-running-p t)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -56,7 +56,41 @@ As a workaround, we never leave the GTK main loop when running from a REPL.
 
 See https://github.com/atlas-engineer/nyxt/issues/740")
 
-(defmethod ffi-initialize ((browser gtk-browser) urls startup-timestamp)
+(defmethod ffi-within-renderer-thread ((browser gtk-browser) thunk)
+  (declare (ignore browser))
+  (gtk:within-gtk-thread
+    (funcall thunk)))
+
+(defmacro define-ffi-method (name args &body body) ; TODO: Support declare, docstring.
+  "Make a window."
+  (let* ((docstring (when (stringp (first body))
+                      (prog1
+                          (first body)
+                        (setf body (rest body)))))
+         (declares (when (and (listp (first body))
+                              (eq 'declare (first (first body))))
+                     (prog1
+                         (first body)
+                       (setf body (rest body))))))
+    `(defmethod ,name ,args
+       ,docstring
+       ,declares
+       (let ((channel (make-instance 'chanl:channel)))
+         (ffi-within-renderer-thread
+          *browser*
+          (lambda ()
+            (chanl:send
+             channel
+             (progn
+               ,@body))))
+         ;; (chanl:pexec ()
+         ;;   (chanl:send
+         ;;    channel
+         ;;    (progn
+         ;;      ,@body)))
+         (chanl:recv channel)))))
+
+(define-ffi-method ffi-initialize ((browser gtk-browser) urls startup-timestamp)
   "gtk:within-main-loop handles all the GTK initialization. On
    GNU/Linux, Nyxt could hang after 10 minutes if it's not
    used. Conversely, on Darwin, if gtk:within-main-loop is used, no
@@ -84,7 +118,7 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
         (finalize browser urls startup-timestamp)
         (gtk:gtk-main))))
 
-(defmethod ffi-kill-browser ((browser gtk-browser))
+(define-ffi-method ffi-kill-browser ((browser gtk-browser))
   (unless *keep-alive*
     (gtk:leave-gtk-main)))
 
@@ -122,94 +156,100 @@ data-manager will store the data separately for each buffer."))
                  :web-context (make-context buffer)))
 
 (defmethod initialize-instance :after ((buffer status-buffer) &key)
-  (with-slots (gtk-object) buffer
-    (setf gtk-object (make-web-view buffer))
-    (gobject:g-signal-connect
-     gtk-object "decide-policy"
-     (lambda (web-view response-policy-decision policy-decision-type-response)
-       (declare (ignore web-view))
-       (on-signal-decide-policy buffer response-policy-decision policy-decision-type-response)))))
+  (ffi-within-renderer-thread
+   *browser*
+   (lambda ()
+     (with-slots (gtk-object) buffer
+       (setf gtk-object (make-web-view buffer))
+       (gobject:g-signal-connect
+        gtk-object "decide-policy"
+        (lambda (web-view response-policy-decision policy-decision-type-response)
+          (declare (ignore web-view))
+          (on-signal-decide-policy buffer response-policy-decision policy-decision-type-response)))))))
 
 (defmethod initialize-instance :after ((window gtk-window) &key)
-  (with-slots (gtk-object box-layout active-buffer
-               minibuffer-container minibuffer-view
-               status-buffer status-container
-               message-container message-view
-               id key-string-buffer) window
-    (setf id (get-unique-window-identifier *browser*))
-    (setf gtk-object (make-instance 'gtk:gtk-window
-                                    :type :toplevel
-                                    :default-width 1024
-                                    :default-height 768))
-    (setf box-layout (make-instance 'gtk:gtk-box
-                                    :orientation :vertical
-                                    :spacing 0))
-    (setf minibuffer-container (make-instance 'gtk:gtk-box
+  (ffi-within-renderer-thread
+   *browser*
+   (lambda ()
+     (with-slots (gtk-object box-layout active-buffer
+                  minibuffer-container minibuffer-view
+                  status-buffer status-container
+                  message-container message-view
+                  id key-string-buffer) window
+       (setf id (get-unique-window-identifier *browser*))
+       (setf gtk-object (make-instance 'gtk:gtk-window
+                                       :type :toplevel
+                                       :default-width 1024
+                                       :default-height 768))
+       (setf box-layout (make-instance 'gtk:gtk-box
+                                       :orientation :vertical
+                                       :spacing 0))
+       (setf minibuffer-container (make-instance 'gtk:gtk-box
+                                                 :orientation :vertical
+                                                 :spacing 0))
+       (setf message-container (make-instance 'gtk:gtk-box
                                               :orientation :vertical
                                               :spacing 0))
-    (setf message-container (make-instance 'gtk:gtk-box
-                                           :orientation :vertical
-                                           :spacing 0))
-    (setf status-container (make-instance 'gtk:gtk-box
-                                          :orientation :vertical
-                                          :spacing 0))
-    (setf key-string-buffer (make-instance 'gtk:gtk-entry))
-    (setf active-buffer (make-instance 'user-buffer))
+       (setf status-container (make-instance 'gtk:gtk-box
+                                             :orientation :vertical
+                                             :spacing 0))
+       (setf key-string-buffer (make-instance 'gtk:gtk-entry))
+       (setf active-buffer (make-instance 'user-buffer))
 
-    ;; Add the views to the box layout and to the window
-    (gtk:gtk-box-pack-start box-layout (gtk-object active-buffer))
+       ;; Add the views to the box layout and to the window
+       (gtk:gtk-box-pack-start box-layout (gtk-object active-buffer))
 
-    (setf message-view (make-web-view))
-    (gtk:gtk-box-pack-end box-layout message-container :expand nil)
-    (gtk:gtk-box-pack-start message-container message-view :expand t)
-    (setf (gtk:gtk-widget-size-request message-container)
-          (list -1 (message-buffer-height window)))
+       (setf message-view (make-web-view))
+       (gtk:gtk-box-pack-end box-layout message-container :expand nil)
+       (gtk:gtk-box-pack-start message-container message-view :expand t)
+       (setf (gtk:gtk-widget-size-request message-container)
+             (list -1 (message-buffer-height window)))
 
-    (setf status-buffer (make-instance 'user-status-buffer))
-    (gtk:gtk-box-pack-end box-layout status-container :expand nil)
-    (gtk:gtk-box-pack-start status-container (gtk-object status-buffer) :expand t)
-    (setf (gtk:gtk-widget-size-request status-container)
-          (list -1 (height status-buffer)))
+       (setf status-buffer (make-instance 'user-status-buffer))
+       (gtk:gtk-box-pack-end box-layout status-container :expand nil)
+       (gtk:gtk-box-pack-start status-container (gtk-object status-buffer) :expand t)
+       (setf (gtk:gtk-widget-size-request status-container)
+             (list -1 (height status-buffer)))
 
-    (setf minibuffer-view (make-web-view))
-    (gtk:gtk-box-pack-end box-layout minibuffer-container :expand nil)
-    (gtk:gtk-box-pack-start minibuffer-container minibuffer-view :expand t)
-    (setf (gtk:gtk-widget-size-request minibuffer-container)
-          (list -1 0))
+       (setf minibuffer-view (make-web-view))
+       (gtk:gtk-box-pack-end box-layout minibuffer-container :expand nil)
+       (gtk:gtk-box-pack-start minibuffer-container minibuffer-view :expand t)
+       (setf (gtk:gtk-widget-size-request minibuffer-container)
+             (list -1 0))
 
-    (gtk:gtk-container-add gtk-object box-layout)
-    (setf (slot-value *browser* 'last-active-window) window)
-    (gtk:gtk-widget-show-all gtk-object)
-    (gobject:g-signal-connect
-     gtk-object "key_press_event"
-     (lambda (widget event) (declare (ignore widget))
-       #+darwin
-       (push-modifier *browser* event)
-       (on-signal-key-press-event window event)))
-    (gobject:g-signal-connect
-     gtk-object "key_release_event"
-     (lambda (widget event) (declare (ignore widget))
-       #+darwin
-       (pop-modifier *browser* event)
-       (on-signal-key-release-event window event)))
-    (gobject:g-signal-connect
-     gtk-object "destroy"
-     (lambda (widget) (declare (ignore widget))
-       (on-signal-destroy window)))))
+       (gtk:gtk-container-add gtk-object box-layout)
+       (setf (slot-value *browser* 'last-active-window) window)
+       (gtk:gtk-widget-show-all gtk-object)
+       (gobject:g-signal-connect
+        gtk-object "key_press_event"
+        (lambda (widget event) (declare (ignore widget))
+          #+darwin
+          (push-modifier *browser* event)
+          (on-signal-key-press-event window event)))
+       (gobject:g-signal-connect
+        gtk-object "key_release_event"
+        (lambda (widget event) (declare (ignore widget))
+          #+darwin
+          (pop-modifier *browser* event)
+          (on-signal-key-release-event window event)))
+       (gobject:g-signal-connect
+        gtk-object "destroy"
+        (lambda (widget) (declare (ignore widget))
+          (on-signal-destroy window)))))))
 
-(defmethod on-signal-destroy ((window gtk-window))
+(define-ffi-method on-signal-destroy ((window gtk-window))
   ;; remove buffer from window to avoid corruption of buffer
   (gtk:gtk-container-remove (box-layout window) (gtk-object (active-buffer window)))
   (window-delete window))
 
-(defmethod ffi-window-delete ((window gtk-window))
+(define-ffi-method ffi-window-delete ((window gtk-window))
   "Delete a window object and remove it from the hash of windows."
   (gtk:gtk-widget-destroy (gtk-object window)))
 
-(defmethod ffi-window-fullscreen ((window gtk-window))
+(define-ffi-method ffi-window-fullscreen ((window gtk-window))
   (gtk:gtk-window-fullscreen (gtk-object window)))
 
-(defmethod ffi-window-unfullscreen ((window gtk-window))
+(define-ffi-method ffi-window-unfullscreen ((window gtk-window))
   (gtk:gtk-window-unfullscreen (gtk-object window)))
 
 (defun derive-key-string (keyval character)
@@ -344,7 +384,7 @@ See `gtk-browser's `modifier-translator' slot."
           (character character))
       (setf (gtk:gtk-entry-text (key-string-buffer window)) ""))))
 
-(defmethod on-signal-key-press-event ((sender gtk-window) event)
+(define-ffi-method on-signal-key-press-event ((sender gtk-window) event)
   (let* ((keycode (gdk:gdk-event-key-hardware-keycode event))
          (keyval (gdk:gdk-event-key-keyval event))
          (keyval-name (gdk:gdk-keyval-name keyval))
@@ -369,7 +409,7 @@ See `gtk-browser's `modifier-translator' slot."
         ;; Do not forward modifier-only to renderer.
         t)))
 
-(defmethod on-signal-key-release-event ((sender gtk-window) event)
+(define-ffi-method on-signal-key-release-event ((sender gtk-window) event)
   "We don't handle key release events.
 Warning: This behaviour may change in the future."
   (declare (ignore event))
@@ -379,7 +419,7 @@ Warning: This behaviour may change in the future."
       ;; Forward release event to the web view.
       nil))
 
-(defmethod on-signal-button-press-event ((sender gtk-buffer) event)
+(define-ffi-method on-signal-button-press-event ((sender gtk-buffer) event)
   (let* ((button (gdk:gdk-event-button-button event))
          ;; REVIEW: No need to store X and Y?
          ;; (x (gdk:gdk-event-button-x event))
@@ -397,7 +437,7 @@ Warning: This behaviour may change in the future."
                            :status :pressed)))
       (funcall (input-dispatcher window) event sender window nil))))
 
-(defmethod on-signal-scroll-event ((sender gtk-buffer) event)
+(define-ffi-method on-signal-scroll-event ((sender gtk-buffer) event)
   (let* ((button (match (gdk:gdk-event-scroll-direction event)
                    (:up 4)
                    (:down 5)
@@ -461,10 +501,10 @@ Warning: This behaviour may change in the future."
                                                         (id buffer))))))
   (ffi-buffer-make buffer))
 
-(defmethod ffi-buffer-uri ((buffer gtk-buffer))
+(define-ffi-method ffi-buffer-uri ((buffer gtk-buffer))
   (quri:uri (webkit:webkit-web-view-uri (gtk-object buffer))))
 
-(defmethod ffi-buffer-title ((buffer gtk-buffer))
+(define-ffi-method ffi-buffer-title ((buffer gtk-buffer))
   (or (webkit:webkit-web-view-title (gtk-object buffer)) ""))
 
 (defmethod on-signal-load-failed-with-tls-errors ((buffer gtk-buffer) certificate url)
@@ -591,38 +631,41 @@ Warning: This behaviour may change in the future."
     (url (print-message (str:concat "→ " (quri:url-decode url)))
          (setf (url-at-point buffer) (quri:uri url)))))
 
-(defmethod ffi-window-make ((browser gtk-browser))
+(define-ffi-method ffi-window-make ((browser gtk-browser))
   "Make a window."
-  (make-instance 'user-window))
+  (let ((channel (make-instance 'chanl:channel)))
+    (chanl:pexec ()
+      (chanl:send channel (make-instance 'user-window)))
+    (chanl:recv channel)))
 
-(defmethod ffi-window-to-foreground ((window gtk-window))
+(define-ffi-method ffi-window-to-foreground ((window gtk-window))
   "Show window in foreground."
   (gtk:gtk-window-present (gtk-object window))
   (setf (slot-value *browser* 'last-active-window) window))
 
-(defmethod ffi-window-set-title ((window gtk-window) title)
+(define-ffi-method ffi-window-set-title ((window gtk-window) title)
   "Set the title for a window."
   (setf (gtk:gtk-window-title (gtk-object window)) title))
 
-(defmethod ffi-window-active ((browser gtk-browser))
+(define-ffi-method ffi-window-active ((browser gtk-browser))
   "Return the window object for the currently active window."
   (setf (slot-value browser 'last-active-window)
         (or (find-if #'gtk:gtk-window-is-active (window-list) :key #'gtk-object)
             (first (window-list))
             (slot-value browser 'last-active-window))))
 
-(defmethod ffi-window-set-active-buffer ((window gtk-window) (buffer gtk-buffer))
+(define-ffi-method ffi-window-set-active-buffer ((window gtk-window) (buffer gtk-buffer))
   "Set BROWSER's WINDOW buffer to BUFFER. "
   (gtk:gtk-container-remove (box-layout window) (gtk-object (active-buffer window)))
   (gtk:gtk-box-pack-start (box-layout window) (gtk-object buffer) :expand t)
   (gtk:gtk-widget-show (gtk-object buffer))
   buffer)
 
-(defmethod ffi-window-set-minibuffer-height ((window gtk-window) height)
+(define-ffi-method ffi-window-set-minibuffer-height ((window gtk-window) height)
   (setf (gtk:gtk-widget-size-request (minibuffer-container window))
         (list -1 height)))
 
-(defmethod ffi-buffer-make ((buffer gtk-buffer))
+(define-ffi-method ffi-buffer-make ((buffer gtk-buffer))
   "Initialize BUFFER's GTK web view."
   (setf (gtk-object buffer) (make-web-view buffer))
   (ffi-buffer-enable-smooth-scrolling buffer t)
@@ -690,10 +733,10 @@ Warning: This behaviour may change in the future."
      nil))
   buffer)
 
-(defmethod ffi-buffer-delete ((buffer gtk-buffer))
+(define-ffi-method ffi-buffer-delete ((buffer gtk-buffer))
   (gtk:gtk-widget-destroy (gtk-object buffer)))
 
-(defmethod ffi-buffer-load ((buffer gtk-buffer) uri)
+(define-ffi-method ffi-buffer-load ((buffer gtk-buffer) uri)
   "Load URI in BUFFER.
 An optimization technique is to make use of the renderer history cache.
 For WebKit, if the URL matches an entry in the webkit-history then we fetch the
@@ -701,7 +744,7 @@ page from the cache.
 
 We don't use the cache if URI matches BUFFER's URL since this means the user
 requested a reload."
-  (declare (type quri:uri uri))
+  ;; (declare (type quri:uri uri))
   (let* ((history (webkit-history buffer))
          (entry (or (find uri history :test #'quri:uri= :key #'webkit-history-entry-uri)
                     (find uri history :test #'quri:uri= :key #'webkit-history-entry-original-uri))))
@@ -711,7 +754,7 @@ requested a reload."
           (load-webkit-history-entry buffer entry))
         (webkit:webkit-web-view-load-uri (gtk-object buffer) (object-string uri)))))
 
-(defmethod ffi-buffer-evaluate-javascript ((buffer gtk-buffer) javascript)
+(define-ffi-method ffi-buffer-evaluate-javascript ((buffer gtk-buffer) javascript)
   (let ((channel (make-instance 'chanl:channel)))
     (ffi-within-renderer-thread
      *browser*
@@ -723,41 +766,41 @@ requested a reload."
                                                     #'javascript-error-handler)))
     (chanl:recv channel)))
 
-(defmethod ffi-minibuffer-evaluate-javascript ((window gtk-window) javascript)
+(define-ffi-method ffi-minibuffer-evaluate-javascript ((window gtk-window) javascript)
   (webkit2:webkit-web-view-evaluate-javascript (minibuffer-view window) javascript))
 
-(defmethod ffi-buffer-enable-javascript ((buffer gtk-buffer) value)
+(define-ffi-method ffi-buffer-enable-javascript ((buffer gtk-buffer) value)
   (setf (webkit:webkit-settings-enable-javascript
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         value))
 
-(defmethod ffi-buffer-enable-javascript-markup ((buffer gtk-buffer) value)
+(define-ffi-method ffi-buffer-enable-javascript-markup ((buffer gtk-buffer) value)
   (setf (webkit:webkit-settings-enable-javascript-markup
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         value))
 
-(defmethod ffi-buffer-enable-smooth-scrolling ((buffer gtk-buffer) value)
+(define-ffi-method ffi-buffer-enable-smooth-scrolling ((buffer gtk-buffer) value)
   (setf (webkit:webkit-settings-enable-smooth-scrolling
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         value))
 
 #+webkit2-media
-(defmethod ffi-buffer-enable-media ((buffer gtk-buffer) value)
+(define-ffi-method ffi-buffer-enable-media ((buffer gtk-buffer) value)
   (setf (webkit:webkit-settings-enable-media
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         value))
 
-(defmethod ffi-buffer-auto-load-image ((buffer gtk-buffer) value)
+(define-ffi-method ffi-buffer-auto-load-image ((buffer gtk-buffer) value)
   (setf (webkit:webkit-settings-auto-load-images
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         value))
 
-(defmethod ffi-buffer-user-agent ((buffer gtk-buffer) value)
+(define-ffi-method ffi-buffer-user-agent ((buffer gtk-buffer) value)
   (setf (webkit:webkit-settings-user-agent
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         value))
 
-(defmethod ffi-buffer-set-proxy ((buffer gtk-buffer)
+(define-ffi-method ffi-buffer-set-proxy ((buffer gtk-buffer)
                                  &optional (proxy-uri (quri:uri ""))
                                    (ignore-hosts (list nil)))
   "Redirect network connections of BUFFER to proxy server PROXY-URI.
@@ -785,13 +828,13 @@ custom (the specified proxy) and none."
     (webkit:webkit-web-context-set-network-proxy-settings
      context mode settings)))
 
-(defmethod ffi-buffer-get-proxy ((buffer gtk-buffer))
+(define-ffi-method ffi-buffer-get-proxy ((buffer gtk-buffer))
   "Return the proxy URI and list of ignored hosts (a list of strings) as second value."
   (the (values (or quri:uri null) list-of-strings)
        (values (proxy-uri buffer)
                (proxy-ignored-hosts buffer))))
 
-(defmethod ffi-generate-input-event ((window gtk-window) event)
+(define-ffi-method ffi-generate-input-event ((window gtk-window) event)
   ;; The "send_event" field is used to mark the event as an "unconsumed"
   ;; keypress.  The distinction allows us to avoid looping indefinitely.
   (etypecase event
@@ -803,22 +846,17 @@ custom (the specified proxy) and none."
      (setf (gdk:gdk-event-scroll-send-event event) t)))
   (gtk:gtk-main-do-event event))
 
-(defmethod ffi-generated-input-event-p ((window gtk-window) event)
+(define-ffi-method ffi-generated-input-event-p ((window gtk-window) event)
   (gdk:gdk-event-send-event event))
 
-(defmethod ffi-within-renderer-thread ((browser gtk-browser) thunk)
-  (declare (ignore browser))
-  (gtk:within-gtk-thread
-    (funcall thunk)))
-
-(defmethod ffi-inspector-show ((buffer gtk-buffer))
+(define-ffi-method ffi-inspector-show ((buffer gtk-buffer))
   (setf (webkit:webkit-settings-enable-developer-extras
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         t)
   (webkit:webkit-web-inspector-show
    (webkit:webkit-web-view-get-inspector (gtk-object buffer))))
 
-(defmethod ffi-print-status ((window gtk-window) text)
+(define-ffi-method ffi-print-status ((window gtk-window) text)
   (let ((text (markup:markup
                (:head (:style (style (status-buffer window))))
                (:body (markup:raw text)))))
@@ -828,7 +866,7 @@ custom (the specified proxy) and none."
        (ps:ps (setf (ps:@ document Body |innerHTML|) ; TODO: Rename all "Body" to "body".
                     (ps:lisp text)))))))
 
-(defmethod ffi-print-message ((window gtk-window) text)
+(define-ffi-method ffi-print-message ((window gtk-window) text)
   (let ((text (markup:markup
                (:head (:style (message-buffer-style window)))
                (:body (markup:raw text)))))
@@ -838,7 +876,7 @@ custom (the specified proxy) and none."
        (ps:ps (setf (ps:@ document Body |innerHTML|)
                     (ps:lisp text)))))))
 
-(defmethod ffi-display-uri (text)
+(define-ffi-method ffi-display-uri (text)
   (webkit:webkit-uri-for-display text))
 
 (declaim (ftype (function (webkit:webkit-cookie-manager cookie-policy)) set-cookie-policy))
@@ -850,7 +888,7 @@ custom (the specified proxy) and none."
      (:never :webkit-cookie-policy-accept-never)
      (:no-third-party :webkit-cookie-policy-accept-no-third-party))))
 
-(defmethod ffi-buffer-cookie-policy ((buffer gtk-buffer) value)
+(define-ffi-method ffi-buffer-cookie-policy ((buffer gtk-buffer) value)
   "VALUE is one of`:always', `:never' or `:no-third-party'."
   (let* ((context (webkit:webkit-web-view-web-context (gtk-object buffer)))
          (cookie-manager (webkit:webkit-web-context-get-cookie-manager context)))
@@ -863,7 +901,7 @@ custom (the specified proxy) and none."
   original-uri
   gtk-object)
 
-(defmethod webkit-history ((buffer gtk-buffer))
+(define-ffi-method webkit-history ((buffer gtk-buffer))
   "Return a list of `webkit-history-entry's for the current buffer.
 Oldest entries come last.
 

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -13,8 +13,8 @@ The returned function sends the compiled Javascript to the current buffer webvie
 The function can be passed ARGS."
   `(progn
      (defun ,script-name ,args
-       (ffi-buffer-evaluate-javascript (current-buffer)
-                                       (ps:ps ,@script-body)))))
+       (ffi-buffer-evaluate-javascript-sync (current-buffer)
+                                            (ps:ps ,@script-body)))))
 
 (export-always 'pflet)
 (defmacro pflet (((function function-arguments &body function-body)) &body body)

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -9,8 +9,8 @@
 SCRIPT-BODY must be a valid parenscript and will be wrapped in (PS:PS ...).
 Any Lisp expression must be wrapped in (PS:LISP ...).
 
-The returned function is called with the ARGS lambda-list over the current
-buffer."
+The returned function sends the compiled Javascript to the current buffer webview.
+The function can be passed ARGS."
   `(progn
      (defun ,script-name ,args
        (ffi-buffer-evaluate-javascript (current-buffer)

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -79,10 +79,9 @@ bookmarks."
 
 (define-command search-selection ()
   "Search selected text using the queried search engine."
-  (with-result* ((selection (%copy))
-                 (engine (read-from-minibuffer
-                          (make-minibuffer
-                           :input-prompt "Search engine"
-                           :suggestion-function #'search-engine-suggestion-filter))))
+  (let* ((selection (%copy))
+         (engine (prompt-minibuffer
+                  :input-prompt "Search engine"
+                  :suggestion-function #'search-engine-suggestion-filter)))
     (when engine
       (buffer-load (generate-search-query selection (search-url engine))))))

--- a/source/spell-check.lisp
+++ b/source/spell-check.lisp
@@ -8,9 +8,8 @@
     (if word-supplied-p
         (enchant:with-dict (lang (spell-check-language *browser*))
           (enchant:dict-check lang word))
-        (with-result (word (read-from-minibuffer
-                            (make-minibuffer
-                             :input-prompt "Spell check word")))
+        (let ((word (prompt-minibuffer
+                     :input-prompt "Spell check word")))
           (if (enchant:with-dict (lang (spell-check-language *browser*))
                 (enchant:dict-check lang word))
               (echo "~a spelled correctly." word)
@@ -19,7 +18,7 @@
 (define-command spell-check-highlighted-word ()
   "Spell check a highlighted word. If a word is incorrectly spelled,
 pull up a prompt of suggestions."
-  (with-result (word (%copy))
+  (let ((word (%copy)))
     (spell-check-prompt word)))
 
 (defun spell-check-prompt (word)
@@ -32,7 +31,7 @@ suggestions."
 
 (define-command spell-check-word-at-cursor ()
   "Spell check the word at cursor."
-  (with-result* ((contents (active-input-area-content))
+  (let* ((contents (active-input-area-content))
                  (cursor-position (active-input-area-cursor)))
     (let ((text-buffer (make-instance 'text-buffer:text-buffer))
           (cursor (make-instance 'text-buffer:cursor)))
@@ -44,11 +43,10 @@ suggestions."
 
 (define-command spell-check-suggest-word (&key word)
   "Suggest a spelling for a given word."
-  (with-result (selected-word (read-from-minibuffer
-                               (make-minibuffer
-                                :input-buffer word
-                                :input-prompt "Suggest spelling (3+ characters)"
-                                :suggestion-function 'enchant-suggestion)))
+  (let ((selected-word (prompt-minibuffer
+                        :input-buffer word
+                        :input-prompt "Suggest spelling (3+ characters)"
+                        :suggestion-function 'enchant-suggestion)))
     (trivial-clipboard:text selected-word)
     (echo "Word copied to clipboard.")))
 

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -206,10 +206,9 @@ Return the short error message and the full error message as second value."
 
 (define-command load-file ()
   "Load the prompted Lisp file."
-  (with-result (file-name-input (read-from-minibuffer
-                                 (make-minibuffer
-                                  :input-prompt "Load file"
-                                  :hide-suggestion-count-p t)))
+  (let ((file-name-input (prompt-minibuffer
+                          :input-prompt "Load file"
+                          :hide-suggestion-count-p t)))
     (load-lisp file-name-input)))
 
 (define-command load-init-file (&key (init-file (expand-path *init-file-path*)))

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -51,7 +51,7 @@ supply the URL you would like to navigate to. The minibuffer can provide
 suggestions.  The list of suggestions will automatically narrow down to those
 matching your input as you type.")
    (:ul
-    (:li (command-markup 'nyxt/minibuffer-mode:return-input
+    (:li (command-markup 'nyxt/minibuffer-mode:return-selection
                          :modes (list (make-instance 'nyxt/minibuffer-mode:minibuffer-mode)))
          ": Validate the selected suggestion(s) or the current input if there is
 no suggestion.")

--- a/source/vcs-mode.lisp
+++ b/source/vcs-mode.lisp
@@ -182,10 +182,9 @@ The default username can be set in `*vcs-username*' or `*vcs-username-alist*'."
       ((= 1 (length nyxt/vcs::*vcs-projects-roots*))
        (setf target-dir (first nyxt/vcs::*vcs-projects-roots*))
        (nyxt/vcs::clone project-name root-name target-dir clone-uri))
-      (t (with-result (target-dir (read-from-minibuffer
-                                   (make-minibuffer
-                                    :input-prompt "Target directory"
-                                    :suggestion-function #'nyxt/vcs::projects-roots-suggestion-filter)))
+      (t (let ((target-dir (prompt-minibuffer
+                            :input-prompt "Target directory"
+                            :suggestion-function #'nyxt/vcs::projects-roots-suggestion-filter)))
            (nyxt/vcs::clone project-name root-name target-dir clone-uri))))))
 
 (define-command git-clone ()

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -87,7 +87,7 @@ vi-normal-mode.")
   (ffi-generate-input-event
    (current-window)
    (nyxt::last-event buffer))
-  (with-result (response (nyxt/web-mode:%clicked-in-input?))
+  (let ((response (nyxt/web-mode:%clicked-in-input?)))
     (cond
       ((and (nyxt/web-mode:input-tag-p response)
             (find-submode buffer 'vi-normal-mode))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -430,10 +430,8 @@ Otherwise go forward to the only child."
   ;; can only be done after the URL has been loaded which is a bit of a
   ;; kludge.  Instead we could add an FFI endpoint,
   ;; e.g. webkit_web_view_set_zoom_level.
-
-  ;; TODO: Temporarily commented out to work with synchronous minibuffers.
-  ;; (unzoom-page :buffer (buffer mode)
-  ;;              :ratio (current-zoom-ratio (buffer mode)))
+  (unzoom-page :buffer (buffer mode)
+               :ratio (current-zoom-ratio (buffer mode)))
   url)
 
 (defmethod nyxt:object-string ((node htree:node))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -358,15 +358,14 @@ Otherwise go forward to the only child."
   "Paste from clipboard into active-element."
   ;; On some systems like Xorg, clipboard pasting happens just-in-time.  So if we
   ;; copy something from the context menu 'Copy' action, upon pasting we will
-  ;; retrieved the text from the GTK thread.  This is prone to create
+  ;; retrieve the text from the GTK thread.  This is prone to create
   ;; dead-locks (e.g. when executing a Parenscript that acts upon the clipboard).
   ;;
   ;; To avoid this, we can 'flush' the clipboard to ensure that the copied text
   ;; is present the clipboard and need not be retrieved from the GTK thread.
-  (bt:make-thread
-   (lambda ()
-     (trivial-clipboard:text (trivial-clipboard:text))
-     (ffi-within-renderer-thread *browser* #'%paste))))
+  ;; TODO: Do we still need to flush now that we have multiple threads?
+  ;; (trivial-clipboard:text (trivial-clipboard:text))
+  (%paste))
 
 (defun ring-suggestion-filter (ring)
   (let ((ring-items (containers:container->list ring)))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -179,7 +179,7 @@ search.")
 
 (defun call-non-input-command-or-forward (command &key (buffer (current-buffer))
                                                     (window (current-window)))
-  (with-result (response (%clicked-in-input?))
+  (let ((response (%clicked-in-input?)))
     (if (input-tag-p response)
         (ffi-generate-input-event
          window
@@ -188,7 +188,7 @@ search.")
 
 (define-command paste-or-set-url (&optional (buffer (current-buffer)))
   "Paste text if active element is an input tag, forward event otherwise."
-  (with-result (response (%clicked-in-input?))
+  (let ((response (%clicked-in-input?)))
     (let ((url-empty (url-empty-p (url-at-point buffer))))
       (if (and (input-tag-p response) url-empty)
           (funcall-safely #'paste)
@@ -245,10 +245,9 @@ search.")
 
 (define-command history-backwards-query ()
   "Query parent URL to navigate back to."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Navigate backwards to"
-                        :suggestion-function (history-backwards-suggestion-filter))))
+  (let ((input (prompt-minibuffer
+                :input-prompt "Navigate backwards to"
+                :suggestion-function (history-backwards-suggestion-filter))))
     (when input
       (set-url-from-history input))))
 
@@ -264,10 +263,9 @@ search.")
 
 (define-command history-forwards-query ()
   "Query forward-URL to navigate to."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Navigate forwards to"
-                        :suggestion-function (history-forwards-suggestion-filter))))
+  (let ((input (prompt-minibuffer
+                :input-prompt "Navigate forwards to"
+                :suggestion-function (history-forwards-suggestion-filter))))
     (when input
       (set-url-from-history input))))
 
@@ -292,10 +290,9 @@ Otherwise go forward to the only child."
 
 (define-command history-forwards-all-query ()
   "Query URL to forward to, from all child branches."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Navigate forwards to (all branches)"
-                        :suggestion-function (history-forwards-all-suggestion-filter))))
+  (let ((input (prompt-minibuffer
+                :input-prompt "Navigate forwards to (all branches)"
+                :suggestion-function (history-forwards-all-suggestion-filter))))
     (when input
       (set-url-from-history input))))
 
@@ -311,10 +308,9 @@ Otherwise go forward to the only child."
 
 (define-command history-all-query ()
   "Query URL to go to, from the whole history."
-  (with-result (input (read-from-minibuffer
-                       (make-minibuffer
-                        :input-prompt "Navigate to"
-                        :suggestion-function (history-all-suggestion-filter))))
+  (let ((input (prompt-minibuffer
+                :input-prompt "Navigate to"
+                :suggestion-function (history-all-suggestion-filter))))
     (when input
       (set-url-from-history input))))
 
@@ -380,27 +376,25 @@ Otherwise go forward to the only child."
 
 (define-command paste-from-ring ()
   "Show `*browser*' clipboard ring and paste selected entry."
-  (with-result (ring-item (read-from-minibuffer
-                           (make-minibuffer
-                            :suggestion-function (ring-suggestion-filter
-                                                  (nyxt::clipboard-ring *browser*)))))
+  (let ((ring-item (prompt-minibuffer
+                    :suggestion-function (ring-suggestion-filter
+                                          (nyxt::clipboard-ring *browser*)))))
     (%paste :input-text ring-item)))
 
 (define-command copy ()
   "Copy selected text to clipboard."
-  (with-result (input (%copy))
+  (let ((input (%copy)))
     (copy-to-clipboard input)
     (echo "Text copied.")))
 
 (define-command autofill ()
   "Fill in a field with a value from a saved list."
-  (with-result (selected-fill (read-from-minibuffer
-                               (make-minibuffer
-                                :input-prompt "Autofill"
-                                :suggestion-function
-                                (lambda (minibuffer)
-                                  (fuzzy-match (input-buffer minibuffer)
-                                               (autofills *browser*))))))
+  (let ((selected-fill (prompt-minibuffer
+                        :input-prompt "Autofill"
+                        :suggestion-function
+                        (lambda (minibuffer)
+                          (fuzzy-match (input-buffer minibuffer)
+                                       (autofills *browser*))))))
     (cond ((stringp (autofill-fill selected-fill))
            (%paste :input-text (autofill-fill selected-fill)))
           ((functionp (autofill-fill selected-fill))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -431,8 +431,10 @@ Otherwise go forward to the only child."
   ;; can only be done after the URL has been loaded which is a bit of a
   ;; kludge.  Instead we could add an FFI endpoint,
   ;; e.g. webkit_web_view_set_zoom_level.
-  (unzoom-page :buffer (buffer mode)
-               :ratio (current-zoom-ratio (buffer mode)))
+
+  ;; TODO: Temporarily commented out to work with synchronous minibuffers.
+  ;; (unzoom-page :buffer (buffer mode)
+  ;;              :ratio (current-zoom-ratio (buffer mode)))
   url)
 
 (defmethod nyxt:object-string ((node htree:node))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -316,14 +316,13 @@ Otherwise go forward to the only child."
 
 (define-command meta-search-history-buffers ()
   "Set the URL from the history or from the set of buffers."
-  (nyxt::meta-search
-   (list
-    (make-minibuffer
-     :suggestion-function (history-all-suggestion-filter)
-     :callback (lambda (i) (set-url-from-history i)))
-    (make-minibuffer
-     :suggestion-function (buffer-suggestion-filter :current-is-last-p t)
-     :callback (lambda (i) (set-current-buffer i))))))
+  (set-url-from-history
+   (nyxt::meta-search
+    (list
+     (make-minibuffer
+      :suggestion-function (history-all-suggestion-filter))
+     (make-minibuffer
+      :suggestion-function (buffer-suggestion-filter :current-is-last-p t))))))
 
 (define-command buffer-history-tree (&optional (buffer (current-buffer)))
   "Open a new buffer displaying the whole history tree."

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -122,11 +122,10 @@ The handlers take the window as argument."))
 
 (define-command delete-window ()
   "Delete the queried window(s)."
-  (with-result (windows (read-from-minibuffer
-                         (make-minibuffer
-                          :input-prompt "Delete window(s)"
-                          :multi-selection-p t
-                          :suggestion-function (window-suggestion-filter))))
+  (let ((windows (prompt-minibuffer
+                  :input-prompt "Delete window(s)"
+                  :multi-selection-p t
+                  :suggestion-function (window-suggestion-filter))))
     (mapcar #'delete-current-window windows)))
 
 (define-command delete-current-window (&optional (window (current-window)))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -12,6 +12,10 @@
                        :documentation "The stack of currently active minibuffers.")
    (key-stack '()
               :documentation "A stack that keeps track of the key chords a user has pressed.")
+   (last-key nil
+             :export nil
+             :type (or nil keymap:key)
+             :documentation "Last last pressed key.  Useful for `self-insert'.")
    ;; TODO: each frame should have a status buffer, not each window
    (status-buffer :export nil)
    (message-buffer-height 16


### PR DESCRIPTION
I've tried to apply #928 to all of Nyxt.  The result is that it does not start :( 

The problem with starting command in a new thread is that if a command calls a renderer instruction (like making a buffer) it needs to switch to the renderer thread.  

One way to fix it is to wrap all FFI functions with `ffi-within-renderer-thread`.  But what about the FFI functions for which the command needs a return value?

We can juggle with threads but it seems hard to guarantee the absence of dead locks.