### PR TITLE
Ospama multiversion

### DIFF
--- a/libraries/class-star/package.lisp
+++ b/libraries/class-star/package.lisp
@@ -14,4 +14,6 @@
            #:no-unbound-initform-inference
            #:nil-fallback-initform-inference
            #:*type-inference*
-           #:basic-type-inference))
+           #:basic-type-inference
+           #:*predicate-name-transformer*
+           #:*export-predicate-name-p*))

--- a/libraries/class-star/readme.org
+++ b/libraries/class-star/readme.org
@@ -1,9 +1,10 @@
 This library enhances the class definition idiom with saner defaults and more
-slot and class options.  It wraps around the =hu.dwim.defclass-star= macro and
-adds a few more features:
+slot and class options.  It wraps around the =hu.dwim.defclass-star= macro,
+fixes a few bugs and adds a few more features:
 
 - initform customization (such as zero values);
-- type inference (optionally errors out when type cannot be inferred).
+- type inference (optionally errors out when type cannot be inferred);
+- predicate generation and customization (just like defstruct).
 
 Metaclasses would not be very useful here since most of our features need to be
 enacted at compile-time, while metaclasses are mostly useful on classe
@@ -26,6 +27,7 @@ read slots by their name, not by their properties).
   position, right after the slot name.
 - Class option to toggle the default slot exportation.
 - The `:export' slot option allows to specify the exportation of individual slots.
+- Implicit, customizable predicate generator.
 
 * Examples
 

--- a/libraries/ospama/ospama-guix.lisp
+++ b/libraries/ospama/ospama-guix.lisp
@@ -317,10 +317,17 @@ for non-standard profiles."
   (declare (ignore manager))
   (setf *guix-database* nil))
 
-(defmethod install-command ((manager guix-manager) profile)
-  (append (list (path manager) "install")
-          (when profile
-            (list (str:concat "--profile=" (namestring profile))))))
+(defmethod manager-install ((manager guix-manager) output-list &optional profile)
+  (run (append (list (path manager) "install")
+               (mapcar (lambda (output)
+                         (let ((package (parent-package output)))
+                           (format nil "~a@~a:~a"
+                                   (name package)
+                                   (version package)
+                                   (name output))))
+                       output-list)
+               (when profile
+                 (list (str:concat "--profile=" (namestring profile)))))))
 
 (defmethod manager-install-manifest ((manager guix-manager) manifest &optional profile)
   (run (append (list (path manager) "package"

--- a/libraries/ospama/ospama-guix.lisp
+++ b/libraries/ospama/ospama-guix.lisp
@@ -25,9 +25,6 @@ This can only be derived if `path' has been derived."))
   (:documentation "OS package outputs are meaningful mostly for functional
 package managers like Nix or Guix."))
 
-(defun guix-package-output-p (object)
-  (mopu:subclassp (class-of object) 'guix-package-output))
-
 (detect-manager "guix" 'guix-manager)
 
 (defmethod print-object ((obj (eql 'ospama::\#t)) stream)
@@ -158,9 +155,6 @@ value.
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:accessor-name-transformer #'class*:name-identity))
-
-(defun guix-package-p (object)
-  (mopu:subclassp (class-of object) 'guix-package))
 
 (export-always 'expanded-output-p)
 (defun expanded-output-p (output)

--- a/libraries/ospama/ospama-guix.lisp
+++ b/libraries/ospama/ospama-guix.lisp
@@ -208,8 +208,8 @@ value.
           (mapcar #'make-guix-package (generate-database))))
   *guix-database*)
 
-(defmethod manager-find-os-package ((manager guix-manager) name)
-  (find name (guix-database) :key #'name :test #'string=))
+(defmethod manager-find-os-packages ((manager guix-manager) name)
+  (remove name (guix-database) :key #'name :test #'string/=))
 
 (defmethod manager-list-packages ((manager guix-manager) &optional profile)
   (if profile

--- a/libraries/ospama/ospama.lisp
+++ b/libraries/ospama/ospama.lisp
@@ -164,11 +164,11 @@ With INCLUDE-MANAGER-P, also return the package manager own profile."))
   (:documentation "Delete GENERATIONS from PROFILE."))
 
 (export-always 'install)
-(defun install (package-list &optional profile)
-  (manager-install (manager) package-list profile))
+(defun install (package-or-output-list &optional profile)
+  (manager-install (manager) package-or-output-list profile))
 
-(defmethod manager-install ((manager manager) package-list &optional profile)
-  (run (append (install-command manager profile) (mapcar #'name package-list))))
+(defmethod manager-install ((manager manager) package-or-output-list &optional profile)
+  (run (append (install-command manager profile) (mapcar #'name package-or-output-list))))
 
 (export-always 'install-command)
 (defgeneric install-command (manager profile)

--- a/libraries/ospama/ospama.lisp
+++ b/libraries/ospama/ospama.lisp
@@ -105,15 +105,17 @@ when PROFILE is specified."))
 This only needs to be implemented for package managers that support outputs."))
 
 (export-always 'find-os-packages)
-(defun find-os-packages (name)
-  (manager-find-os-packages (manager) name))
+(defun find-os-packages (name &key version)
+  (manager-find-os-packages (manager) name :version version))
 
-(defgeneric manager-find-os-packages (manager name) ; TODO: Optionally take a version and an output as key arg?
-  (:method ((manager manager) name)
-    (declare (ignorable name))
+(defgeneric manager-find-os-packages (manager name &key version)
+  (:method ((manager manager) name &key version)
+    (declare (ignorable name version))
     (error "Unspecified manager method"))
-  (:documentation "Return the packages matching NAME.
-There may be multiple packages, e.g. in case of multiple versions."))
+  (:documentation "Return the packages matching NAME and optionally VERSION.
+There may be multiple packages, e.g. in case of multiple versions.
+Even though at most one package should ever match a name-version pair,
+we return a list in all cases out of consistency."))
 
 (export-always 'list-profiles)
 (defun list-profiles (&key include-manager-p)

--- a/libraries/ospama/ospama.lisp
+++ b/libraries/ospama/ospama.lisp
@@ -104,15 +104,16 @@ when PROFILE is specified."))
   (:documentation "Return the list of all package outputs.
 This only needs to be implemented for package managers that support outputs."))
 
-(export-always 'find-os-package)
-(defun find-os-package (name)
-  (manager-find-os-package (manager) name))
+(export-always 'find-os-packages)
+(defun find-os-packages (name)
+  (manager-find-os-packages (manager) name))
 
-(defgeneric manager-find-os-package (manager name)
+(defgeneric manager-find-os-packages (manager name) ; TODO: Optionally take a version and an output as key arg?
   (:method ((manager manager) name)
     (declare (ignorable name))
     (error "Unspecified manager method"))
-  (:documentation "Return the package matching NAME."))
+  (:documentation "Return the packages matching NAME.
+There may be multiple packages, e.g. in case of multiple versions."))
 
 (export-always 'list-profiles)
 (defun list-profiles (&key include-manager-p)

--- a/libraries/ospama/readme.org
+++ b/libraries/ospama/readme.org
@@ -25,7 +25,7 @@ The library provides functions to interact with packages:
 
 - =list-files=
 
-- =find-os-package=
+- =find-os-packages=
 
 The following is mostly for functional package managers like Nix and Guix:
 

--- a/libraries/ospama/readme.org
+++ b/libraries/ospama/readme.org
@@ -6,7 +6,8 @@ Supported package managers:
 
 - [[https://guix.gnu.org][Guix]]
 
-It provides an =os-package= with children which specialize for various package managers.
+It provides an =os-package= class with subclsses which specialize for various
+package managers.
 
 If the package manager supports it, the class also includes the list of
 dependencies and dependents.

--- a/libraries/ospama/tests/test-functional.lisp
+++ b/libraries/ospama/tests/test-functional.lisp
@@ -5,6 +5,9 @@
 ;; Tests for functional package managers.
 
 (defvar *test-package-name* "hello")
+(defvar *test-package-with-outputs* "sbcl-slynk")
+(defvar *test-package-with-outputs-output* "image")
+
 (defvar *test-profile* (uiop:resolve-absolute-location ; TODO: Can we generate a temp dir in Common Lisp?
                         (list (uiop:temporary-directory) "ospama-tests/profile")))
 (defvar *test-manifest-file* (uiop:resolve-absolute-location 
@@ -28,6 +31,20 @@
     (prove:is (ospama:list-packages *test-profile*)
               nil
               "final profile is empty")))
+
+(prove:subtest "Install output"
+  (uiop:ensure-all-directories-exist
+   (list (uiop:pathname-directory-pathname *test-profile*)))
+  (let ((process-info (ospama:install (list (find *test-package-with-outputs-output*
+                                                  (ospama:outputs (first (ospama:find-os-packages *test-package-with-outputs*)))
+                                                  :key #'ospama:name
+                                                  :test #'string=))
+                                      *test-profile*)))
+    (uiop:wait-process process-info)
+    (prove:is (ospama:name (first (ospama:list-packages *test-profile*)))
+              *test-package-with-outputs-output*)
+    ;; TODO: Delete *test-profile* afterwards?
+    ))
 
 (prove:subtest "Install manifest to temp profile"
   (uiop:ensure-all-directories-exist

--- a/libraries/ospama/tests/test-functional.lisp
+++ b/libraries/ospama/tests/test-functional.lisp
@@ -15,7 +15,7 @@
 (prove:subtest "Install to temp profile"
   (uiop:ensure-all-directories-exist
    (list (uiop:pathname-directory-pathname *test-profile*)))
-  (let ((process-info (ospama:install (list (ospama:find-os-package *test-package-name*))
+  (let ((process-info (ospama:install (ospama:find-os-packages *test-package-name*)
                                       *test-profile*)))
     (uiop:wait-process process-info)
     (prove:is (ospama:name (ospama:parent-package
@@ -44,7 +44,7 @@
               *test-package-name*)))
 
 (prove:subtest "List files"
-  (let* ((output-list (ospama:outputs (ospama:find-os-package *test-package-name*)))
+  (let* ((output-list (ospama:outputs (first (ospama:find-os-packages *test-package-name*))))
          (file-list (ospama:list-files
                      (list (first output-list)))))
     (prove:is (pathname-name (first file-list))

--- a/libraries/ospama/tests/test-functional.lisp
+++ b/libraries/ospama/tests/test-functional.lisp
@@ -46,6 +46,23 @@
     ;; TODO: Delete *test-profile* afterwards?
     ))
 
+(defvar *test-package-with-versions* "libpng")
+(defvar *test-package-with-versions-version* "1.2.59")
+
+(prove:subtest "Install version"
+  (uiop:ensure-all-directories-exist
+   (list (uiop:pathname-directory-pathname *test-profile*)))
+  (let ((process-info (ospama:install (list (first (ospama:find-os-packages
+                                                    *test-package-with-versions*
+                                                    :version *test-package-with-versions-version*)))
+                                      *test-profile*)))
+    (uiop:wait-process process-info)
+    (prove:is (ospama:version (ospama:parent-package
+                               (first (ospama:list-packages *test-profile*))))
+              *test-package-with-versions-version*)
+    ;; TODO: Delete *test-profile* afterwards?
+    ))
+
 (prove:subtest "Install manifest to temp profile"
   (uiop:ensure-all-directories-exist
    (list (uiop:pathname-directory-pathname *test-profile*)

--- a/libraries/ospama/tests/test-generic.lisp
+++ b/libraries/ospama/tests/test-generic.lisp
@@ -4,7 +4,7 @@
 
 (defvar *test-package-name* "hello")
 (defvar *test-complex-package-name* "nyxt")
-(defvar *multi-version-package-name* "linux-libre")
+(defvar *test-multi-version-package-name* "linux-libre")
 
 (prove:subtest "Package list"
   (prove:ok (< 0 (length (ospama:list-packages))))
@@ -15,7 +15,7 @@
             *test-package-name*))
 
 (prove:subtest "Find multiple package versions"
-  (prove:ok (<= 2 (length (ospama:find-os-packages *multi-version-package-name*)))))
+  (prove:ok (<= 2 (length (ospama:find-os-packages *test-multi-version-package-name*)))))
 
 (prove:subtest "Package inputs"
   (let* ((pkg (first (ospama:find-os-packages *test-complex-package-name*)))

--- a/libraries/ospama/tests/test-generic.lisp
+++ b/libraries/ospama/tests/test-generic.lisp
@@ -4,6 +4,7 @@
 
 (defvar *test-package-name* "hello")
 (defvar *test-complex-package-name* "nyxt")
+(defvar *multi-version-package-name* "linux-libre")
 
 (prove:subtest "Package list"
   (prove:ok (< 0 (length (ospama:list-packages))))
@@ -12,6 +13,9 @@
 (prove:subtest "Find package"
   (prove:is (ospama:name (first (ospama:find-os-packages *test-package-name*)))
             *test-package-name*))
+
+(prove:subtest "Find multiple package versions"
+  (prove:ok (<= 2 (length (ospama:find-os-packages *multi-version-package-name*)))))
 
 (prove:subtest "Package inputs"
   (let* ((pkg (first (ospama:find-os-packages *test-complex-package-name*)))

--- a/libraries/ospama/tests/test-generic.lisp
+++ b/libraries/ospama/tests/test-generic.lisp
@@ -10,16 +10,16 @@
   (prove:ok (typep (first (ospama:list-packages)) 'ospama:os-package)))
 
 (prove:subtest "Find package"
-  (prove:is (ospama:name (ospama:find-os-package *test-package-name*))
+  (prove:is (ospama:name (first (ospama:find-os-packages *test-package-name*)))
             *test-package-name*))
 
 (prove:subtest "Package inputs"
-  (let* ((pkg (ospama:find-os-package *test-complex-package-name*))
+  (let* ((pkg (first (ospama:find-os-packages *test-complex-package-name*)))
          (all-inputs (append
                       (ospama:inputs pkg)
                       (ospama:propagated-inputs pkg)
                       (ospama:native-inputs pkg))))
-    (prove:ok (mapc #'ospama:find-os-package all-inputs))))
+    (prove:ok (mapc #'ospama:find-os-packages all-inputs))))
 
 (prove:subtest "List profiles"
   (prove:ok (uiop:directory-exists-p (first (ospama:list-profiles)))))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -219,6 +219,7 @@ Rules are kept in browser's `user-data', keyed by the expanded `auto-mode-rules-
                       :documentation "Path where `*error-output*' can be written to."))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
+  (:export-predicate-name-p t)
   (:accessor-name-transformer #'class*:name-identity))
 
 (define-user-class buffer)
@@ -246,7 +247,7 @@ The mode instances are stored in the `modes' slot.")
           :documentation "Proxy for buffer.")
    (certificate-exceptions '()
                            :type list-of-strings
-                           :documentation  "A list of hostnames for which certificate errors shall be ignored.")
+                           :documentation "A list of hostnames for which certificate errors shall be ignored.")
    (cookies-path (make-instance 'cookies-data-path :basename "cookies.txt")
                  :type data-path
                  :documentation "The path where cookies are stored.  Not all
@@ -258,6 +259,7 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
 `:no-third-party' (accept cookies for current website only)."))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
+  (:export-predicate-name-p t)
   (:accessor-name-transformer #'class*:name-identity))
 
 (define-user-class web-buffer)
@@ -265,10 +267,6 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
 (defmethod initialize-instance :after ((buffer web-buffer) &key)
   (when (expand-path (cookies-path buffer))
     (ensure-parent-exists (expand-path (cookies-path buffer)))))
-
-(export-always 'web-buffer-p)
-(defun web-buffer-p (buffer)
-  (subtypep (type-of buffer) 'web-buffer))
 
 (define-class internal-buffer (user-buffer)
   ((style #.(cl-css:css
@@ -317,6 +315,7 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                 :color "white")))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
+  (:export-predicate-name-p t)
   (:accessor-name-transformer #'class*:name-identity))
 
 (define-user-class internal-buffer)
@@ -396,16 +395,10 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                 :color "black")))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
+  (:export-predicate-name-p t)
   (:accessor-name-transformer #'class*:name-identity))
 
 (define-user-class status-buffer)
-
-(export-always 'internal-buffer-p)
-(defmethod internal-buffer-p ((buffer buffer))
-  nil)
-
-(defmethod internal-buffer-p ((internal-buffer internal-buffer))
-  t)
 
 (defmethod proxy ((buffer buffer))
   (slot-value buffer 'proxy))

--- a/source/os-package-manager-mode.lisp
+++ b/source/os-package-manager-mode.lisp
@@ -300,7 +300,7 @@ OBJECTS can be a list of packages, a generation, etc."
                    :suggestion-function (os-profile-suggestion-filter)
                    :input-prompt "Target profile"))
          (packages (prompt-minibuffer
-                    :suggestion-function (os-package-suggestion-filter)
+                    :suggestion-function (os-package-output-suggestion-filter)
                     :input-prompt "Install OS package(s)"
                     :multi-selection-p t)))
     (operate-os-package "Installing packages..." #'ospama:install profile packages)))


### PR DESCRIPTION
This fixes an important issue with Ospama's previous design: it adds multi-version packages support.

Bonuses:

- It fixes a bug in which it would fail when listing an installed package with a version that was not found in the current Guix package database.

- It's now possible to install any variation of a package `(version output)` pair.