### PR TITLE
minor documentation fix: only web-buffer class has the 'load-status slot

### DIFF
--- a/source/window.lisp
+++ b/source/window.lisp
@@ -70,7 +70,8 @@ Example formatter that prints the buffer indices over the total number of buffer
              buffer-count
              (length (buffer-list)))
      (format nil \"~a~a — ~a\"
-            (if (eq (slot-value buffer 'load-status) :loading)
+            (if (and (web-buffer-p buffer)
+                     (eq (slot-value buffer 'load-status) :loading))
                 \"(Loading) \"
                 \"\")
             (object-display (url buffer))


### PR DESCRIPTION
As the `load-status` slot is in `web-buffer` class since 2-pre-release-2 nyxt version, the example of a `status-formatter` function in the documentation of the window class (in `source/window.lisp`) is currently buggy and will error out every time a non-web buffer is loaded (it will say that there is no slot like that in the `buffer` class). I think that the example should be corrected, adding a check if the buffer is a web buffer (it works perfectly fine with this check), and that's what this pull request is for.