### PR TITLE
Enable custom charset for hints.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -172,6 +172,11 @@ down.")
                               :font-weight "500"
                               :background "#fcff9e")))
                           :documentation "The style of highlighted boxes, e.g. link hints.")
+   (hints-alphabet "abcdefghijklmnopqrstuvwxyz"
+                   :type string
+                   :documentation "The alphabet (charset) to use for hints.
+Order matters -- the ones that go first are more likely to appear more often
+and to index the top of the page.")
    (buffer-load-hook (make-hook-uri->uri
                       :combination #'hooks:combine-composed-hook)
                      :type hook-uri->uri

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -95,26 +95,29 @@ identifier for every hinted element."
                                      (element-in-view-port-p (elt elements i))))
                        collect (object-create (elt elements i) (elt hints i)))))))
 
-  (defun hints-determine-chars-length (length)
+  (defun hints-determine-chars-length (length alphabet)
     "Finds out how many chars long the hints must be"
-    (floor (+ 1 (/ (log length) (log 26)))))
+    (floor (+ 1 (/ (log length) (log (ps:@ alphabet length))))))
 
   (defun hints-generate (length)
     "Generates hints that will appear on the elements"
-    (strings-generate length (hints-determine-chars-length length)))
+    (ps:let ((alphabet (ps:lisp (hints-alphabet (current-buffer)))))
+      (strings-generate length alphabet)))
 
-  (defun strings-generate (length chars-length)
+  (defun strings-generate (length alphabet)
     "Generates strings of specified length"
-    (ps:let ((minimum (1+ (ps:chain -math (pow 26 (- chars-length 1))))))
-      (loop for i from minimum to (+ minimum length)
-            collect (string-generate i))))
+    (ps:let ((chars-length (hints-determine-chars-length length alphabet)))
+      (ps:let ((minimum (1+ (ps:chain -math (pow (ps:@ alphabet length)
+                                                 (- chars-length 1))))))
+        (loop for i from minimum to (+ minimum length)
+              collect (string-generate i alphabet)))))
 
-  (defun string-generate (n)
+  (defun string-generate (n alphabet)
     "Generates a string from a number"
-    (if (>= n 0)
-        (+ (string-generate (floor (- (/ n 26) 1)))
-           (code-char (+ 65
-                         (rem n 26)))) ""))
+    (ps:let ((alphabet-length (ps:@ alphabet length)))
+      (if (>= n 0)
+          (+ (string-generate (floor (- (/ n alphabet-length) 1)) alphabet)
+             (aref alphabet (rem n alphabet-length))) "")))
 
   (add-stylesheet)
   (hints-add (qsa document (list "a" "button" "input" "textarea" "img"))))


### PR DESCRIPTION
This adds an option to customize the list of characters that `follow-hint` builds hints from. The most releaving use-case is rebinding this to the home row of whatever keyboard one uses (`"dsjkhlfagnmxcweio"` work like a charm on my QWERTY).

# What's New:
- `hints-alphabet` slot of `buffer` to set the alphabet for hints to compose labels from.
- Smal alterations to `hints-add` to support custom char indexing.

# How has this been tested
- I `follow-hint`-ed quite a lot of links on Wikipedia with the new aplphabet (`"dsjkhlfagnmxcweio"` mentioned above). It was comfortable :)

How do you like that?

Closes #527. 

EDIT: `follow-hinted` -> `follow-hint`-ed.
EDIT: Hints are no longer going missing.