### PR TITLE
text-buffer.lisp: Added new approach to word-wise cursor movements

### DIFF
--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -56,7 +56,9 @@ When `before' is `t', look before the cursor."
         (word-separation-characters cursor)
         :test #'equal))
 
-(defmethod move-to-word ((cursor cursor) &key backward)
+(defmethod move-to-word ((cursor cursor) &key backward
+                                           (conservative-word-move
+                                           conservative-word-move))
   "Move the cursor to the boundary of a word and return its position.
 
 A word is a string bounded by `word-separation-characters'."
@@ -93,15 +95,11 @@ When `over-non-word-chars' is `t' move the cursor otherwise."
   (move-to-word cursor :backward t))
 
 (defmethod delete-word ((cursor cursor) &key backward)
-  "Delete characters until encountering the boundary of a word.
-
-Notice that unless `conservative-word-move' is set to `t' it's hard to
-make sense of this procedure."
-  (let* ((conservative-word-move t)
-         (beg (cluffer:cursor-position cursor))
-         (end (if backward
-                  (move-backward-word cursor)
-                  (move-forward-word cursor))))
+  "Delete characters until encountering the boundary of a word."
+  (let ((beg (cluffer:cursor-position cursor))
+        (end (if backward
+                 (move-to-word cursor :backward t :conservative-word-move t)
+                 (move-to-word cursor :conservative-word-move t))))
     (when (numberp end)
       (loop repeat (abs (- beg end))
             do (if backward

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -63,27 +63,27 @@ A word is a string bounded by `word-separation-characters'."
   (unless (if backward
               (cluffer:beginning-of-line-p cursor)
               (cluffer:end-of-line-p cursor))
-    (flet ((move-to-boundary (&key move-over-non-word-chars)
-             "Move the cursor while it finds `word-separation-characters'
-adjacent to it.
+    (flet ((word-separation-chars-p ()
+             (apply #'word-separation-chars-at-cursor-p
+                    cursor (when backward '(:before t)))))
+      (flet ((move-to-boundary (&key over-non-word-chars)
+               "Move the cursor while it finds
+`word-separation-characters' adjacent to it.
 
-When `move-over-non-word-chars' is `t' move the cursor otherwise."
-             (loop while (if move-over-non-word-chars
-                             (apply #'word-separation-chars-at-cursor-p
-                                    cursor (when backward '(:before t)))
-                             (not (apply #'word-separation-chars-at-cursor-p
-                                         cursor (when backward '(:before t)))))
-                   do (if backward
-                          (cluffer:backward-item cursor)
-                          (cluffer:forward-item cursor))
-                   until (if backward
-                             (cluffer:beginning-of-line-p cursor)
-                             (cluffer:end-of-line-p cursor)))))
-      (if (apply #'word-separation-chars-at-cursor-p
-                 cursor (when backward '(:before t)))
-          (progn (move-to-boundary :move-over-non-word-chars t)
-                 (when conservative-word-move (move-to-boundary)))
-          (move-to-boundary)))
+When `over-non-word-chars' is `t' move the cursor otherwise."
+               (loop while (if over-non-word-chars
+                               (word-separation-chars-p)
+                               (not (word-separation-chars-p)))
+                     do (if backward
+                            (cluffer:backward-item cursor)
+                            (cluffer:forward-item cursor))
+                     until (if backward
+                               (cluffer:beginning-of-line-p cursor)
+                               (cluffer:end-of-line-p cursor)))))
+        (if (word-separation-chars-p)
+            (progn (move-to-boundary :over-non-word-chars t)
+                   (when conservative-word-move (move-to-boundary)))
+            (move-to-boundary))))
     (cluffer:cursor-position cursor)))
 
 (defmethod move-forward-word ((cursor cursor))

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -90,18 +90,22 @@ When `over-non-word-chars' is `t' move the cursor otherwise."
           (move-to-boundary))))
   (cluffer:cursor-position cursor))
 
-(defmethod move-forward-word ((cursor cursor))
+(defmethod move-forward-word ((cursor cursor)
+                              &key (conservative-word-move
+                                    conservative-word-move))
   (move-to-word cursor))
 
-(defmethod move-backward-word ((cursor cursor))
+(defmethod move-backward-word ((cursor cursor)
+                               &key (conservative-word-move
+                                     conservative-word-move))
   (move-to-word cursor :backward t))
 
 (defmethod delete-word ((cursor cursor) &key backward)
   "Delete characters until encountering the boundary of a word."
   (let ((beg (cluffer:cursor-position cursor))
         (end (if backward
-                 (move-to-word cursor :backward t :conservative-word-move t)
-                 (move-to-word cursor :conservative-word-move t))))
+                 (move-backward-word cursor :conservative-word-move t)
+                 (move-forward-word cursor :conservative-word-move t))))
     (when (numberp end)
       (loop repeat (abs (- beg end))
             do (if backward

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -35,11 +35,6 @@
     (cluffer:backward-item cursor)
     t))
 
-(defmethod delete-item-backward ((cursor cursor))
-  (when (safe-backward cursor)
-    (cluffer:delete-item cursor)
-    t))
-
 (defmethod delete-item-forward ((cursor cursor))
   (unless (cluffer:end-of-line-p cursor)
     (cluffer:delete-item cursor)
@@ -49,6 +44,11 @@
                                                    &key before)
   "Return non-nil when `word-separation-characters' are found before or
 after the cursor position."
+(defmethod delete-item-backward ((cursor cursor))
+  (unless (cluffer:beginning-of-line-p cursor)
+    (cluffer:erase-item cursor)
+    t))
+
   (find (if before
             (cluffer:item-before-cursor cursor)
             (cluffer:item-after-cursor cursor))

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -117,10 +117,7 @@ make sense of this procedure."
   (delete-word cursor :backward t))
 
 (defmethod kill-forward-line ((cursor cursor))
-  (let ((beg (cluffer:cursor-position cursor))
-        (end (cluffer:end-of-line cursor)))
-    (loop repeat (abs (- beg end))
-          do (cluffer:erase-item cursor))))
+  (loop while (delete-item-forward cursor)))
 
 (defmethod insert-string ((cursor cursor) string)
   (loop for char across string do

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -53,9 +53,7 @@ When `before' is `t', look before the cursor."
         :test #'equal))
 
 (defmethod move-to-word ((cursor cursor)
-                         &key backward
-                           (conservative-word-move
-                            (nyxt::conservative-word-move buffer)))
+                         &key backward conservative-word-move)
   "Move the cursor to the boundary of a word and return its position.
 
 A word is a string bounded by `word-separation-characters'."
@@ -87,15 +85,12 @@ When `over-non-word-chars' is `t' move the cursor otherwise."
           (move-to-boundary))))
   (cluffer:cursor-position cursor))
 
-(defmethod move-forward-word ((cursor cursor)
-                              &key (conservative-word-move
-                                    (nyxt::conservative-word-move buffer)))
-  (move-to-word cursor))
+(defmethod move-forward-word ((cursor cursor) &key conservative-word-move)
+  (move-to-word cursor :conservative-word-move (if conservative-word-move t nil)))
 
-(defmethod move-backward-word ((cursor cursor)
-                               &key (conservative-word-move
-                                     (nyxt::conservative-word-move buffer)))
-  (move-to-word cursor :backward t))
+(defmethod move-backward-word ((cursor cursor) &key conservative-word-move)
+  (move-to-word cursor :backward t
+                       :conservative-word-move (if conservative-word-move t nil)))
 
 (defmethod delete-word ((cursor cursor) &key backward)
   "Delete characters until encountering the boundary of a word."

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -12,10 +12,6 @@
     :accessor word-separation-characters
     :initform '(":" "/" "." " " " "))))
 
-(defvar conservative-word-move nil
-  "If non-nil, the cursor moves to the end (resp. beginning) of the word
-  when `move-forward-word' (resp. `move-backward-word') is called.")
-
 (defmethod string-representation ((buffer text-buffer))
   (with-output-to-string (out)
     (map nil (lambda (string)
@@ -56,9 +52,10 @@ When `before' is `t', look before the cursor."
         (word-separation-characters cursor)
         :test #'equal))
 
-(defmethod move-to-word ((cursor cursor) &key backward
-                                           (conservative-word-move
-                                           conservative-word-move))
+(defmethod move-to-word ((cursor cursor)
+                         &key backward
+                           (conservative-word-move
+                            (nyxt::conservative-word-move buffer)))
   "Move the cursor to the boundary of a word and return its position.
 
 A word is a string bounded by `word-separation-characters'."
@@ -92,12 +89,12 @@ When `over-non-word-chars' is `t' move the cursor otherwise."
 
 (defmethod move-forward-word ((cursor cursor)
                               &key (conservative-word-move
-                                    conservative-word-move))
+                                    (nyxt::conservative-word-move buffer)))
   (move-to-word cursor))
 
 (defmethod move-backward-word ((cursor cursor)
                                &key (conservative-word-move
-                                     conservative-word-move))
+                                     (nyxt::conservative-word-move buffer)))
   (move-to-word cursor :backward t))
 
 (defmethod delete-word ((cursor cursor) &key backward)

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -14,7 +14,7 @@
 
 (defvar conservative-word-move nil
   "If non-nil, the cursor moves to the end (resp. beginning) of the word
-  when `move-forward-word' (resp. `move-backward-word') are called.")
+  when `move-forward-word' (resp. `move-backward-word') is called.")
 
 (defmethod string-representation ((buffer text-buffer))
   (with-output-to-string (out)
@@ -56,7 +56,10 @@ after the cursor position."
         :test #'equal))
 
 (defmethod move-boundary-word ((cursor cursor) &key (backwards nil))
-  "TODO"
+  "Move the cursor to the nearest boundary of a word while moving
+forward of backwards.
+
+Notice that a word is bounded by `word-separation-characters'."
   (if (apply #'word-separation-characters-at-cursor-p
              cursor (when backwards (list :before t)))
       (loop while
@@ -144,4 +147,3 @@ If cursor is between two words, return the first one."
                    (or (position char s :start position)
                        (length s)))
                  white-spaces)))
-

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -59,7 +59,7 @@ When `before' is `t', look before the cursor."
 (defmethod move-to-word ((cursor cursor) &key backward)
   "Move the cursor to the boundary of a word and return its position.
 
-Notice that a word is a string bounded by `word-separation-characters'."
+A word is a string bounded by `word-separation-characters'."
   (unless (if backward
               (cluffer:beginning-of-line-p cursor)
               (cluffer:end-of-line-p cursor))

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -67,19 +67,19 @@ Notice that a word is bounded by `word-separation-characters'."
                    cursor (when backwards (list :before t)))
             do (if backwards
                    (cluffer:backward-item cursor)
-                 (cluffer:forward-item cursor))
+                   (cluffer:forward-item cursor))
             until (if backwards
                       (cluffer:beginning-of-line-p cursor)
-                    (cluffer:end-of-line-p cursor)))
+                      (cluffer:end-of-line-p cursor)))
     (loop while
           (not (apply #'word-separation-characters-at-cursor-p
                       cursor (when backwards (list :before t))))
           do (if backwards
                  (cluffer:backward-item cursor)
-               (cluffer:forward-item cursor))
+                 (cluffer:forward-item cursor))
           until (if backwards
                     (cluffer:beginning-of-line-p cursor)
-                  (cluffer:end-of-line-p cursor)))))
+                    (cluffer:end-of-line-p cursor)))))
 
 (defmethod move-forward-word ((cursor cursor))
   (if conservative-word-move

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -46,7 +46,7 @@
     t))
 
 (defmethod word-separation-characters-at-cursor-p ((cursor cursor)
-                                                   &key (before nil))
+                                                   &key before)
   "Return non-nil when `word-separation-characters' are found before or
 after the cursor position."
   (find (if before
@@ -55,16 +55,16 @@ after the cursor position."
         (word-separation-characters cursor)
         :test #'equal))
 
-(defmethod move-boundary-word ((cursor cursor) &key (backwards nil))
+(defmethod move-boundary-word ((cursor cursor) &key backwards)
   "Move the cursor to the nearest boundary of a word while moving
 forward of backwards.
 
 Notice that a word is bounded by `word-separation-characters'."
   (if (apply #'word-separation-characters-at-cursor-p
-             cursor (when backwards (list :before t)))
+             cursor (when backwards '(:before t)))
       (loop while
             (apply #'word-separation-characters-at-cursor-p
-                   cursor (when backwards (list :before t)))
+                   cursor (when backwards '(:before t)))
             do (if backwards
                    (cluffer:backward-item cursor)
                    (cluffer:forward-item cursor))
@@ -73,7 +73,7 @@ Notice that a word is bounded by `word-separation-characters'."
                       (cluffer:end-of-line-p cursor)))
     (loop while
           (not (apply #'word-separation-characters-at-cursor-p
-                      cursor (when backwards (list :before t))))
+                      cursor (when backwards '(:before t))))
           do (if backwards
                  (cluffer:backward-item cursor)
                  (cluffer:forward-item cursor))
@@ -85,13 +85,13 @@ Notice that a word is bounded by `word-separation-characters'."
   (if conservative-word-move
       (loop repeat 2
             do (move-boundary-word cursor))
-    (move-boundary-word cursor)))
+      (move-boundary-word cursor)))
 
 (defmethod move-backward-word ((cursor cursor))
   (if conservative-word-move
       (loop repeat 2
             do (move-boundary-word cursor :backwards t))
-    (move-boundary-word cursor :backwards t)))
+      (move-boundary-word cursor :backwards t)))
 
 (defmethod delete-backward-word ((cursor cursor))
   (dotimes (i (- (cluffer:cursor-position cursor) (or (nth-value 1 (move-backward-word cursor)) 0)))

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -102,10 +102,11 @@ make sense of this procedure."
          (end (if backward
                   (move-backward-word cursor)
                   (move-forward-word cursor))))
-    (loop repeat (abs (- beg end))
-          do (if backward
-                 (cluffer:delete-item cursor)
-                 (cluffer:erase-item cursor)))))
+    (when (numberp end)
+      (loop repeat (abs (- beg end))
+            do (if backward
+                   (cluffer:delete-item cursor)
+                   (cluffer:erase-item cursor))))))
 
 (defmethod delete-forward-word ((cursor cursor))
   "Delete characters forward until encountering the end of a word."

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -90,15 +90,30 @@ When `move-over-non-word-chars' is `t' move the cursor otherwise."
   (move-to-word cursor))
 
 (defmethod move-backward-word ((cursor cursor))
-
-(defmethod delete-backward-word ((cursor cursor))
-  (dotimes (i (- (cluffer:cursor-position cursor) (or (nth-value 1 (move-backward-word cursor)) 0)))
-    (cluffer:delete-item cursor)))
   (move-to-word cursor :backward t))
 
+(defmethod delete-word ((cursor cursor) &key backward)
+  "Delete characters until encountering the boundary of a word.
+
+Notice that unless `conservative-word-move' is set to `t' it's hard to
+make sense of this procedure."
+  (let* ((conservative-word-move t)
+         (beg (cluffer:cursor-position cursor))
+         (end (if backward
+                  (move-backward-word cursor)
+                  (move-forward-word cursor))))
+    (loop repeat (abs (- beg end))
+          do (if backward
+                 (cluffer:delete-item cursor)
+                 (cluffer:erase-item cursor)))))
+
 (defmethod delete-forward-word ((cursor cursor))
-  (dotimes (i (abs (- (cluffer:cursor-position cursor) (or (nth-value 1 (move-forward-word cursor)) 0))))
-    (delete-item-backward cursor)))
+  "Delete characters forward until encountering the end of a word."
+  (delete-word cursor))
+
+(defmethod delete-backward-word ((cursor cursor))
+  "Delete characters backward until encountering the end of a word."
+  (delete-word cursor :backward t))
 
 (defmethod kill-forward-line ((cursor cursor))
   (loop while (delete-item-forward cursor)))

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -63,34 +63,34 @@ Notice that a word is bounded by `word-separation-characters'."
   (if (apply #'word-separation-characters-at-cursor-p
              cursor (when backwards '(:before t)))
       (loop while
-            (apply #'word-separation-characters-at-cursor-p
-                   cursor (when backwards '(:before t)))
-            do (if backwards
-                   (cluffer:backward-item cursor)
-                   (cluffer:forward-item cursor))
-            until (if backwards
-                      (cluffer:beginning-of-line-p cursor)
-                      (cluffer:end-of-line-p cursor)))
-    (loop while
-          (not (apply #'word-separation-characters-at-cursor-p
-                      cursor (when backwards '(:before t))))
-          do (if backwards
-                 (cluffer:backward-item cursor)
-                 (cluffer:forward-item cursor))
-          until (if backwards
-                    (cluffer:beginning-of-line-p cursor)
-                    (cluffer:end-of-line-p cursor)))))
+           (apply #'word-separation-characters-at-cursor-p
+                  cursor (when backwards '(:before t)))
+         do (if backwards
+                (cluffer:backward-item cursor)
+                (cluffer:forward-item cursor))
+         until (if backwards
+                   (cluffer:beginning-of-line-p cursor)
+                   (cluffer:end-of-line-p cursor)))
+      (loop while
+           (not (apply #'word-separation-characters-at-cursor-p
+                       cursor (when backwards '(:before t))))
+         do (if backwards
+                (cluffer:backward-item cursor)
+                (cluffer:forward-item cursor))
+         until (if backwards
+                   (cluffer:beginning-of-line-p cursor)
+                   (cluffer:end-of-line-p cursor)))))
 
 (defmethod move-forward-word ((cursor cursor))
   (if conservative-word-move
       (loop repeat 2
-            do (move-boundary-word cursor))
+         do (move-boundary-word cursor))
       (move-boundary-word cursor)))
 
 (defmethod move-backward-word ((cursor cursor))
   (if conservative-word-move
       (loop repeat 2
-            do (move-boundary-word cursor :backwards t))
+         do (move-boundary-word cursor :backwards t))
       (move-boundary-word cursor :backwards t)))
 
 (defmethod delete-backward-word ((cursor cursor))

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -116,7 +116,10 @@ make sense of this procedure."
   (delete-word cursor :backward t))
 
 (defmethod kill-forward-line ((cursor cursor))
-  (loop while (delete-item-forward cursor)))
+  (let ((beg (cluffer:cursor-position cursor))
+        (end (cluffer:end-of-line cursor)))
+    (loop repeat (abs (- beg end))
+          do (cluffer:erase-item cursor))))
 
 (defmethod insert-string ((cursor cursor) string)
   (loop for char across string do

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -40,15 +40,16 @@
     (cluffer:delete-item cursor)
     t))
 
-(defmethod word-separation-characters-at-cursor-p ((cursor cursor)
-                                                   &key before)
-  "Return non-nil when `word-separation-characters' are found before or
-after the cursor position."
 (defmethod delete-item-backward ((cursor cursor))
   (unless (cluffer:beginning-of-line-p cursor)
     (cluffer:erase-item cursor)
     t))
 
+(defmethod word-separation-chars-at-cursor-p ((cursor cursor) &key before)
+  "Return non-nil when `word-separation-characters' are found after the
+cursor position.
+
+When `before' is `t', look before the cursor."
   (find (if before
             (cluffer:item-before-cursor cursor)
             (cluffer:item-after-cursor cursor))

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -62,31 +62,32 @@ When `before' is `t', look before the cursor."
   "Move the cursor to the boundary of a word and return its position.
 
 A word is a string bounded by `word-separation-characters'."
-  (labels ((line-limits-p ()
-             (if backward
-                 (cluffer:beginning-of-line-p cursor)
-                 (cluffer:end-of-line-p cursor)))
-           (word-separation-chars-p ()
-             (apply #'word-separation-chars-at-cursor-p
-                    cursor (when backward '(:before t))))
-           (move-to-boundary (&key over-non-word-chars)
-             "Move the cursor while it finds
-`word-separation-characters' adjacent to it.
+  (labels
+      ((line-limits-p ()
+         (if backward
+             (cluffer:beginning-of-line-p cursor)
+             (cluffer:end-of-line-p cursor)))
+       (word-separation-chars-p ()
+         (apply #'word-separation-chars-at-cursor-p
+                cursor (when backward '(:before t))))
+       (move-to-boundary (&key over-non-word-chars)
+         "Move the cursor while it finds `word-separation-characters'
+adjacent to it.
 
 When `over-non-word-chars' is `t' move the cursor otherwise."
-             (unless (line-limits-p)
-               (loop while (if over-non-word-chars
-                               (word-separation-chars-p)
-                               (not (word-separation-chars-p)))
-                     do (if backward
-                            (cluffer:backward-item cursor)
-                            (cluffer:forward-item cursor))
-                     until (line-limits-p)))))
+         (unless (line-limits-p)
+           (loop while (if over-non-word-chars
+                           (word-separation-chars-p)
+                           (not (word-separation-chars-p)))
+                 do (if backward
+                        (cluffer:backward-item cursor)
+                        (cluffer:forward-item cursor))
+                 until (line-limits-p)))))
     (unless (line-limits-p)
       (if (word-separation-chars-p)
-        (progn (move-to-boundary :over-non-word-chars t)
-               (when conservative-word-move (move-to-boundary)))
-        (move-to-boundary))))
+          (progn (move-to-boundary :over-non-word-chars t)
+                 (when conservative-word-move (move-to-boundary)))
+          (move-to-boundary))))
   (cluffer:cursor-position cursor))
 
 (defmethod move-forward-word ((cursor cursor))

--- a/libraries/text-buffer/text-buffer.lisp
+++ b/libraries/text-buffer/text-buffer.lisp
@@ -87,20 +87,14 @@ When `move-over-non-word-chars' is `t' move the cursor otherwise."
     (cluffer:cursor-position cursor)))
 
 (defmethod move-forward-word ((cursor cursor))
-  (if conservative-word-move
-      (loop repeat 2
-         do (move-boundary-word cursor))
-      (move-boundary-word cursor)))
+  (move-to-word cursor))
 
 (defmethod move-backward-word ((cursor cursor))
-  (if conservative-word-move
-      (loop repeat 2
-         do (move-boundary-word cursor :backwards t))
-      (move-boundary-word cursor :backwards t)))
 
 (defmethod delete-backward-word ((cursor cursor))
   (dotimes (i (- (cluffer:cursor-position cursor) (or (nth-value 1 (move-backward-word cursor)) 0)))
     (cluffer:delete-item cursor)))
+  (move-to-word cursor :backward t))
 
 (defmethod delete-forward-word ((cursor cursor))
   (dotimes (i (abs (- (cluffer:cursor-position cursor) (or (nth-value 1 (move-forward-word cursor)) 0))))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -65,6 +65,11 @@ query is not a valid URL, or the first keyword is not recognized.")
      :combination #'hooks:combine-composed-hook)
     :type hook-keymaps-buffer
     :documentation "Hook run as a return value of `current-keymaps'.")
+   (conservative-word-move
+    nil
+    :documentation "If non-nil, the cursor moves to the end
+(resp. beginning) of the word when `move-forward-word'
+(resp. `move-backward-word') is called.")
    (override-map (let ((map (make-keymap "overide-map")))
                    (define-key map
                      "C-space" 'execute-command))

--- a/source/input-edit.lisp
+++ b/source/input-edit.lisp
@@ -59,7 +59,9 @@
   "Move cursor forwards a word."
   (with-input-area (contents cursor-position)
     (with-text-buffer (text-buffer cursor contents cursor-position)
-      (text-buffer::move-forward-word cursor)
+      (text-buffer::move-forward-word cursor
+                                      :conservative-word-move
+                                      (conservative-word-move (current-buffer)))
       (set-active-input-area-cursor (cluffer:cursor-position cursor)
                                     (cluffer:cursor-position cursor)))))
 
@@ -67,7 +69,9 @@
   "Move cursor backwards a word."
   (with-input-area (contents cursor-position)
     (with-text-buffer (text-buffer cursor contents cursor-position)
-      (text-buffer::move-backward-word cursor)
+      (text-buffer::move-backward-word cursor
+                                      :conservative-word-move
+                                      (conservative-word-move (current-buffer)))
       (set-active-input-area-cursor (cluffer:cursor-position cursor)
                                     (cluffer:cursor-position cursor)))))
 

--- a/source/minibuffer-mode.lisp
+++ b/source/minibuffer-mode.lisp
@@ -192,14 +192,18 @@ complete against a search engine."
 
 (define-command cursor-forwards-word (&optional (minibuffer (current-minibuffer)))
   "Move cursor to the end of the word at point."
-  (text-buffer::move-forward-word (input-cursor minibuffer))
+  (text-buffer::move-forward-word (input-cursor minibuffer)
+                                  :conservative-word-move
+                                  (conservative-word-move (current-buffer)))
   (state-changed minibuffer)
   (update-input-buffer-display minibuffer)
   (cluffer:cursor-position (input-cursor minibuffer)))
 
 (define-command cursor-backwards-word (&optional (minibuffer (current-minibuffer)))
   "Move cursor to the beginning of the word at point."
-  (text-buffer::move-backward-word (input-cursor minibuffer))
+  (text-buffer::move-backward-word (input-cursor minibuffer)
+                                   :conservative-word-move
+                                   (conservative-word-move (current-buffer)))
   (state-changed minibuffer)
   (update-input-buffer-display minibuffer)
   (cluffer:cursor-position (input-cursor minibuffer)))

--- a/source/repl-mode.lisp
+++ b/source/repl-mode.lisp
@@ -97,12 +97,16 @@
 
 (define-command cursor-forwards-word (&optional (repl (current-repl)))
   "Move cursor forwards a word."
-  (text-buffer::move-forward-word (input-cursor repl))
+  (text-buffer::move-forward-word (input-cursor repl)
+                                  :conservative-word-move
+                                  (conservative-word-move (current-buffer)))
   (update-input-buffer-display repl))
 
 (define-command cursor-backwards-word (&optional (repl (current-repl)))
   "Move cursor backwards a word."
-  (text-buffer::move-backward-word (input-cursor repl))
+  (text-buffer::move-backward-word (input-cursor repl)
+                                   :conservative-word-move
+                                   (conservative-word-move (current-buffer)))
   (update-input-buffer-display repl))
 
 (define-command delete-backwards-word (&optional (repl (current-repl)))
@@ -152,7 +156,7 @@
 
 (defmethod update-evaluation-history-display ((repl repl-mode))
   (flet ((generate-evaluation-history-html (repl)
-           (markup:markup 
+           (markup:markup
             (:ul (loop for item in (reverse (evaluation-history repl))
                        collect (markup:markup
                                 (:li item)))))))


### PR DESCRIPTION
Introduced a new global variable that customizes the behaviour of
cursor-forwards-word and cursor-backwards-word.

By default, the cursor navigates to both left and right boundaries of
words.

Without loss of generality, let's look at the case of
cursor-forwards-word.

Let the symbol "|" denote the position of the cursor after sucessive
calls of cursor-forwards-word.  Assume that the cursor started off at
the beginning of the line:

a |piece| |of| |text|

When *conservative-mode-word* is non-nil:

a| piece| of| text|


------

Hi Nyxt!

This addresses #1008.

Again, I'm happy to follow your lead as I'm very unexperienced.

I don't really understand how I can set the value of `*conservative-move-word*` to `t` in my init file. I thought that `(setq *move-always-beginning-word* t)` would do it.