### PR TITLE
Fix startup race condition when invoking the minibuffer.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -575,7 +575,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
     ;; Modes might require that buffer exists, so we need to initialize them
     ;; after the view has been created.
     (initialize-modes buffer)
-    (when dead-buffer
+    (when dead-buffer                   ; TODO: URL should be already set.  Useless?
       (setf (url buffer) (url dead-buffer)))
     (buffers-set (id buffer) buffer)
     ;; Run hooks before `initialize-modes' to allow for last-minute modification

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -320,6 +320,11 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
 
 (define-user-class internal-buffer)
 
+(defun make-dummy-buffer ()
+  ;; Internal buffers are lighter than full-blown buffers which can have a
+  ;; WebKit context, etc.
+  (make-instance 'user-internal-buffer))
+
 (define-class status-buffer (user-internal-buffer)
   ((height 20
            :type integer
@@ -642,7 +647,7 @@ proceeding."
   (let ((window-with-same-buffer (find buffer (delete window (window-list))
                                        :key #'active-buffer)))
     (if window-with-same-buffer ;; if visible on screen perform swap, otherwise just show
-        (let ((temp-buffer (make-instance 'user-buffer))
+        (let ((temp-buffer (make-dummy-buffer))
               (old-buffer (active-buffer window)))
           (log:debug "Swapping old buffer ~a with other window ~a to switch to ~a"
                      (object-string (url old-buffer))

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -46,6 +46,16 @@ Currently we store the list of current URLs of all buffers."
                                             (s-serialization:serialize-sexp (session-data) out)))
                 (read in))))))
 
+(defun make-buffer-from-history (history)
+  (let* ((buffer (make-buffer))
+         (mode (find-submode buffer 'web-mode))) ; TODO: This assumes BUFFER has web-mode.  What if it doesn't?
+    (setf (url buffer)
+          (ensure-url (url (htree:data (htree:current history)))))
+    (setf (title buffer)
+          (title (htree:data (htree:current history))))
+    (setf (slot-value buffer 'load-status) :unloaded)
+    (setf (nyxt/web-mode:history mode) history)))
+
 (defmethod restore ((profile data-profile) (path session-data-path))
   "Restore the current Nyxt session from the BUFFER's `session-path'."
   (handler-case
@@ -68,17 +78,17 @@ Currently we store the list of current URLs of all buffers."
            (log:info "Restoring ~a."
                      (mapcar (alex:compose #'object-string #'htree:data #'htree:current)
                              buffer-histories))
-           ;; Make the new ones.
-           ;; TODO: Replace the loop with a function `make-buffer-from-history' in web-mode?
-           (loop for history in buffer-histories
-                 for buffer = (make-buffer)
-                 for mode = (find-submode buffer 'web-mode) ; TODO: This assumes BUFFER has web-mode.  What if it doesn't?
-                 do (setf (url buffer)
-                          (ensure-url (url (htree:data (htree:current history)))))
-                 do (setf (title buffer)
-                          (title (htree:data (htree:current history))))
-                 do (setf (slot-value buffer 'load-status) :unloaded)
-                 do (setf (nyxt/web-mode:history mode) history))
+           (mapc (lambda (history)
+                   ;; Making multiple buffers (in particular WebKit contexts)
+                   ;; too rapidly may create collisions with libsoup.  We sleep a litle
+                   ;; to avoid collisions.
+                   ;; TODO: This is brittle.  Better: Only create the webview on demand.
+                   (sleep 0.05)
+                   (make-buffer-from-history history))
+                 buffer-histories)
+           (echo "Restored session of ~a URLs from ~s."
+                 (length buffer-histories)
+                 (expand-path path))
            ;; TODO: Switch to the last active buffer.  We probably need to serialize *browser*.
            ;; Or else we could include `access-time' in the buffer class.
            )))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -268,15 +268,14 @@ EXPR is expected to be as per the expression sent in `bind-socket-or-quit'."
           nil))))
 
 (export-always 'make-startup-function)
-(defun make-startup-function (&key (buffer-fn #'help))
+(defun make-startup-function (&key buffer-fn)
   "Return a function suitable as a `browser' `startup-function'.
 To change the default buffer, e.g. set it to a given URL:
 
   (make-startup-function
    :buffer-fn (lambda () (make-buffer :url \"https://example.org\")))"
   (lambda (&optional urls)
-    (let ((window (window-make *browser*))
-          (buffer (current-buffer)))
+    (let ((buffer (current-buffer)))
       ;; Restore session before opening command line URLs, otherwise it will
       ;; reset the session with the new URLs.
       (when (and (expand-path (session-path buffer))
@@ -288,9 +287,10 @@ To change the default buffer, e.g. set it to a given URL:
           (:always-restore (funcall-safely #'restore (data-profile buffer)
                                            (session-path buffer)))
           (:never-restore (log:info "Not restoring session."))))
-      (if urls
-          (open-urls urls)
-          (window-set-active-buffer window (funcall-safely buffer-fn))))
+      (cond
+        (urls (open-urls urls))
+        (buffer-fn
+         (window-set-active-buffer (current-window) (funcall-safely buffer-fn)))))
     (when (startup-error-reporter-function *browser*)
       (funcall-safely (startup-error-reporter-function *browser*)))))
 


### PR DESCRIPTION
Major change: `finalize' is now in charge for spawning the first window.
This should make `startup-function's much easier to write on the user end.