### PR TITLE
Fix GHT startup race condition

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -221,8 +221,7 @@ editor executable."))
       (log:error "In *after-init-hook*: ~a" c)))
   ;; Most of the code assumes the existence of a window.  Let's create it here
   ;; so that the user does not have to bother with it in the `startup-function'.
-  (let ((window (window-make browser)))
-    (window-set-active-buffer window (help)))
+  (window-make browser)
   ;; The `startup-function' must be run _after_ this function returns;
   ;; `ffi-within-renderer-thread' runs its body on the renderer thread when it's
   ;; idle, so it should do the job.  It's not enough since the

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -121,7 +121,11 @@ window or not.")
                       :documentation "`local-time:timestamp' of when Nyxt was started.")
    (init-time 0.0
               :export nil
-              :documentation "Init time in seconds.")
+              :documentation "Initialization time in seconds.")
+   (ready-p nil
+            :reader ready-p
+            :documentation "If true, browser is ready for operation: make
+buffers, load data files, prompt minibuffer, etc.")
    (session-restore-prompt :always-ask
                            :documentation "Ask whether to restore the
 session. Possible values are :always-ask :always-restore :never-restore.")
@@ -233,7 +237,8 @@ editor executable."))
   ;; Set 'init-time at the end of finalize to take the complete startup time
   ;; into account.
   (setf (slot-value *browser* 'init-time)
-        (local-time:timestamp-difference (local-time:now) startup-timestamp)))
+        (local-time:timestamp-difference (local-time:now) startup-timestamp))
+  (setf (slot-value *browser* 'ready-p) t))
 
 ;; Catch a common case for a better error message.
 (defmethod buffers :before ((browser t))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -545,8 +545,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
                             :id (get-unique-buffer-identifier *browser*)
                             (append (when title `(:title ,title))
                                     (when default-modes `(:default-modes ,default-modes))
-                                    (when data-profile `(:data-profile ,data-profile))))))
-         (from-internal-p (internal-buffer-p (current-buffer))))
+                                    (when data-profile `(:data-profile ,data-profile)))))))
     (hooks:run-hook (buffer-before-make-hook *browser*) buffer)
     ;; Modes might require that buffer exists, so we need to initialize them
     ;; after the view has been created.
@@ -556,7 +555,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
     (buffers-set (id buffer) buffer)
     (unless no-history-p
       ;; Register buffer in global history:
-      (with-data-access (history (history-path (if from-internal-p buffer (current-buffer)))
+      (with-data-access (history (history-path buffer)
                          :default (make-history-tree buffer))
         ;; Owner may already exist if history was just create with the above
         ;; default value.

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -461,9 +461,10 @@ The version number is stored in the clipboard."
     (or (first (keymap:binding-keys fn keymaps))
         "UNBOUND")))
 
-(define-command help ()
+(define-command help (&key no-history-p)
   "Print help information."
-  (with-current-html-buffer (buffer "*Help*" 'nyxt/help-mode:help-mode)
+  (with-current-html-buffer (buffer "*Help*" 'nyxt/help-mode:help-mode
+                             :no-history-p no-history-p)
     (markup:markup
      (:style (style buffer))
      (:style (cl-css:css '((:h2

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -357,8 +357,6 @@ We keep this variable as a means to import the old format to the new one.")
                    (expand-path path))
              (setf (get-data path) history)
              (match (session-restore-prompt *browser*)
-               ;; Need `funcall-safely' so we continue if the user exits the
-               ;; minibuffer (which raises a condition).
                (:always-ask (if-confirm ("Restore session?")
                                         (restore-buffers history)))
                (:always-restore (restore-buffers history))

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -88,7 +88,9 @@ The function can be passed ARGS."
                                             (ps:lisp style)))))))
 
 (export-always 'with-current-html-buffer)
-(defmacro with-current-html-buffer ((buffer-var title mode) &body body)
+(defmacro with-current-html-buffer ((buffer-var title mode
+                                     &key no-history-p)
+                                    &body body)
   "Switch to a buffer in MODE displaying CONTENT.
 If a buffer in MODE with TITLE exists, reuse it, otherwise create a new buffer.
 BUFFER-VAR is bound to the new bufer in BODY.
@@ -100,7 +102,9 @@ BODY must return the HTML markup as a string."
                                     (buffer-list))
                            (funcall (symbol-function ,mode)
                                     :activate t
-                                    :buffer (make-internal-buffer :title ,title)))))
+                                    :buffer (make-internal-buffer
+                                             :title ,title
+                                             :no-history-p ,no-history-p)))))
      (html-set
       (progn
         ,@body)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -149,6 +149,7 @@ Example: --with-path bookmarks=/path/to/bookmarks
   (loop for window in (window-list)
         do (ffi-window-delete window))
   (ffi-kill-browser *browser*)
+  (setf (slot-value *browser* 'ready-p) nil)
   (when (socket-thread *browser*)
     (ignore-errors
      (bt:destroy-thread (socket-thread *browser*)))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -280,6 +280,7 @@ To change the default buffer, e.g. set it to a given URL:
   (make-startup-function
    :buffer-fn (lambda () (make-buffer :url \"https://example.org\")))"
   (lambda (&optional urls)
+    (window-set-active-buffer window (help))
     (let ((buffer (current-buffer)))
       ;; TODO: Select which history file to load.
       ;; Restore session before opening command line URLs, otherwise it will

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -280,16 +280,22 @@ To change the default buffer, e.g. set it to a given URL:
   (make-startup-function
    :buffer-fn (lambda () (make-buffer :url \"https://example.org\")))"
   (lambda (&optional urls)
-    (window-set-active-buffer window (help))
-    (let ((buffer (current-buffer)))
-      ;; TODO: Select which history file to load.
-      ;; Restore session before opening command line URLs, otherwise it will
-      ;; reset the session with the new URLs.
-      (get-user-data (data-profile buffer) (history-path buffer))
-      (cond
-        (urls (open-urls urls))
-        (buffer-fn
-         (window-set-active-buffer (current-window) (funcall-safely buffer-fn)))))
+    (let ((window (current-window)))
+      ;; Since this is the first buffer, we don't use any history for it:
+      ;; - it's not interesting;
+      ;; - most importantly because restoring the history may prompt the
+      ;; user which blocks further action such as the loading of the page,
+      ;; something we don't want for the startup.
+      (window-set-active-buffer window (help :no-history-p t))
+      (let ((buffer (current-buffer)))
+        ;; Restore session before opening command line URLs, otherwise it will
+        ;; reset the session with the new URLs.
+        ;; TODO: Select which history file to load.
+        (get-user-data (data-profile buffer) (history-path buffer))
+        (cond
+          (urls (open-urls urls))
+          (buffer-fn
+           (window-set-active-buffer window (funcall-safely buffer-fn))))))
     (when (startup-error-reporter-function *browser*)
       (funcall-safely (startup-error-reporter-function *browser*)))))
 


### PR DESCRIPTION
This should fix #1124.

Problem is similar to #1070.  This time we strengthen the browser to never prompt the minibuffer before it's done finalizing.
We also setup the `help` buffer with an extra parameter to tell it not to register the buffer to history, which allows the Help to show without being blocked by the prompt.

I've also removed the internal-buffer condition in https://github.com/atlas-engineer/nyxt/commit/478ef9aea88cbb4677fd64c369369612330f7501 since I don't think it's useful anymore.  @aartaka Can you confirm?

@duikboot Is this working for you?