### PR TITLE
Asd refactor

### DIFF
--- a/.github/workflows/package-ubuntu.yml
+++ b/.github/workflows/package-ubuntu.yml
@@ -32,10 +32,9 @@ jobs:
         sudo apt-get install -y ruby ruby-dev rubygems dpkg-dev sbcl curl git-core zlib1g-dev
         sudo apt-get install -y libfixposix0 libfixposix-dev libwebkit2gtk-4.0-dev glib-networking gsettings-desktop-schemas xclip notify-osd enchant
 
-    - name: Fetch Common Lisp third-party dependencies
+    - name: Register Common Lisp third-party dependencies location
       shell: bash
       run: |
-        make quicklisp-extra-libs
         mkdir -p ~/.config/common-lisp/source-registry.conf.d/
         echo "(:tree \"$PWD/quicklisp-libraries\")" >> ~/.config/common-lisp/source-registry.conf.d/asdf.conf
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,10 +56,10 @@ jobs:
       shell: bash
       run: ros -e "(ql:update-all-dists :prompt nil)"
 
-    - name: Fetch Common Lisp third-party dependencies
+    - name: Register Common Lisp third-party dependencies location
       shell: bash
       run: |
-        make quicklisp-extra-libs
+        mkdir -p ~/.config/common-lisp/source-registry.conf.d/
         echo "(:tree \"$PWD/quicklisp-libraries\")" > ~/.config/common-lisp/source-registry.conf.d/asdf.conf
 
     - name: Load system and run tests
@@ -68,7 +68,7 @@ jobs:
       env:
        NYXT_TESTS_ERROR_ON_FAIL: yes
       run: |
-        ros -e '(handler-bind (#+asdf3.2 (asdf:bad-system-name (function MUFFLE-WARNING))) (handler-case (ql:quickload :nyxt/tests) (error (a) (format t "caught error ~s~%~a~%" a a) (uiop:quit 17))))' -e '(asdf:test-system :nyxt)'
+        ros -e '(push :nyxt-internal-quicklisp *features*)' -e '(asdf:test-system :nyxt)'
 
     - name: Compilation warnings
       shell: bash

--- a/INSTALL
+++ b/INSTALL
@@ -1,8 +1,8 @@
 Usage:
 
-   make all                 Create Nyxt.
-   make install             Install Nyxt.
-   make doc                 Generate Nyxt documentation (as a fallback).
+    make all                 # Create Nyxt.
+    make install             # Install Nyxt.
+    make doc                 # Generate Nyxt documentation (as a fallback).
 
 Set DESTDIR to change the target destinatation.  It should be
 an absolute path.
@@ -32,7 +32,7 @@ Otherwise, the dependencies will have to be locally installed
 on your system.  You may have to accomodate the LISP_FLAGS
 to, use your local install of Quicklisp.  For example:
 
-make all NYXT_INTERNAL_QUICKLISP=false LISP_FLAGS=
+    make all NYXT_INTERNAL_QUICKLISP=false LISP_FLAGS=
 
 WARNING: Make sure your Quicklisp distribution is up-to-date when using
 NYXT_INTERNAL_QUICKLISP=false.  Also check the .gitmodules file for Common Lisp

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ clean-fasls:
 	$(LISP) $(LISP_FLAGS) \
 		--eval '(require "asdf")' \
 		--load $(QUICKLISP_DIR)/setup.lisp \
-		--load nyxt.asd \
+		--eval '(asdf:load-asd "nyxt.asd")' \
 		--eval '(ql:quickload :swank)' \
 		--eval '(load (merge-pathnames  "contrib/swank-asdf.lisp" swank-loader:*source-directory*))' \
 		--eval '(swank:delete-system-fasls "nyxt")' \
@@ -45,7 +45,7 @@ application: deps
 	env NYXT_INTERNAL_QUICKLISP=$(NYXT_INTERNAL_QUICKLISP) $(LISP) $(LISP_FLAGS) \
 		--eval '(require "asdf")' \
 		--eval '$(quicklisp_maybe_load)' \
-		--load nyxt.asd \
+		--eval '(asdf:load-asd "nyxt.asd")' \
 		--eval '(asdf:make :nyxt/$(NYXT_RENDERER)-application)' \
 		--eval '(uiop:quit)' || (printf "\n%s\n%s\n" "Compilation failed, see the above stacktrace." && exit 1)
 
@@ -75,7 +75,7 @@ version: deps
 	env NYXT_INTERNAL_QUICKLISP=$(NYXT_INTERNAL_QUICKLISP) $(LISP) $(LISP_FLAGS) \
 		--eval '(require "asdf")' \
 		--eval '$(quicklisp_maybe_load)' \
-		--load nyxt.asd \
+		--eval '(asdf:load-asd "nyxt.asd")' \
 		--eval '(asdf:load-system :nyxt)' \
 		--eval '(with-open-file (stream "version" :direction :output :if-exists :supersede) (format stream "~a" nyxt:+version+))' \
 		--eval '(uiop:quit)'
@@ -125,7 +125,7 @@ build-deps: quicklisp-extra-libs
 		--eval '(require "asdf")' \
 		--load $(QUICKLISP_DIR)/setup.lisp \
 		--eval '$(quicklisp_set_dir)' \
-		--load nyxt.asd \
+		--eval '(asdf:load-asd "nyxt.asd")' \
 		--eval '(ql:quickload :nyxt/$(NYXT_RENDERER)-application)' \
 		--eval '(uiop:quit)' || true
 	$(MAKE) quicklisp-update
@@ -140,7 +140,7 @@ doc:
 	env NYXT_INTERNAL_QUICKLISP=$(NYXT_INTERNAL_QUICKLISP) $(LISP) $(LISP_FLAGS) \
 		--eval '(require "asdf")' \
 		--eval '$(quicklisp_maybe_load)' \
-		--load nyxt.asd \
+		--eval '(asdf:load-asd "nyxt.asd")' \
 		--eval '(asdf:load-system :nyxt/documentation)' \
 		--eval '(uiop:quit)'
 
@@ -154,7 +154,7 @@ check-asdf: deps
 	env NYXT_INTERNAL_QUICKLISP=$(NYXT_INTERNAL_QUICKLISP) $(LISP) $(LISP_FLAGS) \
 		--eval '(require "asdf")' \
 		--eval '$(quicklisp_maybe_load)' \
-		--load nyxt.asd \
+		--eval '(asdf:load-asd "nyxt.asd")' \
 		--eval '(asdf:test-system :nyxt)' \
 		--eval '(uiop:quit)'
 

--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,12 @@ endif
 ## right version number.  Since "version" is a file target, third-party
 ## packaging systems can choose to generate "version" in advance before calling
 ## "make install-assets", so that they won't need to rely on Quicklisp.
-version: deps
+version:
 	env NYXT_INTERNAL_QUICKLISP=$(NYXT_INTERNAL_QUICKLISP) $(LISP) $(LISP_FLAGS) \
 		--eval '(require "asdf")' \
 		--eval '$(quicklisp_maybe_load)' \
 		--eval '(asdf:load-asd "nyxt.asd")' \
-		--eval '(asdf:load-system :nyxt)' \
-		--eval '(with-open-file (stream "version" :direction :output :if-exists :supersede) (format stream "~a" nyxt:+version+))' \
+		--eval '(asdf:make :nyxt/version)' \
 		--eval '(uiop:quit)'
 
 .PHONY: install-assets

--- a/Makefile
+++ b/Makefile
@@ -27,17 +27,9 @@ lisp_eval:=$(LISP) $(LISP_FLAGS) \
 	--eval '(asdf:load-asd "nyxt.asd")' --eval
 lisp_quit:=--eval '(uiop:quit)'
 
-## TODO: Move clean-fasls to .asd.
 .PHONY: clean-fasls
 clean-fasls:
-	$(NYXT_INTERNAL_QUICKLISP) && \
-	$(LISP) $(LISP_FLAGS) \
-		--eval '(require "asdf")' \
-		--eval '(asdf:load-asd "nyxt.asd")' \
-		--eval '(ql:quickload :swank)' \
-		--eval '(load (merge-pathnames  "contrib/swank-asdf.lisp" swank-loader:*source-directory*))' \
-		--eval '(swank:delete-system-fasls "nyxt")' \
-		--eval '(uiop:quit)' || true
+	$(lisp_eval) '(asdf:make :nyxt/clean-fasls)' $(lisp_quit)
 
 nyxt:
 	$(lisp_eval) '(asdf:make :nyxt/$(NYXT_RENDERER)-application)' \

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,12 @@ APPLICATIONSDIR = /Applications
 help:
 	@cat INSTALL
 
+makefile_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 lisp_eval:=$(LISP) $(LISP_FLAGS) \
 	--eval '(require "asdf")' \
 	--eval '(when (string= "true" "$(NYXT_INTERNAL_QUICKLISP)") (push :nyxt-internal-quicklisp *features*))' \
-	--eval '(asdf:load-asd "nyxt.asd")' --eval
+	--eval '(asdf:load-asd "$(makefile_dir)/nyxt.asd")' --eval
 lisp_quit:=--eval '(uiop:quit)'
 
 .PHONY: clean-fasls

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,6 @@ build-deps: quicklisp-extra-libs
 .PHONY: deps
 deps:
 	$(NYXT_INTERNAL_QUICKLISP) && $(MAKE) build-deps || true
-	if [ $(basename "$(LISP)") = "sbcl" ]; then $(LISP) --no-userinit --non-interactive --eval '(assert-version->= 1 5 0)'; fi
 
 .PHONY: doc
 doc:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ lisp_quit:=--eval '(uiop:quit)'
 clean-fasls:
 	$(lisp_eval) '(asdf:make :nyxt/clean-fasls)' $(lisp_quit)
 
+.PHONY: nyxt
 nyxt:
 	$(lisp_eval) '(asdf:make :nyxt/$(NYXT_RENDERER)-application)' \
 		$(lisp_quit) || \
@@ -61,28 +62,10 @@ endif
 version:
 	$(lisp_eval) '(asdf:make :nyxt/version)' $(lisp_quit)
 
-## TODO: Move install-assets to .asd.
-.PHONY: install-assets
-install-assets: version
-	mkdir -p "$(DESTDIR)$(DATADIR)/applications/"
-	sed "s/VERSION/$$(cat version)/" assets/nyxt.desktop > "$(DESTDIR)$(DATADIR)/applications/nyxt.desktop"
-	rm version
-	for i in 16 32 128 256 512; do \
-		mkdir -p "$(DESTDIR)$(DATADIR)/icons/hicolor/$${i}x$${i}/apps/" ; \
-		cp -f assets/nyxt_$${i}x$${i}.png "$(DESTDIR)$(DATADIR)/icons/hicolor/$${i}x$${i}/apps/nyxt.png" ; \
-		done
-
-.PHONY: install-nyxt
-install-nyxt: nyxt
-	mkdir -p "$(DESTDIR)$(BINDIR)"
-	cp -f $< "$(DESTDIR)$(BINDIR)/"
-	chmod 755 "$(DESTDIR)$(BINDIR)/"$<
-
 .PHONY: install
-install:
-install:
 ifeq ($(UNAME), Linux)
-install: install-nyxt install-assets
+install:
+	$(lisp_eval) '(asdf:make :nyxt/install)' $(lisp_quit)
 endif
 ifeq ($(UNAME), Darwin)
 install: install-app-bundle

--- a/Makefile
+++ b/Makefile
@@ -135,17 +135,14 @@ deps:
 	$(NYXT_INTERNAL_QUICKLISP) && $(MAKE) build-deps || true
 	if [ $(basename "$(LISP)") = "sbcl" ]; then $(LISP) --no-userinit --non-interactive --eval '(assert-version->= 1 5 0)'; fi
 
-manual.html: $(lisp_files)
+.PHONY: doc
+doc:
 	env NYXT_INTERNAL_QUICKLISP=$(NYXT_INTERNAL_QUICKLISP) $(LISP) $(LISP_FLAGS) \
 		--eval '(require "asdf")' \
 		--eval '$(quicklisp_maybe_load)' \
 		--load nyxt.asd \
-		--eval '(asdf:load-system :nyxt)' \
-		--eval '(with-open-file  (out "manual.html" :direction :output) (write-string (nyxt::manual-content) out))' \
+		--eval '(asdf:load-system :nyxt/documentation)' \
 		--eval '(uiop:quit)'
-
-.PHONY: doc
-doc: manual.html
 
 .PHONY: check
 check: check-asdf check-binary

--- a/nyxt-ubuntu-package.asd
+++ b/nyxt-ubuntu-package.asd
@@ -1,10 +1,13 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
 ;; TODO: Can we move this file to build-scripts?  Looks like linux-packaging
 ;; fails to find the produced binary then.
 (defsystem "nyxt-ubuntu-package"
-  :defsystem-depends-on ("linux-packaging")
+  :defsystem-depends-on (linux-packaging)
   :class "linux-packaging:deb"
   :build-operation "linux-packaging:build-op"
-  :depends-on ("nyxt/gtk")
+  :depends-on (nyxt/gtk)
   :package-name "nyxt"
   :version #.(asdf:system-version (asdf:find-system :nyxt))
   :author #.(asdf:system-author (asdf:find-system :nyxt))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -1,4 +1,4 @@
-(defsystem :nyxt
+(defsystem "nyxt"
   :version "2" ; Pre-release 4
   :author "Atlas Engineer LLC"
   :homepage "https://nyxt.atlas.engineer"
@@ -146,20 +146,20 @@
        (uiop:getenv "NYXT_TESTS_ERROR_ON_FAIL")
        (uiop:quit 18)))
 
-(defsystem nyxt/tests
+(defsystem "nyxt/tests"
   :depends-on (nyxt prove)
   :perform (test-op (op c)
-                         (nyxt-run-test c "tests/")
-                         (nyxt-run-test c "tests-network-needed/" :network-needed-p t)))
+                    (nyxt-run-test c "tests/")
+                    (nyxt-run-test c "tests-network-needed/" :network-needed-p t)))
 
-(defsystem :nyxt/gtk
+(defsystem "nyxt/gtk"
   :depends-on (:nyxt
                :cl-cffi-gtk
                :cl-webkit2)
   :pathname "source/"
   :components ((:file "renderer-gtk")))
 
-(defsystem :nyxt/qt
+(defsystem "nyxt/qt"
   :depends-on (:nyxt
                :cl-webengine
                :trivial-main-thread)
@@ -175,13 +175,13 @@
 ;; The workaround is to set a new dummy system of which the sole purpose is to
 ;; produce the desired binary.
 
-(defsystem :nyxt/gtk-application
+(defsystem "nyxt/gtk-application"
   :depends-on (:nyxt/gtk)
   :build-operation "program-op"
   :build-pathname "nyxt"
   :entry-point "nyxt:entry-point")
 
-(defsystem :nyxt/qt-application
+(defsystem "nyxt/qt-application"
   :depends-on (:nyxt/qt)
   :build-operation "program-op"
   :build-pathname "nyxt-qt"
@@ -193,7 +193,7 @@
                    :executable t
                    :compression (not (null (uiop:getenv "NYXT_COMPRESS")))))
 
-(defsystem nyxt/download-manager
+(defsystem "nyxt/download-manager"
   :depends-on (chanl
                cl-ppcre
                dexador
@@ -206,13 +206,13 @@
                (:file "native"))
   :in-order-to ((test-op (test-op "nyxt/download-manager/tests"))))
 
-(defsystem nyxt/download-manager/tests
+(defsystem "nyxt/download-manager/tests"
   :depends-on (nyxt/download-manager prove)
   :perform (test-op (op c)
-                         (nyxt-run-test c "libraries/download-manager/tests/"
-                                        :network-needed-p t)))
+                    (nyxt-run-test c "libraries/download-manager/tests/"
+                                   :network-needed-p t)))
 
-(defsystem nyxt/text-analysis
+(defsystem "nyxt/text-analysis"
   :depends-on (:str
                :serapeum
                :alexandria
@@ -225,30 +225,30 @@
                (:file "analysis")
                (:file "text-rank")))
 
-(defsystem nyxt/user-interface
+(defsystem "nyxt/user-interface"
   :depends-on (:cl-markup)
   :pathname "libraries/user-interface/"
   :components ((:file "package")
                (:file "user-interface")))
 
-(defsystem nyxt/text-buffer
+(defsystem "nyxt/text-buffer"
   :depends-on (:cluffer)
   :pathname "libraries/text-buffer/"
   :components ((:file "package")
                (:file "text-buffer")))
 
-(defsystem nyxt/history-tree
+(defsystem "nyxt/history-tree"
   :pathname "libraries/history-tree/"
   :components ((:file "package")
                (:file "history-tree"))
   :in-order-to ((test-op (test-op "nyxt/history-tree/tests"))))
 
-(defsystem nyxt/history-tree/tests
+(defsystem "nyxt/history-tree/tests"
   :depends-on (nyxt/history-tree prove)
   :perform (test-op (op c)
-                         (nyxt-run-test c "libraries/history-tree/tests/")))
+                    (nyxt-run-test c "libraries/history-tree/tests/")))
 
-(defsystem nyxt/password-manager
+(defsystem "nyxt/password-manager"
   :depends-on (bordeaux-threads
                cl-ppcre
                str
@@ -262,7 +262,7 @@
                ;; Keep password-store last so that it has higher priority.
                (:file "password-pass")))
 
-(defsystem nyxt/keymap
+(defsystem "nyxt/keymap"
   :depends-on (alexandria fset str)
   :pathname "libraries/keymap/"
   :components ((:file "package")
@@ -273,24 +273,24 @@
                (:file "scheme-names"))
   :in-order-to ((test-op (test-op "nyxt/keymap/tests"))))
 
-(defsystem nyxt/keymap/tests
+(defsystem "nyxt/keymap/tests"
   :depends-on (alexandria fset nyxt/keymap prove)
   :perform (test-op (op c)
-                         (nyxt-run-test c "libraries/keymap/tests/")))
+                    (nyxt-run-test c "libraries/keymap/tests/")))
 
-(defsystem nyxt/class-star
+(defsystem "nyxt/class-star"
   :depends-on (hu.dwim.defclass-star moptilities alexandria)
   :pathname "libraries/class-star/"
   :components ((:file "package")
                (:file "class-star"))
   :in-order-to ((test-op (test-op "nyxt/class-star/tests"))))
 
-(defsystem nyxt/class-star/tests
+(defsystem "nyxt/class-star/tests"
   :depends-on (nyxt/class-star prove)
   :perform (test-op (op c)
-                         (nyxt-run-test c "libraries/class-star/tests/")))
+                    (nyxt-run-test c "libraries/class-star/tests/")))
 
-(defsystem nyxt/ospama
+(defsystem "nyxt/ospama"
   :depends-on (alexandria cl-ppcre local-time osicat serapeum str nyxt/class-star)
   :pathname "libraries/ospama/"
   :components ((:file "package")
@@ -298,7 +298,7 @@
                (:file "ospama-guix"))
   :in-order-to ((test-op (test-op "nyxt/ospama/tests"))))
 
-(defsystem nyxt/ospama/tests
+(defsystem "nyxt/ospama/tests"
   :depends-on (nyxt/ospama prove)
   :perform (test-op (op c)
-                         (nyxt-run-test c "libraries/ospama/tests/tests.lisp")))
+                    (nyxt-run-test c "libraries/ospama/tests/tests.lisp")))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -224,7 +224,7 @@
 (defmethod perform ((o image-op) (c system))
   (uiop:dump-image (output-file o c)
                    :executable t
-                   :compression (not (null (uiop:getenv "NYXT_COMPRESS")))))
+                   :compression (uiop:getenv "NYXT_COMPRESS")))
 
 (defsystem "nyxt/download-manager"
   :depends-on (chanl

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -158,6 +158,19 @@
                     (nyxt-run-test c "tests/")
                     (nyxt-run-test c "tests-network-needed/" :network-needed-p t)))
 
+(defsystem "nyxt/version"
+  :depends-on (nyxt)
+  :output-files (compile-op (o c)
+                            (values (list (system-relative-pathname c "version"))
+                                    t))
+  :perform (compile-op (o c)
+                       (with-open-file (out (output-file o c)
+                                            :direction :output
+                                            :if-exists :supersede)
+                         (princ (symbol-value (find-symbol (string '+version+)
+                                                           (find-package 'nyxt)))
+                                out))))
+
 (defsystem "nyxt/documentation"         ; TODO: Only rebuild if input changed.
   :depends-on (nyxt)
   :output-files (compile-op (o c)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -1,3 +1,6 @@
+#+sbcl
+(sb-ext:assert-version->= 1 5 0)
+
 (defsystem "nyxt"
   :version "2" ; Pre-release 4
   :author "Atlas Engineer LLC"

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -152,6 +152,20 @@
                     (nyxt-run-test c "tests/")
                     (nyxt-run-test c "tests-network-needed/" :network-needed-p t)))
 
+(defsystem "nyxt/documentation"         ; TODO: Only rebuild if input changed.
+  :depends-on (nyxt)
+  :output-files (compile-op (o c)
+                            (values (list (system-relative-pathname c "manual.html"))
+                                    t))
+  :perform (compile-op (o c)
+                       (with-open-file (out (output-file o c)
+                                            :direction :output
+                                            :if-exists :supersede)
+                         (write-string (funcall (find-symbol (string 'manual-content)
+                                                             (find-package 'nyxt)))
+
+                                       out))))
+
 (defsystem "nyxt/gtk"
   :depends-on (nyxt
                cl-cffi-gtk

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -1,4 +1,4 @@
-(asdf:defsystem :nyxt
+(defsystem :nyxt
   :version "2" ; Pre-release 4
   :author "Atlas Engineer LLC"
   :homepage "https://nyxt.atlas.engineer"
@@ -142,24 +142,24 @@
   (and (or (not network-needed-p)
            (not (uiop:getenv "NYXT_TESTS_NO_NETWORK")))
        (not (funcall (read-from-string "prove:run")
-                     (asdf:system-relative-pathname c path)))
+                     (system-relative-pathname c path)))
        (uiop:getenv "NYXT_TESTS_ERROR_ON_FAIL")
        (uiop:quit 18)))
 
-(asdf:defsystem nyxt/tests
+(defsystem nyxt/tests
   :depends-on (nyxt prove)
-  :perform (asdf:test-op (op c)
+  :perform (test-op (op c)
                          (nyxt-run-test c "tests/")
                          (nyxt-run-test c "tests-network-needed/" :network-needed-p t)))
 
-(asdf:defsystem :nyxt/gtk
+(defsystem :nyxt/gtk
   :depends-on (:nyxt
                :cl-cffi-gtk
                :cl-webkit2)
   :pathname "source/"
   :components ((:file "renderer-gtk")))
 
-(asdf:defsystem :nyxt/qt
+(defsystem :nyxt/qt
   :depends-on (:nyxt
                :cl-webengine
                :trivial-main-thread)
@@ -175,25 +175,25 @@
 ;; The workaround is to set a new dummy system of which the sole purpose is to
 ;; produce the desired binary.
 
-(asdf:defsystem :nyxt/gtk-application
+(defsystem :nyxt/gtk-application
   :depends-on (:nyxt/gtk)
   :build-operation "program-op"
   :build-pathname "nyxt"
   :entry-point "nyxt:entry-point")
 
-(asdf:defsystem :nyxt/qt-application
+(defsystem :nyxt/qt-application
   :depends-on (:nyxt/qt)
   :build-operation "program-op"
   :build-pathname "nyxt-qt"
   :entry-point "nyxt:entry-point")
 
 #+sb-core-compression
-(defmethod asdf:perform ((o asdf:image-op) (c asdf:system))
-  (uiop:dump-image (asdf:output-file o c)
+(defmethod perform ((o image-op) (c system))
+  (uiop:dump-image (output-file o c)
                    :executable t
                    :compression (not (null (uiop:getenv "NYXT_COMPRESS")))))
 
-(asdf:defsystem nyxt/download-manager
+(defsystem nyxt/download-manager
   :depends-on (chanl
                cl-ppcre
                dexador
@@ -206,13 +206,13 @@
                (:file "native"))
   :in-order-to ((test-op (test-op "nyxt/download-manager/tests"))))
 
-(asdf:defsystem nyxt/download-manager/tests
+(defsystem nyxt/download-manager/tests
   :depends-on (nyxt/download-manager prove)
-  :perform (asdf:test-op (op c)
+  :perform (test-op (op c)
                          (nyxt-run-test c "libraries/download-manager/tests/"
                                         :network-needed-p t)))
 
-(asdf:defsystem nyxt/text-analysis
+(defsystem nyxt/text-analysis
   :depends-on (:str
                :serapeum
                :alexandria
@@ -225,30 +225,30 @@
                (:file "analysis")
                (:file "text-rank")))
 
-(asdf:defsystem nyxt/user-interface
+(defsystem nyxt/user-interface
   :depends-on (:cl-markup)
   :pathname "libraries/user-interface/"
   :components ((:file "package")
                (:file "user-interface")))
 
-(asdf:defsystem nyxt/text-buffer
+(defsystem nyxt/text-buffer
   :depends-on (:cluffer)
   :pathname "libraries/text-buffer/"
   :components ((:file "package")
                (:file "text-buffer")))
 
-(asdf:defsystem nyxt/history-tree
+(defsystem nyxt/history-tree
   :pathname "libraries/history-tree/"
   :components ((:file "package")
                (:file "history-tree"))
   :in-order-to ((test-op (test-op "nyxt/history-tree/tests"))))
 
-(asdf:defsystem nyxt/history-tree/tests
+(defsystem nyxt/history-tree/tests
   :depends-on (nyxt/history-tree prove)
-  :perform (asdf:test-op (op c)
+  :perform (test-op (op c)
                          (nyxt-run-test c "libraries/history-tree/tests/")))
 
-(asdf:defsystem nyxt/password-manager
+(defsystem nyxt/password-manager
   :depends-on (bordeaux-threads
                cl-ppcre
                str
@@ -262,7 +262,7 @@
                ;; Keep password-store last so that it has higher priority.
                (:file "password-pass")))
 
-(asdf:defsystem nyxt/keymap
+(defsystem nyxt/keymap
   :depends-on (alexandria fset str)
   :pathname "libraries/keymap/"
   :components ((:file "package")
@@ -273,24 +273,24 @@
                (:file "scheme-names"))
   :in-order-to ((test-op (test-op "nyxt/keymap/tests"))))
 
-(asdf:defsystem nyxt/keymap/tests
+(defsystem nyxt/keymap/tests
   :depends-on (alexandria fset nyxt/keymap prove)
-  :perform (asdf:test-op (op c)
+  :perform (test-op (op c)
                          (nyxt-run-test c "libraries/keymap/tests/")))
 
-(asdf:defsystem nyxt/class-star
+(defsystem nyxt/class-star
   :depends-on (hu.dwim.defclass-star moptilities alexandria)
   :pathname "libraries/class-star/"
   :components ((:file "package")
                (:file "class-star"))
   :in-order-to ((test-op (test-op "nyxt/class-star/tests"))))
 
-(asdf:defsystem nyxt/class-star/tests
+(defsystem nyxt/class-star/tests
   :depends-on (nyxt/class-star prove)
-  :perform (asdf:test-op (op c)
+  :perform (test-op (op c)
                          (nyxt-run-test c "libraries/class-star/tests/")))
 
-(asdf:defsystem nyxt/ospama
+(defsystem nyxt/ospama
   :depends-on (alexandria cl-ppcre local-time osicat serapeum str nyxt/class-star)
   :pathname "libraries/ospama/"
   :components ((:file "package")
@@ -298,7 +298,7 @@
                (:file "ospama-guix"))
   :in-order-to ((test-op (test-op "nyxt/ospama/tests"))))
 
-(asdf:defsystem nyxt/ospama/tests
+(defsystem nyxt/ospama/tests
   :depends-on (nyxt/ospama prove)
-  :perform (asdf:test-op (op c)
+  :perform (test-op (op c)
                          (nyxt-run-test c "libraries/ospama/tests/tests.lisp")))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -193,6 +193,15 @@
                        (funcall (read-from-string "ql:update-dist")
                                 "quicklisp" :prompt nil)))
 
+(defsystem "nyxt/clean-fasls"
+  :depends-on (swank)
+  :perform (compile-op (o c)
+                       (load (merge-pathnames
+                              "contrib/swank-asdf.lisp"
+                              (symbol-value
+                               (read-from-string "swank-loader:*source-directory*"))))
+                       (funcall (read-from-string "swank:delete-system-fasls") "nyxt")))
+
 (defsystem "nyxt/version"
   :depends-on (nyxt)
   :output-files (compile-op (o c)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -5,49 +5,49 @@
   :description "Extensible web-browser in Common Lisp"
   :license "BSD 3-Clause"
   :serial t
-  :depends-on (:alexandria
-               :bordeaux-threads
-               :chanl
-               :cl-css
-               :cl-json
-               :cl-markup
-               :cl-ppcre
-               :cl-ppcre-unicode
-               :cl-prevalence
-               :closer-mop
-               :cl-containers
-               :moptilities
-               :dexador
-               :enchant
-               :iolib
-               :local-time
-               :log4cl
-               :mk-string-metrics
+  :depends-on (alexandria
+               bordeaux-threads
+               chanl
+               cl-css
+               cl-json
+               cl-markup
+               cl-ppcre
+               cl-ppcre-unicode
+               cl-prevalence
+               closer-mop
+               cl-containers
+               moptilities
+               dexador
+               enchant
+               iolib
+               local-time
+               log4cl
+               mk-string-metrics
                #-darwin
-               :osicat
-               :parenscript
-               :quri
-               :serapeum
-               :str
-               :plump
-               :swank
-               :trivia
-               :trivial-clipboard
-               :trivial-features
-               :trivial-package-local-nicknames
-               :trivial-types
-               :unix-opts
-               :usocket
+               osicat
+               parenscript
+               quri
+               serapeum
+               str
+               plump
+               swank
+               trivia
+               trivial-clipboard
+               trivial-features
+               trivial-package-local-nicknames
+               trivial-types
+               unix-opts
+               usocket
                ;; Local systems:
-               :nyxt/user-interface
-               :nyxt/text-buffer
-               :nyxt/text-analysis
-               :nyxt/download-manager
-               :nyxt/history-tree
-               :nyxt/password-manager
-               :nyxt/keymap
-               :nyxt/class-star
-               :nyxt/ospama)
+               nyxt/user-interface
+               nyxt/text-buffer
+               nyxt/text-analysis
+               nyxt/download-manager
+               nyxt/history-tree
+               nyxt/password-manager
+               nyxt/keymap
+               nyxt/class-star
+               nyxt/ospama)
   :pathname "source/"
   :components ((:file "package")
                ;; Independent utilities
@@ -153,16 +153,16 @@
                     (nyxt-run-test c "tests-network-needed/" :network-needed-p t)))
 
 (defsystem "nyxt/gtk"
-  :depends-on (:nyxt
-               :cl-cffi-gtk
-               :cl-webkit2)
+  :depends-on (nyxt
+               cl-cffi-gtk
+               cl-webkit2)
   :pathname "source/"
   :components ((:file "renderer-gtk")))
 
 (defsystem "nyxt/qt"
-  :depends-on (:nyxt
-               :cl-webengine
-               :trivial-main-thread)
+  :depends-on (nyxt
+               cl-webengine
+               trivial-main-thread)
   :pathname "source/"
   :components ((:file "renderer-qt")))
 
@@ -176,13 +176,13 @@
 ;; produce the desired binary.
 
 (defsystem "nyxt/gtk-application"
-  :depends-on (:nyxt/gtk)
+  :depends-on (nyxt/gtk)
   :build-operation "program-op"
   :build-pathname "nyxt"
   :entry-point "nyxt:entry-point")
 
 (defsystem "nyxt/qt-application"
-  :depends-on (:nyxt/qt)
+  :depends-on (nyxt/qt)
   :build-operation "program-op"
   :build-pathname "nyxt-qt"
   :entry-point "nyxt:entry-point")
@@ -213,10 +213,10 @@
                                    :network-needed-p t)))
 
 (defsystem "nyxt/text-analysis"
-  :depends-on (:str
-               :serapeum
-               :alexandria
-               :cl-ppcre)
+  :depends-on (str
+               serapeum
+               alexandria
+               cl-ppcre)
   :pathname "libraries/text-analysis/"
   :components ((:file "package")
                (:file "data")
@@ -226,13 +226,13 @@
                (:file "text-rank")))
 
 (defsystem "nyxt/user-interface"
-  :depends-on (:cl-markup)
+  :depends-on (cl-markup)
   :pathname "libraries/user-interface/"
   :components ((:file "package")
                (:file "user-interface")))
 
 (defsystem "nyxt/text-buffer"
-  :depends-on (:cluffer)
+  :depends-on (cluffer)
   :pathname "libraries/text-buffer/"
   :components ((:file "package")
                (:file "text-buffer")))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -1,3 +1,6 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
 #+sbcl
 (sb-ext:assert-version->= 1 5 0)
 


### PR DESCRIPTION
This does mostly 2 things:

- Stick to ASDF conventions (mostly), use consistent style.
- Move most Makefile operations to `nyxt.asd`.

I've kept most Makefile rules for backward compatibility.  They just call to their .asd counterpart.

Result: The Makefile lost about 100 lines of difficult syntax, thus shrinking to about half its size (barely 90 lines).  We can now control every build rule in Lisp!

After all, why would we use `make` while we have ASDF? :)

Tip: Look at the individual commits, it will make this review easier.