### PR TITLE
Add ensured default value to with-data-access.

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -282,7 +282,7 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
                           (values list &optional))
                 add-modes-to-auto-mode-rules))
 (defun add-modes-to-auto-mode-rules (test &key (append-p nil) exclude include (exact-p nil))
-  (with-data-access rules (auto-mode-rules-path (current-buffer))
+  (with-data-access (rules (auto-mode-rules-path (current-buffer)))
     (let* ((rule (or (find test rules
                            :key #'test :test #'equal)
                      (make-instance 'auto-mode-rule :test test)))

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -88,7 +88,7 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
 (declaim (ftype (function (quri:uri &key (:title string) (:date (or local-time:timestamp null)) (:tags t)) t) bookmark-add))
 (export-always 'bookmark-add)
 (defun bookmark-add (url &key date title tags)
-  (with-data-access bookmarks (bookmarks-path (current-buffer))
+  (with-data-access (bookmarks (bookmarks-path (current-buffer)))
     (unless (or (url-empty-p url)
                 (string= "about:blank" (object-string url)))
       (let* ((entry nil)
@@ -254,7 +254,7 @@ URL."
 
 (define-command bookmark-delete ()
   "Delete bookmark(s)."
-  (with-data-access bookmarks (bookmarks-path (current-buffer))
+  (with-data-access (bookmarks (bookmarks-path (current-buffer)))
     (let ((entries (prompt-minibuffer
                     :input-prompt "Delete bookmark(s)"
                     :multi-selection-p t
@@ -267,7 +267,7 @@ URL."
 (defun delete-bookmark (url)
   "Delete a bookmark by the URL. This function depends on equals only
 comparing URLs."
-  (with-data-access bookmarks (bookmarks-path (current-buffer))
+  (with-data-access (bookmarks (bookmarks-path (current-buffer)))
     (setf bookmarks
           (set-difference
            bookmarks

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -43,10 +43,9 @@ The total number of visit for a given URL is (+ explicit-visits implicit-visits)
 The `implicit-visits' count is incremented unless EXPLICIT is non-nil, in which
 case `explicit-visits'.
 The history is sorted by last access."
-  (with-data-access history (history-path (current-buffer))
+  (with-data-access (history (history-path (current-buffer))
+                     :default (make-hash-table :test #'equal))
     (unless (url-empty-p uri)
-      (unless history
-        (setf history (make-hash-table :test #'equal)))
       (let ((entry (gethash (object-string uri) history)))
         (unless entry
           (setf entry (make-instance 'history-entry :url uri)))
@@ -61,7 +60,7 @@ The history is sorted by last access."
 
 (define-command delete-history-entry ()
   "Delete queried history entries."
-  (with-data-access history (history-path (current-buffer))
+  (with-data-access (history (history-path (current-buffer)))
     (let ((entries (prompt-minibuffer
                     :input-prompt "Delete entries"
                     :suggestion-function (history-suggestion-filter)


### PR DESCRIPTION
This adds the optional parameter to `with-data-access`. This parameter
specifies what value to assign to the given variable if data is not
found.

### Motivation

It can be useful to set the value to some initial value after getting
empty data, like it can be useful to set the `gethash`-ed value in a
hash-table to some sensible default. All in all, this change makes
`with-data-access` capable of `ensure-gethash`-like functionality on
user-data.

### Caveats (?)

One important addition is that all the arguments of `with-data-access`
are now parenthesised -- to ease argument parsing. This, however,
looks similar to `let`-bindings and other `with-*` macros, so it shouldn't
be hard to grasp for a human reader.

### How Has This Been Tested

- `asdf:test-system` 
- I've also ran Nyxt for a short time to check whether the functions
  relying on `with-data-access` do work. They do.

What do you think of this?