### PR TITLE
Start args

### DIFF
--- a/source/minibuffer-prompt.lisp
+++ b/source/minibuffer-prompt.lisp
@@ -1,10 +1,13 @@
 (in-package :nyxt)
 
-(defmacro define-function (name args &body body)
-  "Eval ARGS then define function over the resulting lambda list.
+(defmacro define-function (name args docstring &body body)
+  "Eval ARGS and DOCSTRING then define function over the resulting lambda list
+and string.
 All ARGS are declared as `ignorable'."
-  (let ((evaluated-args (eval args)))
-    `(defun ,name  ,evaluated-args
+  (let ((evaluated-args (eval args))
+        (evaluated-docstring (eval docstring)))
+    `(defun ,name ,evaluated-args
+       ,evaluated-docstring
        (declare (ignorable ,@(set-difference (mapcar (lambda (arg) (if (listp arg) (first arg) arg))
                                                      evaluated-args)
                                              lambda-list-keywords)))
@@ -17,6 +20,7 @@ All ARGS are declared as `ignorable'."
             (delete 'input-buffer
                     (public-initargs 'minibuffer))
             '((input-buffer nil explicit-input-buffer)))
+    "Return a new minibuffer instance."
   (let ((tmp-input-buffer (make-instance 'text-buffer:text-buffer))
         (tmp-input-cursor (make-instance 'text-buffer:cursor)))
     (cluffer:attach-cursor tmp-input-cursor tmp-input-buffer)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -397,9 +397,11 @@ Otherwise bind socket."
                                                            #'symbol-name
                                                            #'opts::name)
                                              opts::*options*))
-  "Start the browser, loading URLs if any.
+    (format nil "Start the browser, loading URLs if any.
 URLs is a list of strings.
 The OPTIONS are the same as the command line options.
+
+~a
 
 Examples:
 
@@ -410,6 +412,7 @@ Examples:
   open the given URLs.
   (nyxt:start '(\"https://nyxt.atlas.engineer\" \"https://en.wikipedia.org\")
               :verbose t :with-path '(\"history\" \"/tmp/nyxt/history.lisp\"))"
+            (with-output-to-string (s) (opts:describe :stream s)))
   ;; Options should be accessible anytime, even when run from the REPL.
   (setf *options* options)
 


### PR DESCRIPTION
Benefit: we now have keyword argument completion from the REPL for the start function!

Drawback: if we want to start the browser over no URL, we still need to pass NIL.