### PR TITLE
Add better type checking to auto-mode with mode-invocation class.

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -12,40 +12,56 @@
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
   (trivial-package-local-nicknames:add-package-local-nickname :hooks :serapeum/contrib/hooks))
 
-(declaim (ftype (function ((or symbol root-mode list)) (values symbol &optional)) maybe-mode-name))
-(defun maybe-mode-name (mode)
-  (let ((mode (if (listp mode)
-                  (first mode)
-                  mode)))
-    (if (symbolp mode) mode (mode-name mode))))
+(define-class mode-invocation ()
+  ((name (error "Mode invocation should have a name to call mode through.")
+         :type symbol
+         :documentation "Mode symbol to call the mode with.
+Package prefix is optional.")
+   (arguments nil ;; TODO: "args" instead of "arguments"?
+              :type list
+              :documentation "Arguments to activate the mode with."))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(declaim (ftype (function ((or symbol root-mode list) (or symbol root-mode list)) boolean)
-                mode-equal))
-(defun mode-equal (mode1 mode2)
-  (string-equal (symbol-name (maybe-mode-name mode1))
-                (symbol-name (maybe-mode-name mode2))))
+(sera:export-always 'equals)
+(defmethod equals ((mode1 mode-invocation) (mode2 mode-invocation))
+  (string-equal (symbol-name (name mode1))
+                (symbol-name (name mode2))))
 
-(declaim (ftype (function ((or symbol root-mode list) (or root-mode null)) list)
+(defgeneric mode-invocation (mode)
+  (:method ((mode mode-invocation))
+    mode)
+  (:method ((mode nyxt:root-mode))
+    (make-instance 'mode-invocation :name (mode-name mode)))
+  (:method ((mode symbol))
+    (make-instance 'mode-invocation :name (nyxt::sym (nyxt::mode-command mode))))
+  (:method ((mode list))
+    (check-type mode (cons symbol *))
+    (make-instance 'mode-invocation
+                   :name (first mode)
+                   :args (rest mode))))
+
+(declaim (ftype (function (list (or auto-mode null))
+                          (or (cons mode-invocation *) null))
                 rememberable-of))
 (defun rememberable-of (modes auto-mode)
   "Filter MODES based on rememberability by AUTO-MODE."
   (if auto-mode
-      (set-difference modes (non-rememberable-modes auto-mode)
-                      :test #'mode-equal)
+      (set-difference (mapcar #'mode-invocation modes)
+                      (non-rememberable-modes auto-mode)
+                      :test #'equals)
       modes))
 
 (define-class auto-mode-rule ()
   ((test (error "Slot `test' should be set.")
          :type list)
    (included '()
-             :type list
-             :documentation "The list of modes to enable on rule activation.
-Here 'modes' can be either mode symbols or a list when the first element is the
-mode symbols and the rest are the arguments to pass to the mode initiatiation
-function.")
+             :type (or (cons mode-invocation *) null)
+             :documentation "The list of `mode-invocation's to enable on rule activation.")
    (excluded '()
-             :type list-of-symbols
-             :documentation "The list of mode symbols to disable on rule activation.")
+             :type (or (cons mode-invocation *) null)
+             :documentation "The list of `mode-invocation's to disable on rule activation.")
    (exact-p nil
             :documentation "If non-nil, enable the INCLUDED modes exclusively.
 Enable INCLUDED modes plus the already present ones, and disable EXCLUDED modes, if nil."))
@@ -73,17 +89,18 @@ Enable INCLUDED modes plus the already present ones, and disable EXCLUDED modes,
 (defun enable-matching-modes (url buffer)
   (let ((rule (matching-auto-mode-rule url buffer))
         (auto-mode (find-mode buffer 'auto-mode)))
-    (dolist (modes+args (mapcar #'alex:ensure-list
-                                (set-difference
-                                 (included rule)
-                                 (rememberable-of (modes buffer) auto-mode)
-                                 :test #'mode-equal)))
-      (enable-modes (list (first modes+args)) buffer (rest modes+args)))
-    (disable-modes (if (exact-p rule)
-                       (set-difference
-                        (rememberable-of (modes buffer) auto-mode)
-                        (included rule) :test #'mode-equal)
-                       (excluded rule))
+    (dolist (mode-invocation (set-difference
+                               (included rule)
+                               (rememberable-of (modes buffer) auto-mode)
+                               :test #'equals))
+      (check-type mode-invocation mode-invocation)
+      (enable-modes (list (name mode-invocation)) buffer (arguments mode-invocation)))
+    (disable-modes (mapcar #'name
+                           (if (exact-p rule)
+                               (set-difference
+                                (rememberable-of (modes buffer) auto-mode)
+                                (included rule) :test #'equals)
+                               (excluded rule)))
                    buffer)))
 
 (defun can-save-last-active-modes (auto-mode url)
@@ -92,23 +109,21 @@ Enable INCLUDED modes plus the already present ones, and disable EXCLUDED modes,
 
 (defun save-last-active-modes (auto-mode url)
   (when (can-save-last-active-modes auto-mode url)
-    ;; `last-active-modes' must be a list separate from the mode list, otherwise
-    ;; when modes get modified, last-active-modes would also be altered.
-    (setf (last-active-modes auto-mode) (copy-list (modes (buffer auto-mode)))
+    (setf (last-active-modes auto-mode) (mapcar #'mode-invocation (modes (buffer auto-mode)))
           (last-active-modes-url auto-mode) url)))
 
 (defun reapply-last-active-modes (auto-mode)
   (disable-modes
-   (mapcar #'maybe-mode-name
-           (set-difference (modes (buffer auto-mode))
+   (mapcar #'name
+           (set-difference (mapcar #'mode-invocation (modes (buffer auto-mode)))
                            (last-active-modes auto-mode)
-                           :test #'mode-equal))
+                           :test #'equals))
    (buffer auto-mode))
   (enable-modes
-   (mapcar #'maybe-mode-name
+   (mapcar #'name
            (set-difference (last-active-modes auto-mode)
-                           (modes (buffer auto-mode))
-                           :test #'mode-equal))
+                           (mapcar #'mode-invocation (modes (buffer auto-mode)))
+                           :test #'equals))
    (buffer auto-mode)))
 
 (defun new-page-request-p (request-data)
@@ -123,9 +138,10 @@ non-new-page requests, buffer URL is not altered."
 (defun auto-mode-handler (request-data)
   (with-data-lookup (history (history-path (buffer request-data)))
     (let* ((auto-mode (find-submode (buffer request-data) 'auto-mode))
-           (previous-url
-             (when (ignore-errors (htree:parent (htree:current-owner-node history)))
-               (url (htree:data (htree:parent (htree:current-owner-node history))))))
+           (previous-url (sera:and-let* ((owner (htree:current-owner-node history))
+                                         (parent (htree:parent owner))
+                                         (url (url (htree:data parent))))
+                           url))
            (rule (matching-auto-mode-rule (url request-data) (buffer request-data)))
            (previous-rule (when previous-url (matching-auto-mode-rule previous-url (buffer request-data)))))
       (when (and rule previous-url (not previous-rule))
@@ -137,19 +153,23 @@ non-new-page requests, buffer URL is not altered."
          (enable-matching-modes (url request-data) (buffer request-data))))))
   request-data)
 
+(declaim (ftype (function (root-mode auto-mode boolean) list)
+                mode-covered-by-auto-mode-p))
 (defun mode-covered-by-auto-mode-p (mode auto-mode enable-p)
-  (or (member mode (non-rememberable-modes auto-mode) :test #'mode-equal)
-      (let ((matching-rule (matching-auto-mode-rule
-                            (url (buffer auto-mode))
-                            (buffer auto-mode))))
-        (member mode (or (and matching-rule (union (included matching-rule)
-                                                   (excluded matching-rule)))
-                         ;; Mode is covered by auto-mode only if it is
-                         ;; in last-active-modes and gets enabled.
-                         ;; If it gets disabled, user should be prompted,
-                         ;; because they may want to persist it.
-                         (and enable-p (last-active-modes auto-mode)))
-                :test #'mode-equal))))
+  (let ((invocation (mode-invocation mode)))
+    (or (member invocation (non-rememberable-modes auto-mode)
+                :test #'equals)
+        (let ((matching-rule (matching-auto-mode-rule
+                              (url (buffer auto-mode))
+                              (buffer auto-mode))))
+          (member invocation (or (and matching-rule (union (included matching-rule)
+                                                           (excluded matching-rule)))
+                                 ;; Mode is covered by auto-mode only if it is
+                                 ;; in last-active-modes and gets enabled.
+                                 ;; If it gets disabled, user should be prompted,
+                                 ;; because they may want to persist it.
+                                 (and enable-p (last-active-modes auto-mode)))
+                  :test #'equals)))))
 
 (declaim (ftype (function (string) list) url-infer-match))
 (defun url-infer-match (url)
@@ -172,28 +192,29 @@ The rules are:
                 make-mode-toggle-prompting-handler))
 (defun make-mode-toggle-prompting-handler (enable-p auto-mode)
   #'(lambda (mode)
-      (when (not (mode-covered-by-auto-mode-p mode auto-mode enable-p))
-        (if-confirm ("Permanently ~:[disable~;enable~] ~a for this URL?"
+      (let ((invocation (mode-invocation mode)))
+        (when (not (mode-covered-by-auto-mode-p mode auto-mode enable-p))
+          (if-confirm ("Permanently ~:[disable~;enable~] ~a for this URL?"
                        enable-p (mode-name mode))
-                    (let ((url (prompt-minibuffer
-                                :input-prompt "URL:"
-                                :input-buffer (object-display (url (buffer mode)))
-                                :must-match-p nil)))
-            (add-modes-to-auto-mode-rules (url-infer-match url)
-                                          :append-p t
-                                          :include (when enable-p (list mode))
-                                          :exclude (unless enable-p (list mode))))
-          (setf (last-active-modes auto-mode)
-                (if enable-p
-                    (union (list mode) (last-active-modes auto-mode)
-                           :test #'mode-equal)
-                    (remove mode (last-active-modes auto-mode)
-                            :test #'mode-equal)))))))
+                      (let ((url (prompt-minibuffer
+                                  :input-prompt "URL:"
+                                  :input-buffer (object-display (url (buffer mode)))
+                                  :must-match-p nil)))
+                        (add-modes-to-auto-mode-rules (url-infer-match url)
+                                                      :append-p t
+                                                      :include (when enable-p (list invocation))
+                                                      :exclude (unless enable-p (list invocation))))
+                      (setf (last-active-modes auto-mode)
+                            (if enable-p
+                                (union (list invocation) (last-active-modes auto-mode)
+                                       :test #'equals)
+                                (remove invocation (last-active-modes auto-mode)
+                                        :test #'equals))))))))
 
 (defun initialize-auto-mode (mode)
   (unless (last-active-modes mode)
     (setf (last-active-modes mode)
-          (default-modes (buffer mode))))
+          (mapcar #'mode-invocation (default-modes (buffer mode)))))
   (when (prompt-on-mode-toggle mode)
     (hooks:add-hook (enable-mode-hook (buffer mode))
                     (nyxt::make-handler-mode
@@ -233,10 +254,14 @@ Be careful with deleting the defaults -- it can be harmful for your browsing.")
 We need to store this to not overwrite the `last-active-modes' for a given URL,
 if `auto-mode-handler' will fire more than once.")
    (last-active-modes '()
-                      :documentation "The list of modes that were enabled
+                      :type (or (cons mode-invocation *) null)
+                      :documentation "The list of `mode-invocation's that were enabled
 on the last URL not covered by `auto-mode'.")
    (destructor #'clean-up-auto-mode)
    (constructor #'initialize-auto-mode)))
+
+(defmethod non-rememberable-modes ((auto-mode auto-mode))
+  (mapcar #'mode-invocation (slot-value auto-mode 'non-rememberable-modes)))
 
 (define-command save-non-default-modes-for-future-visits ()
   "Save the modes present in `default-modes' and not present in current modes as :excluded,
@@ -258,12 +283,12 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
       (setf url (url url)))
     (add-modes-to-auto-mode-rules
      (url-infer-match url)
-     :include (set-difference (modes (current-buffer))
-                              (default-modes (current-buffer))
-                              :test #'mode-equal)
-     :exclude (set-difference (default-modes (current-buffer))
-                              (modes (current-buffer))
-                              :test #'mode-equal))))
+     :include (set-difference (mapcar #'mode-invocation(modes (current-buffer)))
+                              (mapcar #'mode-invocation (default-modes (current-buffer)))
+                              :test #'equals)
+     :exclude (set-difference (mapcar #'mode-invocation (default-modes (current-buffer)))
+                              (mapcar #'mode-invocation (modes (current-buffer)))
+                              :test #'equals))))
 
 (define-command save-exact-modes-for-future-visits ()
   "Store the exact list of enabled modes to auto-mode rules for all the future visits of this
@@ -285,11 +310,11 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
     (when (typep url 'nyxt::history-entry)
       (setf url (url url)))
     (add-modes-to-auto-mode-rules (url-infer-match url)
-                                  :include (modes (current-buffer))
+                                  :include (mapcar #'mode-invocation (modes (current-buffer)))
                                   :exact-p t)))
 
-(declaim (ftype (function (list &key (:append-p boolean) (:exclude list)
-                                (:include list) (:exact-p boolean))
+(declaim (ftype (function (list &key (:append-p boolean) (:exclude (or (cons mode-invocation *) null))
+                                (:include (or (cons mode-invocation *) null)) (:exact-p boolean))
                           (values list &optional))
                 add-modes-to-auto-mode-rules))
 (sera:export-always 'add-modes-to-auto-mode-rules)
@@ -305,11 +330,11 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
             (included rule) (union include
                                    (when append-p
                                      (set-difference (included rule) exclude
-                                                     :test #'mode-equal)))
+                                                     :test #'equals)))
             (excluded rule) (union exclude
                                    (when append-p
                                      (set-difference (excluded rule) include
-                                                     :test #'mode-equal)))
+                                                     :test #'equals)))
             rules (delete-duplicates
                    (append (when (or (included rule) (excluded rule))
                              (list rule))
@@ -325,10 +350,11 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
                      (let ((value (funcall slot rule)))
                        (if modes-p
                            (mapcar
-                            #'(lambda (mode)
-                                (if (listp mode)
-                                    mode
-                                    (maybe-mode-name mode)))
+                            #'(lambda (mode-invocation)
+                                (if (arguments mode-invocation)
+                                    (list (name mode-invocation)
+                                          (arguments mode-invocation))
+                                    (name mode-invocation)))
                             value)
                            value))))))
     (let ((*standard-output* stream)
@@ -349,6 +375,8 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
         (let ((rules (read stream)))
           (mapcar #'(lambda (rule)
                       (let ((rule (append '(:test) rule)))
+                        (setf (getf rule :included) (mapcar #'mode-invocation (getf rule :included))
+                              (getf rule :excluded) (mapcar #'mode-invocation (getf rule :excluded)))
                         (when (stringp (getf rule :test))
                           (setf (getf rule :test) `(match-url ,(getf rule :test))))
                         (apply #'make-instance 'auto-mode-rule rule)))


### PR DESCRIPTION
This adds `mode-invocation` class to finally free us from checking whether `auto-mode`-rule has symbol, mode, or list as mode representation, and bugs stemming from this. This also includes some type declarations/checks added for type safety around the code of auto-mode.

# Things To Discuss:
- Is `mode-invocation` a good name? Alternatives:
  - `mode-invokation` (what's the right spelling?)
  - `mode-activation`
  - `mode-symbol` (see #868), although it collides with the function of the same name in mode.lisp.
- Maybe integrate this into mode.lisp too, so that we can always get mode arguments around when calling modes.
- Is there a better way to get mode symbol, other than `(nyxt::sym (nyxt::mode-command mode))`?
- Abstracts the `(or (cons mode-invocation) null)` type to `list-of-mode-invocations`?
- Initially, we persisted modes without package prefixes. We did switch to prefixes some time ago. Maybe switch back to unprefixed symbols for readability? User-edited unprefixed symbols work alright, though.

# Future work:
- #868 is covered (except for prompting what modes to enable, but is it really necessary?), close it?
- Mark some mode arguments as saveable by `auto-mode`. Example: we can move `current-zoom-ratio` to `web-mode` and persist it if it's not default. This way one will have their most comfortable zoom ratio depending on the website they visit. Cool, eh?

# How Has This Been Tested:
- Compiles. Runs.
- #1095 is not reproduced, so it should be fixed.

Closes: #1095

EDIT: Add note on testing.