### PR TITLE
Avoid tautological buffer-load.

### DIFF
--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -321,8 +321,7 @@ rest in background buffers."
                   :multi-selection-p t)))
     (dolist (entry (rest entries))
       (make-buffer :url (object-string (url entry))))
-    (buffer-load (url (first entries))
-                 :buffer (make-buffer-focus))))
+    (make-buffer-focus :url (url (first entries)))))
 
 (defmethod serialize-object ((entry bookmark-entry) stream)
   (unless (url-empty-p (url entry))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -314,10 +314,7 @@ This is useful to tell REPL instances from binary ones."
 First URL is focused if NO-FOCUS is nil."
   (handler-case
       (let ((first-buffer (first (mapcar
-                                  (lambda (url)
-                                    (let ((buffer (make-buffer)))
-                                      (buffer-load url :buffer buffer)
-                                      buffer))
+                                  (lambda (url) (make-buffer :url url))
                                   urls))))
         (when (and first-buffer (not no-focus))
           (if (open-external-link-in-new-window-p *browser*)

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -264,7 +264,7 @@ identifier for every hinted element."
   (format nil "~a  Textarea" (hint textarea-hint)))
 
 (defmethod %follow-hint ((link-hint link-hint))
-  (buffer-load (url link-hint) :buffer (current-buffer)))
+  (buffer-load (url link-hint)))
 
 (defmethod %follow-hint ((button-hint button-hint))
   (click-button :nyxt-identifier (identifier button-hint)))
@@ -276,16 +276,13 @@ identifier for every hinted element."
   (focus-element :nyxt-identifier (identifier textarea-hint)))
 
 (defmethod %follow-hint-new-buffer-focus ((link-hint link-hint))
-  (let ((new-buffer (make-buffer)))
-    (buffer-load (url link-hint) :buffer new-buffer)
-    (set-current-buffer new-buffer)))
+  (make-buffer-focus :url (url link-hint)))
 
 (defmethod %follow-hint-new-buffer-focus ((hint hint))
   (echo "Unsupported operation for hint: can't open in new buffer."))
 
 (defmethod %follow-hint-new-buffer ((link-hint link-hint))
-  (let ((new-buffer (make-buffer)))
-    (buffer-load (url link-hint) :buffer new-buffer)))
+  (make-buffer :url (url link-hint)))
 
 (defmethod %follow-hint-new-buffer ((hint hint))
   (echo "Unsupported operation for hint: can't open in new buffer."))

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -49,11 +49,9 @@ Can be used as a `*open-file-function*'."
       (cond
         ((and (uiop:directory-pathname-p filename)
               (uiop:directory-exists-p filename))
-         (buffer-load (format nil "file://~a" (uiop:ensure-directory-pathname filename))
-                      :buffer (make-buffer-focus)))
+         (make-buffer-focus :url (format nil "file://~a" (uiop:ensure-directory-pathname filename))))
         ((supported-media filename)
-         (buffer-load (format nil "file://~a" filename)
-                      :buffer (make-buffer-focus)))
+         (make-buffer-focus :url (format nil "file://~a" filename)))
         (t
          (uiop:launch-program
           #+linux

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -195,7 +195,7 @@ search.")
       (if (and (input-tag-p response) url-empty)
           (funcall-safely #'paste)
           (unless url-empty
-            (buffer-load (url-at-point buffer) :buffer (make-buffer-focus)))))))
+            (make-buffer-focus :url (url-at-point buffer)))))))
 
 (define-command maybe-scroll-to-bottom (&optional (buffer (current-buffer)))
   "Scroll to bottom if no input element is active, forward event otherwise."


### PR DESCRIPTION
This rewrites most places of `buffer-load` usage with `:buffer` keyword as
tautological (because `make-buffer` creating the buffer passed with
`:buffer` keyword calls `buffer-load`). `make-buffer` and `make-buffer-focus`
are used instead.

### Motivation

While this doesn't change things dramatically in any way, it make for
a better code and architecture with less nested and repetitive
function calls :)

This also helps in maintaining a coherent history tree in #1007.

### How Has This Been Tested

I've ran most of the functions covered (except for the ones I don't
quite get the use-case of, like `paste-or-set-url`), so it should be
safe to merge.

How does it look to you?

EDIT: mark function names and keywords with backticks.