### PR TITLE
User status formatter

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -328,7 +328,6 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                 :line-height "16px"
                 :margin 0)
                ("#modes"
-                :border-right "2px solid rgb(120, 120, 120)"
                 :display "inline-block"
                 :padding "0 5px 0 5px"
                 :margin "0 5px 0 0")

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -3,23 +3,47 @@
 
 (in-package :nyxt)
 
+(declaim (type (cons string) *invisible-modes*))
+(defvar *invisible-modes* '("base-mode") ; TODO: Export?
+  "List of mode names to hide from the status view")
+
+(defun format-status-modes (&optional (buffer (current-buffer)))
+  (markup:markup
+   (:div
+    :id "modes"
+    (format nil "~{~a~^ ~}"
+            (mapcar (lambda (m) (str:replace-all "-mode" "" m))
+                    (set-difference
+                     (mapcar (alex:compose #'str:downcase #'mode-name) (modes buffer))
+                     *invisible-modes*
+                     :test #'string=))))))
+
+(defun format-status-buttons ()
+  (markup:markup
+   (:a :class "button" :title "Backwards" :href (lisp-url '(nyxt/web-mode:history-backwards)) "←")
+   (:a :class "button" :title "Forwards" :href (lisp-url '(nyxt/web-mode:history-forwards)) "→")
+   (:a :class "button" :title "Reload" :href (lisp-url '(nyxt:reload-current-buffer)) "↺")
+   (:a :class "button" :title "Execute" :href (lisp-url '(nyxt:execute-command)) "⚙")
+   (:a :class "button" :title "Buffers" :href (lisp-url '(nyxt::list-buffers)) "≡")))
+
+(defun format-status-load-status (&optional (buffer (current-buffer)))
+  (markup:markup
+   (:span (if (and (web-buffer-p buffer)
+                   (eq (slot-value buffer 'load-status) :loading))
+              "Loading: " ""))))
+
+(defun format-status-url (&optional (buffer (current-buffer)))
+  (markup:markup
+   (:a :class "button"
+       :href (lisp-url '(nyxt:set-url-from-current-url))
+       (format nil " ~a — ~a"
+               (object-display (url buffer))
+               (title buffer)))))
+
 (defun format-status (window)
   (let ((buffer (current-buffer window)))
-    (markup:markup
-     (:div :id "modes"
-           (format nil "~{~a~^ ~}"
-                   (mapcar (lambda (m) (str:replace-all "-mode" "" (str:downcase (mode-name m))))
-                           (modes buffer))))
-     (:a :class "button" :title "Backwards" :href (lisp-url '(nyxt/web-mode:history-backwards)) "←")
-     (:a :class "button" :title "Forwards" :href (lisp-url '(nyxt/web-mode:history-forwards)) "→")
-     (:a :class "button" :title "Reload" :href (lisp-url '(nyxt:reload-current-buffer)) "↺")
-     (:a :class "button" :title "Execute" :href (lisp-url '(nyxt:execute-command)) "⚙")
-     (:a :class "button" :title "Buffers" :href (lisp-url '(nyxt::list-buffers)) "≡")
-     (:span (if (and (web-buffer-p buffer)
-                     (eq (slot-value buffer 'load-status) :loading))
-                "Loading: " ""))
-     (:a :class "button"
-         :href (lisp-url '(nyxt:set-url-from-current-url))
-      (format nil " ~a — ~a"
-              (object-display (url buffer))
-              (title buffer))))))
+    (str:concat
+     (format-status-modes buffer)
+     (format-status-buttons)
+     (format-status-load-status buffer)
+     (format-status-url buffer))))

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -158,6 +158,7 @@ Otherwise, build a search query with the default search engine."
                  (nil (quri:uri input-url))
                  (default (quri:uri (generate-search-query input-url (search-url default)))))))))))
 
+(export-always 'lisp-url)
 (declaim (ftype (function (t &rest t) string) lisp-url))
 (defun lisp-url (lisp-form &rest more-lisp-forms)
   "Generate a lisp:// URL from the given Lisp forms. This is useful for encoding


### PR DESCRIPTION
My own status bar is now this:

```lisp
(setf nyxt::*invisible-modes* '("base-mode" "my-mode" "certificate-exception-mode" "web-mode"))
(defun my-format-status (window)
  (let ((buffer (current-buffer window)))
    (if (or (internal-buffer-p buffer)
            (find-submode buffer 'proxy-mode))
        (setf (style (status-buffer window))
              (getf (mopu:slot-properties 'status-buffer 'style) :initform))
        (setf (style (status-buffer window))
              my-status-style))
    (str:concat
     (nyxt::format-status-modes buffer)
     (nyxt::format-status-buttons)
     (nyxt::format-status-load-status buffer)
     (nyxt::format-status-url buffer))))
```

Which is some 30 lines shorter than before! :)