### PR TITLE
Disable WebGL in reduce-tracking mode.

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -632,6 +632,7 @@ sometimes yields the wrong reasult."
 (define-ffi-generic ffi-buffer-enable-javascript-markup (buffer value))
 (define-ffi-generic ffi-buffer-enable-smooth-scrolling (buffer value))
 (define-ffi-generic ffi-buffer-enable-media (buffer value))
+(define-ffi-generic ffi-buffer-webgl-enabled-p (buffer))
 (define-ffi-generic ffi-buffer-enable-webgl (buffer value))
 (define-ffi-generic ffi-buffer-auto-load-image (buffer value))
 (define-ffi-generic ffi-buffer-enable-sound (buffer value))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -632,6 +632,7 @@ sometimes yields the wrong reasult."
 (define-ffi-generic ffi-buffer-enable-javascript-markup (buffer value))
 (define-ffi-generic ffi-buffer-enable-smooth-scrolling (buffer value))
 (define-ffi-generic ffi-buffer-enable-media (buffer value))
+(define-ffi-generic ffi-buffer-enable-webgl (buffer value))
 (define-ffi-generic ffi-buffer-auto-load-image (buffer value))
 (define-ffi-generic ffi-buffer-enable-sound (buffer value))
 (define-ffi-generic ffi-buffer-user-agent (buffer value))

--- a/source/reduce-tracking-mode.lisp
+++ b/source/reduce-tracking-mode.lisp
@@ -15,6 +15,8 @@
 part of the Accept-Language HTTP header.")
    (destructor
     (lambda (mode)
+      ;; What if user wants to have WebGL disabled by default?
+      (ffi-buffer-enable-webgl (buffer mode) t)
       (ffi-set-preferred-languages (buffer mode)
                                    (list (first
                                           (str:split
@@ -22,5 +24,6 @@ part of the Accept-Language HTTP header.")
                                            (or (uiop:getenv "LANG") "")))))))
    (constructor
     (lambda (mode)
+      (ffi-buffer-enable-webgl (buffer mode) nil)
       (ffi-set-preferred-languages (buffer mode)
                                    (preferred-languages mode))))))

--- a/source/reduce-tracking-mode.lisp
+++ b/source/reduce-tracking-mode.lisp
@@ -13,10 +13,12 @@
                         :type list-of-strings
                         :documentation "The list of languages that will be sent as
 part of the Accept-Language HTTP header.")
+   (previous-webgl-setting nil
+                           :documentation "The state of WebGL
+before reduce-tracking-mode was enabled.")
    (destructor
     (lambda (mode)
-      ;; What if user wants to have WebGL disabled by default?
-      (ffi-buffer-enable-webgl (buffer mode) t)
+      (ffi-buffer-enable-webgl (buffer mode) (previous-webgl-setting mode))
       (ffi-set-preferred-languages (buffer mode)
                                    (list (first
                                           (str:split
@@ -24,6 +26,7 @@ part of the Accept-Language HTTP header.")
                                            (or (uiop:getenv "LANG") "")))))))
    (constructor
     (lambda (mode)
+      (setf (previous-webgl-setting mode) (ffi-buffer-webgl-enabled-p (buffer mode)))
       (ffi-buffer-enable-webgl (buffer mode) nil)
       (ffi-set-preferred-languages (buffer mode)
                                    (preferred-languages mode))))))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -840,6 +840,11 @@ requested a reload."
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         value))
 
+(define-ffi-method ffi-buffer-enable-webgl ((buffer gtk-buffer) value)
+  (setf (webkit:webkit-settings-enable-webgl
+         (webkit:webkit-web-view-get-settings (gtk-object buffer)))
+        value))
+
 (define-ffi-method ffi-buffer-set-proxy ((buffer gtk-buffer)
                                  &optional (proxy-uri (quri:uri ""))
                                    (ignore-hosts (list nil)))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -840,6 +840,10 @@ requested a reload."
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))
         value))
 
+(define-ffi-method ffi-buffer-webgl-enabled-p ((buffer gtk-buffer))
+  (webkit:webkit-settings-enable-webgl
+         (webkit:webkit-web-view-get-settings (gtk-object buffer))))
+
 (define-ffi-method ffi-buffer-enable-webgl ((buffer gtk-buffer) value)
   (setf (webkit:webkit-settings-enable-webgl
          (webkit:webkit-web-view-get-settings (gtk-object buffer)))


### PR DESCRIPTION
WebGL allows for easy user identification, because the hash of WebGL canvas is almost unique, given that it depends on lost of variables in user's setup. Disabling WebGL is the only solid way to escape fingerprinting via WebGL. Breaks some websites that use WebGL, of course.

I cannot test whether it breaks Nyxt (because I cannot run Nyxt from master since approximately a week ago), so I need help in testing that. Shouldn't be hard -- run Nyxt with this patchset, go to https://panopticlick.eff.org/ , test the browser and see whether there's a WebGL hash captured. If hash is not captured and Nyxt doesn't crash, then we've made `reduce-tracking-mode` better at fingerprinting-avoidance :)

Let me know what you think of it!