### PR TITLE
Fix issue #1107

### DIFF
--- a/assets/nyxt.desktop
+++ b/assets/nyxt.desktop
@@ -13,3 +13,4 @@ Categories=GTK;Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
 StartupNotify=true
 Actions=NewWindow;
+StartupWMClass=sbcl


### PR DESCRIPTION
Addresses the fact that the Nyxt icon is missing on GNOME Wayland.

The key observation is that (gdk:gdk-set-program-class "nyxt") sets the
window manager class (WM class) to "nyxt" under the X window system,
whereas on Wayland the WM class is "sbcl" (which is the default for an
SBCL application).

(gdk:gdk-set-program-class "nyxt") is deprecated and not recommended.



The only shortcoming that I can think of is that if a user runs several SBCL applications, they will all be grouped together (under the same "frame").

Let me know what you think.