### PR TITLE
Make javascript URLs follow-hint-able.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -822,7 +822,11 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
       (when new-url
         (check-type new-url quri:uri)
         (setf url new-url)
-        (ffi-buffer-load buffer url)))))
+        (if (string= (quri:uri-scheme new-url) "javascript")
+            ;; TODO: Can be a source of inefficiency due to an always-checked conditional.
+            ;; Move somewhere (`request-resource'?) where the impact of conditional will be weaker?
+            (ffi-buffer-evaluate-javascript buffer (quri:url-decode (quri:uri-path url)))
+            (ffi-buffer-load buffer url))))))
 
 (define-command set-url (&key new-buffer-p prefill-current-url-p)
   "Set the URL for the current buffer, completing with history."

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -29,8 +29,8 @@ On errors, return URL."
   ;; List of URI schemes: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
   ;; Last updated 2020-08-26.
   (let ((valid-schemes
-          (cons
-           "lisp"                       ; For Nyxt's internal URLs.
+          (append
+           '("lisp" "javascript")              ; For Nyxt's internal URLs and not-standardised ones.
            '("aaa" "aaas" "about" "acap" "acct" "cap" "cid" "coap" "coap+tcp" "coap+ws"
              "coaps" "coaps+tcp" "coaps+ws" "crid" "data" "dav" "dict" "dns" "example" "file"
              "ftp" "geo" "go" "gopher" "h323" "http" "https" "iax" "icap" "im" "imap" "info"


### PR DESCRIPTION
This enables `javascript:`-schemed URL to run properly when `follow-hint`-ed. 

# Caveats
- This complicates a frequently used `buffer-load` with yet another conditional branch. While [Epiphany does it the same way](https://github.com/GNOME/epiphany/blob/36ade6b01cf2084a26b453a1dc3f8ce0a77daf56/embed/ephy-web-view.c#L2771), I'm still not sure whether we should do it this way. Maybe a `request-resource` clause?

# How Has This Been Tested

- Nyxt runs alright with this patchset, `javascript:` URLs load after being `follow-hint`-ed.

How does it look to you?