### PR TITLE
Ospama: Guix server + full Scheme support

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -157,6 +157,7 @@
        ("log4cl" ,cl-log4cl)
        ("mk-string-metrics" ,cl-mk-string-metrics)
        ("moptilities" ,cl-moptilities)
+       ("named-readtables" ,cl-named-readtables)
        ("osicat" ,sbcl-osicat)          ; SBCL version needed for libosicat.so.
        ("parenscript" ,cl-parenscript)
        ("plump" ,cl-plump)

--- a/libraries/ospama/guix-backend.lisp
+++ b/libraries/ospama/guix-backend.lisp
@@ -88,7 +88,11 @@ just-in-time instead."
 
    '(fold-packages
      (lambda (package result)
-       (let ((loc (package-location package)))
+       (let ((loc (package-location package))
+             (inputs->names (lambda (inputs)
+                              (map package-name
+                                   ;; Input may be an `origin', not necessarily a package.
+                                   (filter package? (map cadr inputs))))))
          (cons
           (list
            (package-name package)
@@ -96,9 +100,10 @@ just-in-time instead."
             #:version (package-version package)
             #:outputs (package-outputs package)
             #:supported-systems (package-supported-systems package)
-            #:inputs (map car (package-inputs package))
-            #:propagated-inputs (map car (package-propagated-inputs package))
-            #:native-inputs (map car (package-native-inputs package))
+
+            #:inputs (inputs->names (package-inputs package))
+            #:propagated-inputs (inputs->names (package-propagated-inputs package))
+            #:native-inputs (inputs->names (package-native-inputs package))
             #:location (string-join (list (location-file loc)
                                           (number->string (location-line loc))
                                           (number->string (location-column loc)))

--- a/libraries/ospama/guix-backend.lisp
+++ b/libraries/ospama/guix-backend.lisp
@@ -1,0 +1,198 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :ospama)
+
+(named-readtables:in-readtable scheme-writer-syntax)
+
+(defvar %find-package
+  ;; TODO: Use upstream's way to find packages.
+  '(lambda (name)
+    (let ((result (list)))
+      (fold-packages
+       (lambda (package count)
+         (when (string=? (package-name package)
+                         name)
+           (set! result package))
+         (+ 1 count))
+       1)
+      result)))
+
+;; TODO: Find a fast way to compute the output-paths.
+(defun package-output-paths (name)
+  "Computing the output-paths in `generate-database' is too slow, so we do it
+just-in-time instead."
+  (guix-eval
+   '(use-modules
+     (guix store)
+     (guix derivations)
+     (guix monads)
+     (guix grafts)
+     (guix gexp)
+     (guix packages)
+     (guix utils)
+     (gnu packages))
+
+   `(define find-package ,%find-package)
+
+   '(define* (package-output-paths package)
+     "Return store items, even if not present locally."
+     (define (lower-object/no-grafts obj system) ; From (guix scripts weather)
+      (mlet* %store-monad ((previous (set-grafting #f))
+                           (drv (lower-object obj system))
+                           (_ (set-grafting previous)))
+       (return drv)))
+     (with-store store
+       (run-with-store store
+        (mlet %store-monad ((drv (lower-object/no-grafts package (%current-system))))
+         ;; Note: we don't try building DRV like 'guix archive' does
+         ;; because we don't have to since we can instead rely on
+         ;; substitute meta-data.
+         (return
+           (derivation->output-paths drv))))))
+
+   `(package-output-paths (find-package ,name))))
+
+(defun package-output-size (output-path)
+  (guix-eval
+   '(use-modules
+     (guix store)
+     (guix monads))
+
+   `(let ((path-info (with-store store
+                       (run-with-store store
+                                       (mbegin %store-monad
+                                               (query-path-info* ,output-path))))))
+      (if path-info
+          (path-info-nar-size path-info)
+          0))))
+
+(defun generate-database ()
+  (guix-eval
+   '(use-modules
+     (guix packages)
+     (guix licenses)
+     (guix utils)
+     (guix build utils)                 ; For `string-replace-substring'.
+     (gnu packages))
+
+   '(define (ensure-list l)
+     (if (list? l)
+         l
+         (list l)))
+
+   '(fold-packages
+     (lambda (package result)
+       (let ((location (package-location package)))
+         (cons
+          (list
+           (package-name package)
+           (list
+            #:version (package-version package)
+            #:outputs (package-outputs package)
+            #:supported-systems (package-supported-systems package)
+            #:inputs (map car (package-inputs package))
+            #:propagated-inputs (map car (package-propagated-inputs package))
+            #:native-inputs (map car (package-native-inputs package))
+            #:location (string-join (list (location-file location)
+                                          (number->string (location-line location))
+                                          (number->string (location-column location)))
+                                    ":")
+            ;; In Guix, an empty home-page is #f, but we want a string.
+            #:home-page (or (package-home-page package) "")
+            #:license-name (map license-name (ensure-list (package-license package)))
+            #:synopsis (package-synopsis package)
+            #:description (string-replace-substring (package-description package) "\\n" " ")))
+          result)))
+     '())))
+
+(defun package-dependents (name)        ; TODO: Unused?
+  (guix-eval
+   '(use-modules
+     (guix graph)
+     (guix scripts graph)
+     (guix store)
+     (guix monads)
+     (guix packages)
+     (gnu packages))
+
+   '(define (all-packages)                  ; From refresh.scm.
+     "Return the list of all the distro's packages."
+     (fold-packages (lambda (package result)
+                      ;; Ignore deprecated packages.
+                      (if (package-superseded package)
+                          result
+                          (cons package result)))
+      (list)
+      #:select? (const #t)))
+
+   '(define (list-dependents packages)
+     "List all the things that would need to be rebuilt if PACKAGES are changed."
+     ;; Using %BAG-NODE-TYPE is more accurate than using %PACKAGE-NODE-TYPE
+     ;; because it includes implicit dependencies.
+     (define (full-name package)
+      (string-append (package-name package) "@"
+       (package-version package)))
+     (mlet %store-monad ((edges (node-back-edges %bag-node-type
+                                 (package-closure (all-packages)))))
+      (let* ((dependents (node-transitive-edges packages edges))
+             (covering   (filter (lambda (node)
+                                   (null? (edges node)))
+                                 dependents)))
+        (return dependents))))
+
+   `(define find-package ,%find-package)
+
+   `(map package-name
+         (with-store store
+           (run-with-store
+            store
+            (mbegin %store-monad
+                    (list-dependents (list (find-package ,name)))))))))
+
+(declaim (ftype (function (&optional (or symbol string pathname))) list-installed))
+(defun list-installed (&optional (profile '%current-profile))
+  "Return the installed package outputs in PROFILE as a list of (NAME OUTPUT).
+PROFILE is a full path to a profile."
+  (guix-eval
+   '(use-modules
+     (guix profiles))
+
+   `(map (lambda (entry)
+           (list (manifest-entry-name entry)
+                 (manifest-entry-output entry)))
+         (manifest-entries
+          (profile-manifest ,(namestring profile))))))
+
+(defun generation-list (&optional (profile '%current-profile))
+  "Return the generations in PROFILE as a list of
+(NUMBER CURRENT? PACKAGES TIME FILENAME).
+PROFILE is a full path to a profile.
+Date is in the form 'Oct 22 2020 18:38:42'."
+  (let ((profile (if (pathnamep profile)
+                     (namestring profile)
+                     profile)))
+    (guix-eval
+     '(use-modules
+       (ice-9 match)
+       (srfi srfi-19)
+       (guix profiles))
+
+     `(let loop ((generations (profile-generations ,profile)))
+        (match generations
+          ((number . rest)
+           (cons (list number
+                       (if (= (generation-number ,profile) number)
+                           't
+                           'nil)
+                       (length (manifest-entries
+                                (profile-manifest
+                                 (generation-file-name ,profile number))))
+                       (date->string
+                        (time-utc->date
+                         (generation-time ,profile number))
+                        ;; ISO-8601 date/time
+                        "~5")
+                       (generation-file-name ,profile number))
+                 (loop rest)))
+          (_ '()))))))

--- a/libraries/ospama/guix-backend.lisp
+++ b/libraries/ospama/guix-backend.lisp
@@ -5,6 +5,8 @@
 
 (named-readtables:in-readtable scheme-writer-syntax)
 
+;; TODO: With CCL keywords cannot have the same name as interned symbols.
+
 (defvar %find-package
   ;; TODO: Use upstream's way to find packages.
   '(lambda (name)
@@ -83,7 +85,7 @@ just-in-time instead."
 
    '(fold-packages
      (lambda (package result)
-       (let ((location (package-location package)))
+       (let ((loc (package-location package)))
          (cons
           (list
            (package-name package)
@@ -94,9 +96,9 @@ just-in-time instead."
             #:inputs (map car (package-inputs package))
             #:propagated-inputs (map car (package-propagated-inputs package))
             #:native-inputs (map car (package-native-inputs package))
-            #:location (string-join (list (location-file location)
-                                          (number->string (location-line location))
-                                          (number->string (location-column location)))
+            #:location (string-join (list (location-file loc)
+                                          (number->string (location-line loc))
+                                          (number->string (location-column loc)))
                                     ":")
             ;; In Guix, an empty home-page is #f, but we want a string.
             #:home-page (or (package-home-page package) "")

--- a/libraries/ospama/guix-backend.lisp
+++ b/libraries/ospama/guix-backend.lisp
@@ -5,6 +5,9 @@
 
 (named-readtables:in-readtable scheme-writer-syntax)
 
+;; TODO: Add support for the '() syntax.
+;; Workaround: use `(list)`.
+
 ;; TODO: With CCL keywords cannot have the same name as interned symbols.
 
 (defvar %find-package
@@ -106,7 +109,7 @@ just-in-time instead."
             #:synopsis (package-synopsis package)
             #:description (string-replace-substring (package-description package) "\\n" " ")))
           result)))
-     '())))
+     (list))))
 
 (defun package-dependents (name)        ; TODO: Unused?
   (guix-eval
@@ -197,4 +200,5 @@ Date is in the form 'Oct 22 2020 18:38:42'."
                         "~5")
                        (generation-file-name ,profile number))
                  (loop rest)))
-          (_ '()))))))
+          (_ (list)))))))
+

--- a/libraries/ospama/ospama-guix.lisp
+++ b/libraries/ospama/ospama-guix.lisp
@@ -90,9 +90,9 @@ For each inputs on `%guix-listener-channel' a result is returned on
                 ;; TODO: Report read errors.
                 (chanl:send %guix-result-channel
                             (ignore-errors
-                              (named-readtables:in-readtable scheme-reader-syntax)
-                              (prog1 (read-from-string output)
-                                (named-readtables:in-readtable nil)))))))
+                             (named-readtables:in-readtable scheme-reader-syntax)
+                             (prog1 (read-from-string output)
+                               (named-readtables:in-readtable nil)))))))
         (t ()
           (close (uiop:process-info-input guix-process))
           (unless (uiop:process-alive-p guix-process)

--- a/libraries/ospama/ospama-guix.lisp
+++ b/libraries/ospama/ospama-guix.lisp
@@ -90,9 +90,9 @@ For each inputs on `%guix-listener-channel' a result is returned on
                 ;; TODO: Report read errors.
                 (chanl:send %guix-result-channel
                             (ignore-errors
-                             (named-readtables:in-readtable scheme-reader-syntax)
-                             (prog1 (read-from-string output)
-                               (named-readtables:in-readtable nil)))))))
+                             (let ((*readtable* (named-readtables:ensure-readtable
+                                                 'scheme-reader-syntax)))
+                               (read-from-string output)))))))
         (t ()
           (close (uiop:process-info-input guix-process))
           (unless (uiop:process-alive-p guix-process)

--- a/libraries/ospama/package.lisp
+++ b/libraries/ospama/package.lisp
@@ -9,4 +9,5 @@
   (:import-from #:class* #:define-class)
   (:import-from #:serapeum #:export-always))
 
-(defvar ospama::scheme-syntax nil)
+(defvar ospama::scheme-reader-syntax nil)
+(defvar ospama::scheme-writer-syntax nil)

--- a/libraries/ospama/package.lisp
+++ b/libraries/ospama/package.lisp
@@ -3,7 +3,10 @@
 
 (in-package :cl-user)
 
-(uiop:define-package :ospama
-  (:use :common-lisp)
+(uiop:define-package ospama
+  (:use #:common-lisp)
+  (:use #:trivia)
   (:import-from #:class* #:define-class)
   (:import-from #:serapeum #:export-always))
+
+(defvar ospama::scheme-syntax nil)

--- a/libraries/ospama/scheme-reader.lisp
+++ b/libraries/ospama/scheme-reader.lisp
@@ -1,0 +1,24 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :named-readtables)
+
+(defreadtable ospama::scheme-syntax
+  (:merge :standard)
+  ;; TODO: While Scheme is case sensitive, preserving the case would mean we'd
+  ;; have to upcase all return value symbols.  Or is there a smarter way to "do
+  ;; what I mean"?
+  ;; (:case :preserve)
+  (:macro-char #\[ #'(lambda (stream char)
+                       (declare (ignore char))
+                       (read-delimited-list #\] stream)))
+  (:macro-char #\# :dispatch)
+  (:dispatch-macro-char #\# #\t #'(lambda (stream char1 char2)
+                                    (declare (ignore stream char1 char2))
+                                    T))
+  (:dispatch-macro-char #\# #\f #'(lambda (stream char1 char2)
+                                    (declare (ignore stream char1 char2))
+                                    NIL))
+  (:dispatch-macro-char #\# #\: #'(lambda (stream char1 char2)
+                                    (declare (ignore char1 char2))
+                                    (intern (string-upcase (string (read stream))) "KEYWORD"))))

--- a/libraries/ospama/scheme-syntax.lisp
+++ b/libraries/ospama/scheme-syntax.lisp
@@ -36,4 +36,14 @@
                                     'ospama::\#t))
   (:dispatch-macro-char #\# #\f #'(lambda (stream char1 char2)
                                     (declare (ignore stream char1 char2))
-                                    'ospama::\#f)))
+                                    'ospama::\#f))
+  ;; SBCL seems OK without special #\: treatment, but not CCL.
+  ;; uninterning does not work as it would break with:
+  ;;   (let ((location 'foo)) (list #:location location))
+  #+ccl
+  (:dispatch-macro-char #\# #\: #'(lambda (stream char1 char2)
+                                    (declare (ignore char1 char2))
+                                    ;; (make-instance 'scheme-keyword :sym )
+                                    (let ((s (intern (string-upcase (string (read stream))))))
+                                      (unintern s)
+                                      s))))

--- a/libraries/ospama/scheme-syntax.lisp
+++ b/libraries/ospama/scheme-syntax.lisp
@@ -3,7 +3,7 @@
 
 (in-package :named-readtables)
 
-(defreadtable ospama::scheme-syntax
+(defreadtable ospama::scheme-reader-syntax
   (:merge :standard)
   ;; TODO: While Scheme is case sensitive, preserving the case would mean we'd
   ;; have to upcase all return value symbols.  Or is there a smarter way to "do
@@ -19,6 +19,21 @@
   (:dispatch-macro-char #\# #\f #'(lambda (stream char1 char2)
                                     (declare (ignore stream char1 char2))
                                     NIL))
+  ;; `#:foo' is not a keyword in Common Lisp, read it as `:foo'.
   (:dispatch-macro-char #\# #\: #'(lambda (stream char1 char2)
                                     (declare (ignore char1 char2))
                                     (intern (string-upcase (string (read stream))) "KEYWORD"))))
+
+(defreadtable ospama::scheme-writer-syntax
+  (:merge :standard)
+  ;; (:case :preserve)
+  (:macro-char #\[ #'(lambda (stream char)
+                       (declare (ignore char))
+                       (read-delimited-list #\] stream)))
+  (:macro-char #\# :dispatch)
+  (:dispatch-macro-char #\# #\t #'(lambda (stream char1 char2)
+                                    (declare (ignore stream char1 char2))
+                                    'ospama::\#t))
+  (:dispatch-macro-char #\# #\f #'(lambda (stream char1 char2)
+                                    (declare (ignore stream char1 char2))
+                                    'ospama::\#f)))

--- a/libraries/ospama/tests/test-generic.lisp
+++ b/libraries/ospama/tests/test-generic.lisp
@@ -3,6 +3,7 @@
 (prove:plan nil)
 
 (defvar *test-package-name* "hello")
+(defvar *test-complex-package-name* "nyxt")
 
 (prove:subtest "Package list"
   (prove:ok (< 0 (length (ospama:list-packages))))
@@ -11,6 +12,14 @@
 (prove:subtest "Find package"
   (prove:is (ospama:name (ospama:find-os-package *test-package-name*))
             *test-package-name*))
+
+(prove:subtest "Package inputs"
+  (let* ((pkg (ospama:find-os-package *test-complex-package-name*))
+         (all-inputs (append
+                      (ospama:inputs pkg)
+                      (ospama:propagated-inputs pkg)
+                      (ospama:native-inputs pkg))))
+    (prove:ok (mapc #'ospama:find-os-package all-inputs))))
 
 (prove:subtest "List profiles"
   (prove:ok (uiop:directory-exists-p (first (ospama:list-profiles)))))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -303,7 +303,8 @@
                nyxt/class-star)
   :pathname "libraries/ospama/"
   :components ((:file "package")
-               (:file "scheme-reader")
+               (:file "scheme-syntax")
+               (:file "guix-backend")
                (:file "ospama")
                (:file "ospama-guix"))
   :in-order-to ((test-op (test-op "nyxt/ospama/tests"))))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -291,9 +291,19 @@
                          (nyxt-run-test c "libraries/class-star/tests/")))
 
 (asdf:defsystem nyxt/ospama
-  :depends-on (alexandria cl-ppcre local-time osicat serapeum str nyxt/class-star)
+  :depends-on (alexandria
+               chanl
+               cl-ppcre
+               local-time
+               named-readtables
+               osicat
+               serapeum
+               str
+               trivia
+               nyxt/class-star)
   :pathname "libraries/ospama/"
   :components ((:file "package")
+               (:file "scheme-reader")
                (:file "ospama")
                (:file "ospama-guix"))
   :in-order-to ((test-op (test-op "nyxt/ospama/tests"))))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -292,7 +292,7 @@
 
 (asdf:defsystem nyxt/ospama
   :depends-on (alexandria
-               chanl
+               calispel
                cl-ppcre
                local-time
                named-readtables


### PR DESCRIPTION
While this patch does not add anything user-facing, it's very interesting on the development front.

- I manage the `guix repl` command as a server.  Check out how I combine `uiop:launch-program`, `bt:with-timeout` and channels to do this.  The timeout ensures we don't leave a dangling Guix process behind.  The benefit of a "server"?  Performance. 
  - Before: 50ms overhead per Guix request.  
  - After: 50ms on startup, 0ms overhead afterwards.
  In short, if I run 10 requests in a row, previously it would take 500ms while it only takes 50ms now, assuming the requests are trivial.
Bonus: no more need for intermediary temp files.

- I now parse the return values of the "guix server" instead of parsing the standard output.  So we don't have to `(format t ...)` the results anymore, which makes for much more idiomatic Scheme.

- I use named-readtable to read and write Scheme directly from Common Lisp.  No more need to escape `#t` or `#f` and we can use Scheme keywords directly (e.g. `#:foo`).  This also helps with portability since we don't have need compiler-dependent cl->scheme string transformations anymore.
