### PR TITLE
Html helpers

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -593,6 +593,22 @@ sometimes yields the wrong reasult."
    (ps:ps (setf (ps:@ document body |innerHTML|)
                 (ps:lisp content)))))
 
+(defmacro with-current-html-buffer ((buffer-var title mode) &body body)
+  "Create and switch to a buffer in MODE displaying CONTENT.
+BUFFER-VAR is bound to the new bufer in BODY.
+MODE is a mode symbol.
+BODY must return the HTML markup as a string. "
+  `(let* ((,buffer-var (or (find-buffer ,mode)
+                           (funcall (symbol-function ,mode)
+                            :activate t
+                            :buffer (make-internal-buffer :title ,title)))))
+     (html-set
+      (progn
+        ,@body)
+      ,buffer-var)
+     (set-current-buffer ,buffer-var)
+     ,buffer-var))
+
 (defmacro define-ffi-generic (name arguments)
   `(progn
      (export-always ',name)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -581,6 +581,18 @@ sometimes yields the wrong reasult."
                    :if-does-not-exist :create
                    :if-exists :append))))))
 
+(defun html-write (content &optional (buffer (current-buffer)))
+  (ffi-buffer-evaluate-javascript-async
+   buffer
+   (ps:ps (ps:chain document
+                    (write (ps:lisp content))))))
+
+(defun html-set (content &optional (buffer (current-buffer)))
+  (ffi-buffer-evaluate-javascript-async
+   buffer
+   (ps:ps (setf (ps:@ document body |innerHTML|)
+                (ps:lisp content)))))
+
 (defmacro define-ffi-generic (name arguments)
   `(progn
      (export-always ',name)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -594,14 +594,18 @@ sometimes yields the wrong reasult."
                 (ps:lisp content)))))
 
 (defmacro with-current-html-buffer ((buffer-var title mode) &body body)
-  "Create and switch to a buffer in MODE displaying CONTENT.
+  "Switch to a buffer in MODE displaying CONTENT.
+If a buffer in MODE with TITLE exists, reuse it, otherwise create a new buffer.
 BUFFER-VAR is bound to the new bufer in BODY.
 MODE is a mode symbol.
-BODY must return the HTML markup as a string. "
-  `(let* ((,buffer-var (or (find-buffer ,mode)
+BODY must return the HTML markup as a string."
+  `(let* ((,buffer-var (or (find-if (lambda (b)
+                                      (and (string= (title b) title)
+                                           (find-mode b mode-symbol)))
+                                    (buffer-list))
                            (funcall (symbol-function ,mode)
-                            :activate t
-                            :buffer (make-internal-buffer :title ,title)))))
+                                    :activate t
+                                    :buffer (make-internal-buffer :title ,title)))))
      (html-set
       (progn
         ,@body)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -414,28 +414,19 @@ The version number is stored in the clipboard."
 
 (define-command list-messages ()
   "Show the *Messages* buffer."
-  (let ((buffer (or (find-buffer 'message-mode)
-                    (nyxt/message-mode:message-mode
-                     :activate t
-                     :buffer (make-internal-buffer :title "*Messages*")))))
-    (let* ((content
-             (markup:markup
-              (:style (style buffer))
-              (:h1 "Messages")
-              (:a :class "button"
-                  :href (lisp-url '(nyxt::list-messages)) "Update")
-              (:a :class "button"
-                  :href (lisp-url '(nyxt/message-mode:clear-messages)
-                                  '(nyxt::list-messages))
-                  "Clear")
-              (:ul
-               (loop for message in (reverse (messages-content *browser*))
-                     collect (markup:markup (:li message))))))
-           (insert-content (ps:ps (setf (ps:@ document body |innerHTML|)
-                                        (ps:lisp content)))))
-      (ffi-buffer-evaluate-javascript-async buffer insert-content))
-    (set-current-buffer buffer)
-    buffer))
+  (with-current-html-buffer (buffer "*Messages*" 'message-mode)
+    (markup:markup
+     (:style (style buffer))
+     (:h1 "Messages")
+     (:a :class "button"
+         :href (lisp-url '(nyxt::list-messages)) "Update")
+     (:a :class "button"
+         :href (lisp-url '(nyxt/message-mode:clear-messages)
+                         '(nyxt::list-messages))
+         "Clear")
+     (:ul
+      (loop for message in (reverse (messages-content *browser*))
+            collect (markup:markup (:li message)))))))
 
 (declaim (ftype (function (function-symbol &key (:modes list))) binding-keys))
 (defun binding-keys (fn &key (modes (if (current-buffer)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -296,31 +296,29 @@ CLASS can be a class symbol or a list of class symbols, as with
 (defun tls-help (buffer url)
   "This function is invoked upon TLS certificate errors to give users
 help on how to proceed."
-  (let* ((help-contents
-           (markup:markup
-            (:h1 (format nil "TLS Certificate Error: ~a" (object-display url)))
-            (:p "The address you are trying to visit has an invalid
+  ;; Set (url buffer) so that the user can simply reload the page after
+  ;; allowing the exception:
+  (setf (url buffer) url)
+  (html-set
+   (markup:markup
+    (:h1 (format nil "TLS Certificate Error: ~a" (object-display url)))
+    (:p "The address you are trying to visit has an invalid
 certificate. By default Nyxt refuses to establish a secure connection
 to a host with an erroneous certificate (e.g. self-signed ones). This
 could mean that the address you are attempting the access is
 compromised.")
-            (:p "If you trust the address nonetheless, you can add an exception
+    (:p "If you trust the address nonetheless, you can add an exception
 for the current hostname with the "
-                (:code "add-domain-to-certificate-exceptions")
-                " command.  The "
-                (:code "certificate-exception-mode")
-                " must be active for the current buffer (which is the
+        (:code "add-domain-to-certificate-exceptions")
+        " command.  The "
+        (:code "certificate-exception-mode")
+        " must be active for the current buffer (which is the
 default).")
-            (:p "To persist hostname exceptions in your initialization
+    (:p "To persist hostname exceptions in your initialization
 file, see the "
-                (:code "add-domain-to-certificate-exceptions")
-                " documentation.")))
-         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                   (ps:lisp help-contents)))))
-    ;; Set (url buffer) so that the user can simply reload the page after
-    ;; allowing the exception:
-    (setf (url buffer) url)
-    (ffi-buffer-evaluate-javascript-async buffer insert-help)))
+        (:code "add-domain-to-certificate-exceptions")
+        " documentation."))
+   buffer))
 
 (defun describe-key-dispatch-input (event buffer window printable-p)
   "Display documentation of the value bound to the keys pressed by the user.

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -224,22 +224,13 @@ CLASS can be a class symbol or a list of class symbols, as with
   "Inspect a slot and show it in a help buffer."
   (let* ((input (prompt-minibuffer
                  :input-prompt "Describe slot"
-                 :suggestion-function (slot-suggestion-filter)))
-         (help-buffer (nyxt/help-mode:help-mode
-                       :activate t
-                       :buffer (make-internal-buffer
-                                :title (str:concat "*Help-"
-                                                   (symbol-name (name input))
-                                                   "*"))))
-
-         (help-contents
-           (str:concat (markup:markup (:style (style help-buffer)))
-                       (describe-slot* (name input) (class-sym input)
-                                       :mention-class-p t)))
-         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                   (ps:lisp help-contents)))))
-    (ffi-buffer-evaluate-javascript-async help-buffer insert-help)
-    (set-current-buffer help-buffer)))
+                 :suggestion-function (slot-suggestion-filter))))
+    (with-current-html-buffer (buffer
+                               (str:concat "*Help-" (symbol-name (name input)) "*")
+                               'nyxt/help-mode:help-mode)
+      (str:concat (markup:markup (:style (style buffer)))
+                  (describe-slot* (name input) (class-sym input)
+                                  :mention-class-p t)))))
 
 (define-command common-settings ()
   "Configure a set of frequently used settings."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -192,27 +192,19 @@ A command is a special kind of function that can be called with
   (let* ((input (class-suggestion-name
                  (prompt-minibuffer
                   :input-prompt "Describe class"
-                  :suggestion-function (class-suggestion-filter))))
-         (input (class-suggestion-name input))
-         (help-buffer (nyxt/help-mode:help-mode
-                       :activate t
-                       :buffer (make-internal-buffer
-                                :title (str:concat "*Help-"
-                                                   (symbol-name input)
-                                                   "*"))))
-         (slots (class-public-slots input))
-         (slot-descs (apply #'str:concat (mapcar (alex:rcurry #'describe-slot* input) slots)))
-         (help-contents (str:concat
-                         (markup:markup
-                          (:style (style help-buffer))
-                          (:h1 (symbol-name input))
-                          (:p (:pre (documentation input 'type)))
-                          (:h2 "Slots:"))
-                         slot-descs))
-         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                   (ps:lisp help-contents)))))
-    (ffi-buffer-evaluate-javascript-async help-buffer insert-help)
-    (set-current-buffer help-buffer)))
+                  :suggestion-function (class-suggestion-filter)))))
+    (with-current-html-buffer (buffer
+                               (str:concat "*Help-" (symbol-name input) "*")
+                               'nyxt/help-mode::help-mode)
+      (let* ((slots (class-public-slots input))
+             (slot-descs (apply #'str:concat (mapcar (alex:rcurry #'describe-slot* input) slots))))
+        (str:concat
+         (markup:markup
+          (:style (style buffer))
+          (:h1 (symbol-name input))
+          (:p (:pre (documentation input 'type)))
+          (:h2 "Slots:"))
+         slot-descs)))))
 
 (defun configure-slot (slot class &key (value nil new-value-supplied-p) (type nil))
   "Set the value of a slot in a users auto-config.lisp.

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -234,53 +234,46 @@ CLASS can be a class symbol or a list of class symbols, as with
 
 (define-command common-settings ()
   "Configure a set of frequently used settings."
-  (let* ((help-buffer (nyxt/help-mode:help-mode
-                       :activate t
-                       :buffer (make-internal-buffer :title "*Settings*")))
-         (help-contents
-           (markup:markup
-            (:style (style help-buffer))
-            (:h1 "Common Settings")
-            (:p "Set the values for frequently configured
+  (with-current-html-buffer (buffer "*Settings*" 'nyxt/help-mode:help-mode)
+    (markup:markup
+     (:style (style buffer))
+     (:h1 "Common Settings")
+     (:p "Set the values for frequently configured
             settings. Changes made will apply to newly created
             buffers.")
-            (:h2 "Keybinding style")
-            (:p (:a :class "button"
-                    :href (lisp-url `(nyxt::configure-slot
-                                      'default-modes
-                                      '(buffer web-buffer)
-                                      :value '%slot-default)
-                                    `(nyxt/emacs-mode:emacs-mode :activate nil)
-                                    `(nyxt/vi-mode:vi-normal-mode :activate nil))
-                    "Use default (CUA)"))
-            (:p (:a :class "button"
-                    :href (lisp-url `(nyxt::configure-slot
-                                      'default-modes
-                                      '(buffer web-buffer)
-                                      :value '(append '(emacs-mode) %slot-default))
-                                    `(nyxt/emacs-mode:emacs-mode :activate t)
-                                    `(nyxt/vi-mode:vi-normal-mode :activate nil))
-                    "Use Emacs"))
-            (:p (:a :class "button"
-                    :href (lisp-url `(nyxt::configure-slot
-                                      'default-modes
-                                      '(buffer web-buffer)
-                                      :value '(append '(vi-normal-mode) %slot-default))
-                                    `(nyxt/vi-mode:vi-normal-mode :activate t)
-                                    `(nyxt/emacs-mode:emacs-mode :activate nil))
-                    "Use vi"))
-            (:h2 "Default new buffer URL")
-            (:a :class "button"
-                :href (lisp-url `(nyxt::configure-slot 'default-new-buffer-url 'web-buffer :type 'STRING))
-                "Set default new buffer URL")
-            (:h2 "Default zoom ratio")
-            (:a :class "button"
-                :href (lisp-url `(nyxt::configure-slot 'current-zoom-ratio 'buffer))
-                "Set default zoom ratio")))
-         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                   (ps:lisp help-contents)))))
-    (ffi-buffer-evaluate-javascript-async help-buffer insert-help)
-    (set-current-buffer help-buffer)))
+     (:h2 "Keybinding style")
+     (:p (:a :class "button"
+             :href (lisp-url `(nyxt::configure-slot
+                               'default-modes
+                               '(buffer web-buffer)
+                               :value '%slot-default)
+                             `(nyxt/emacs-mode:emacs-mode :activate nil)
+                             `(nyxt/vi-mode:vi-normal-mode :activate nil))
+             "Use default (CUA)"))
+     (:p (:a :class "button"
+             :href (lisp-url `(nyxt::configure-slot
+                               'default-modes
+                               '(buffer web-buffer)
+                               :value '(append '(emacs-mode) %slot-default))
+                             `(nyxt/emacs-mode:emacs-mode :activate t)
+                             `(nyxt/vi-mode:vi-normal-mode :activate nil))
+             "Use Emacs"))
+     (:p (:a :class "button"
+             :href (lisp-url `(nyxt::configure-slot
+                               'default-modes
+                               '(buffer web-buffer)
+                               :value '(append '(vi-normal-mode) %slot-default))
+                             `(nyxt/vi-mode:vi-normal-mode :activate t)
+                             `(nyxt/emacs-mode:emacs-mode :activate nil))
+             "Use vi"))
+     (:h2 "Default new buffer URL")
+     (:a :class "button"
+         :href (lisp-url `(nyxt::configure-slot 'default-new-buffer-url 'web-buffer :type 'STRING))
+         "Set default new buffer URL")
+     (:h2 "Default zoom ratio")
+     (:a :class "button"
+         :href (lisp-url `(nyxt::configure-slot 'current-zoom-ratio 'buffer))
+         "Set default zoom ratio"))))
 
 (define-command describe-bindings ()
   "Show a buffer with the list of all known bindings for the current buffer."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -478,16 +478,9 @@ The version number is stored in the clipboard."
 
 (define-command manual ()
   "Show the manual."
-  (let ((help-buffer (nyxt/help-mode:help-mode
-                      :activate t
-                      :buffer (make-internal-buffer :title "*Manual*"))))
-    (set-current-buffer help-buffer)
-    (let* ((help-contents (str:concat (markup:markup (:style (style help-buffer)))
-                                      (manual-content)))
-           (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                     (ps:lisp help-contents)))))
-      (ffi-buffer-evaluate-javascript-async help-buffer insert-help))
-    help-buffer))
+  (with-current-html-buffer (buffer "*Manual*" 'nyxt/help-mode:help-mode)
+    (str:concat (markup:markup (:style (style buffer)))
+                (manual-content))))
 
 (define-command tutorial ()
   "Show the tutorial."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -53,23 +53,16 @@
                  (prompt-minibuffer
                   :suggestion-function (variable-suggestion-filter)
                   :input-prompt "Describe variable")))
-         (input (variable-suggestion-name input))
-         (help-buffer (nyxt/help-mode:help-mode
-                       :activate t
-                       :buffer (make-internal-buffer
-                                :title (str:concat "*Help-"
-                                                   (symbol-name input)
-                                                   "*"))))
-         (help-contents (markup:markup
-                         (:style (style help-buffer))
-                         (:h1 (format nil "~s" input)) ; Use FORMAT to keep package prefix.
-                         (:pre (documentation input 'variable))
-                         (:h2 "Current Value:")
-                         (:pre (object-display (symbol-value input)))))
-         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                   (ps:lisp help-contents)))))
-    (ffi-buffer-evaluate-javascript-async help-buffer insert-help)
-    (set-current-buffer help-buffer)))
+         (input (variable-suggestion-name input)))
+    (with-current-html-buffer (buffer
+                               (str:concat "*Help-" (symbol-name input) "*")
+                               'nyxt/help-mode:help-mode)
+      (markup:markup
+       (:style (style buffer))
+       (:h1 (format nil "~s" input)) ; Use FORMAT to keep package prefix.
+       (:pre (documentation input 'variable))
+       (:h2 "Current Value:")
+       (:pre (object-display (symbol-value input)))))))
 
 (declaim (ftype (function (command)) describe-command*))
 (defun describe-command* (command)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -394,17 +394,11 @@ evaluate in order."
 
 (defun error-buffer (title text)
   "Print some help."
-  (let* ((error-buffer (nyxt/help-mode:help-mode :activate t
-                                                 :buffer (make-internal-buffer :title title)))
-         (error-contents
-           (markup:markup
-            (:style (style error-buffer))
-            (:h1 "Error occured:")
-            (:p text)))
-         (insert-error (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                    (ps:lisp error-contents)))))
-    (ffi-buffer-evaluate-javascript-async error-buffer insert-error)
-    error-buffer))
+  (with-current-html-buffer (buffer title 'nyxt/help-mode:help-mode)
+    (markup:markup
+     (:style (style buffer))
+     (:h1 "Error occured:")
+     (:p text))))
 
 (defun error-in-new-window (title text)
   (let* ((window (window-make *browser*))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -484,24 +484,16 @@ The version number is stored in the clipboard."
 
 (define-command tutorial ()
   "Show the tutorial."
-  (let ((help-buffer (nyxt/help-mode:help-mode
-                      :activate t
-                      :buffer (make-internal-buffer :title "*Tutorial*"))))
-    (set-current-buffer help-buffer)
-    (let* ((help-contents
-             (str:concat
-              (markup:markup
-               (:style (style help-buffer))
-               (:h1 "Nyxt tutorial")
-               (:p "The following tutorial introduces the core concepts and the
+  (with-current-html-buffer (buffer "*Tutorial*" 'nyxt/help-mode:help-mode)
+    (str:concat
+     (markup:markup
+      (:style (style buffer))
+      (:h1 "Nyxt tutorial")
+      (:p "The following tutorial introduces the core concepts and the
 basic usage.  For more details, especially regarding the configuration, see
 the "
-                   (:code (command-markup 'manual)) "."))
-              (tutorial-content)))
-           (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                     (ps:lisp help-contents)))))
-      (ffi-buffer-evaluate-javascript-async help-buffer insert-help))
-    help-buffer))
+          (:code (command-markup 'manual)) "."))
+     (tutorial-content))))
 
 (define-command copy-system-information ()
   "Save system information into the clipboard."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -443,45 +443,38 @@ The version number is stored in the clipboard."
 
 (define-command help ()
   "Print help information."
-  (let ((help-buffer (nyxt/help-mode:help-mode :activate t
-                                               :buffer (make-internal-buffer :title "*Help*"))))
-    (set-current-buffer help-buffer)
-    (let* ((help-contents
-             (markup:markup
-              (:style (style help-buffer))
-              (:style (cl-css:css '((:h2
-                                     :font-weight 300
-                                     :padding-top "10px"))))
-              (:h1 "Welcome to Nyxt ☺")
-              (:p "Attention: Nyxt is under active development. Feel free to "
-                  (:a :href "https://github.com/atlas-engineer/nyxt/issues"
-                      "report")
-                  " bugs, instabilities or feature wishes.")
-              (:p "You can help with Nyxt development by supporting us in various ways:"
-                  (:ul
-                   (:li "Support continuous development on "
-                        (:a :href "https://www.patreon.com/nyxt"
-                            "Patreon")
-                        ".")
-                   (:li "Spread the word on social media and "
-                        (:a :href "https://github.com/atlas-engineer/nyxt"
-                            "star the project on GitHub")
-                        ".")))
-              (:hr )
-              (:h2 "Quick configuration")
-              (:p (:a :class "button" :href (lisp-url `(nyxt::common-settings)) "Common settings")
-                  " Switch between Emacs/vi/CUA key bindings, set home page URL, and zoom level.")
-              (:h2 "Documentation")
-              (:p (:a :class "button" :href (lisp-url `(nyxt::describe-bindings)) "List bindings")
-                  " List all bindings for the current buffer.")
-              (:p (:a :class "button" :href (lisp-url `(nyxt::tutorial)) "Tutorial")
-                  " An introduction to Nyxt core concepts.")
-              (:p (:a :class "button" :href (lisp-url `(nyxt::manual)) "Manual")
-                  " Full documentation about Nyxt, how it works and how to configure it.")))
-           (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                     (ps:lisp help-contents)))))
-      (ffi-buffer-evaluate-javascript-async help-buffer insert-help))
-    help-buffer))
+  (with-current-html-buffer (buffer "*Help*" 'nyxt/help-mode:help-mode)
+    (markup:markup
+     (:style (style buffer))
+     (:style (cl-css:css '((:h2
+                            :font-weight 300
+                            :padding-top "10px"))))
+     (:h1 "Welcome to Nyxt ☺")
+     (:p "Attention: Nyxt is under active development. Feel free to "
+         (:a :href "https://github.com/atlas-engineer/nyxt/issues"
+             "report")
+         " bugs, instabilities or feature wishes.")
+     (:p "You can help with Nyxt development by supporting us in various ways:"
+         (:ul
+          (:li "Support continuous development on "
+               (:a :href "https://www.patreon.com/nyxt"
+                   "Patreon")
+               ".")
+          (:li "Spread the word on social media and "
+               (:a :href "https://github.com/atlas-engineer/nyxt"
+                   "star the project on GitHub")
+               ".")))
+     (:hr )
+     (:h2 "Quick configuration")
+     (:p (:a :class "button" :href (lisp-url `(nyxt::common-settings)) "Common settings")
+         " Switch between Emacs/vi/CUA key bindings, set home page URL, and zoom level.")
+     (:h2 "Documentation")
+     (:p (:a :class "button" :href (lisp-url `(nyxt::describe-bindings)) "List bindings")
+         " List all bindings for the current buffer.")
+     (:p (:a :class "button" :href (lisp-url `(nyxt::tutorial)) "Tutorial")
+         " An introduction to Nyxt core concepts.")
+     (:p (:a :class "button" :href (lisp-url `(nyxt::manual)) "Manual")
+         " Full documentation about Nyxt, how it works and how to configure it."))))
 
 (define-command manual ()
   "Show the manual."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -277,29 +277,21 @@ CLASS can be a class symbol or a list of class symbols, as with
 
 (define-command describe-bindings ()
   "Show a buffer with the list of all known bindings for the current buffer."
-  (let* ((title (str:concat "*Help-bindings"))
-         (help-buffer (nyxt/help-mode:help-mode
-                       :activate t
-                       :buffer (make-internal-buffer :title title)))
-         (help-contents
-           (markup:markup
-            (:style (style help-buffer))
-            (:h1 "Bindings")
-            (:p
-             (loop for keymap in (current-keymaps (current-buffer))
-                   collect (markup:markup
-                            (:h3 (keymap:name keymap))
-                            (:table
-                             (loop for keyspec being the hash-keys in (keymap:keymap-with-parents->map keymap)
-                                     using (hash-value bound-value)
-                                   collect (markup:markup
-                                            (:tr
-                                             (:td keyspec)
-                                             (:td (string-downcase bound-value)))))))))))
-         (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
-                                   (ps:lisp help-contents)))))
-    (ffi-buffer-evaluate-javascript-async help-buffer insert-help)
-    (set-current-buffer help-buffer)))
+  (with-current-html-buffer (buffer "*Help-bindings" 'nyxt/help-mode:help-mode)
+    (markup:markup
+     (:style (style buffer))
+     (:h1 "Bindings")
+     (:p
+      (loop for keymap in (current-keymaps (current-buffer))
+            collect (markup:markup
+                     (:h3 (keymap:name keymap))
+                     (:table
+                      (loop for keyspec being the hash-keys in (keymap:keymap-with-parents->map keymap)
+                              using (hash-value bound-value)
+                            collect (markup:markup
+                                     (:tr
+                                      (:td keyspec)
+                                      (:td (string-downcase bound-value))))))))))))
 
 (defun tls-help (buffer url)
   "This function is invoked upon TLS certificate errors to give users

--- a/source/os-package-manager-mode.lisp
+++ b/source/os-package-manager-mode.lisp
@@ -113,19 +113,6 @@
       ;; TODO: Don't prompt when there is just 1 profile.
       (fuzzy-match (input-buffer minibuffer) all-generations))))
 
-;; TODO: Use these helpers everywhere.
-(defun html-write (content &optional (buffer (current-buffer)))
-  (ffi-buffer-evaluate-javascript-async
-   buffer
-   (ps:ps (ps:chain document
-                    (write (ps:lisp content))))))
-
-(defun html-set (content &optional (buffer (current-buffer)))
-  (ffi-buffer-evaluate-javascript-async
-   buffer
-   (ps:ps (setf (ps:@ document body |innerHTML|)
-                (ps:lisp content)))))
-
 (defun %describe-os-package (packages)
   (let* ((buffer (or (find-buffer 'os-package-manager-mode)
                      (nyxt/os-package-manager-mode:os-package-manager-mode


### PR DESCRIPTION
This saves almost 100 lines of code in help.lisp alone!
It also reduce indentation, factors out the redundant code thus removing room for typos.

Thoughts?
If this looks OK, we can use the helpers in the entire code base afterwards.