### PR TITLE
Password improvements

### DIFF
--- a/libraries/password-manager/package.lisp
+++ b/libraries/password-manager/package.lisp
@@ -4,4 +4,5 @@
 (in-package :cl-user)
 
 (uiop:define-package :password
-  (:use :common-lisp))
+    (:use :common-lisp)
+  (:import-from #:class-star #:define-class))

--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -11,6 +11,8 @@
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
+(push 'keepassxc-interface *interfaces*)
+
 (defmethod list-passwords ((password-interface keepassxc-interface))
   (let* ((st (make-string-input-stream (master-password password-interface)))
          (output (execute password-interface (list "ls" (password-file password-interface))

--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -22,41 +22,38 @@
 
 (defmethod list-passwords ((password-interface keepassxc-interface))
   (let* ((st (make-string-input-stream (master-password password-interface)))
-         (output (uiop:run-program (list (executable password-interface)
-                                         "ls" (password-file password-interface))
-                                   :input st :output '(:string :stripped t))))
+         (output (execute password-interface (list "ls" (password-file password-interface))
+                          :input st :output '(:string :stripped t))))
     (remove "Recycle Bin/" (rest (cl-ppcre:split "\\n" output)) :test #'equal)))
 
 (defmethod clip-password ((password-interface keepassxc-interface) &key password-name service)
   (declare (ignore service))
   (with-input-from-string (st (master-password password-interface))
-    (uiop:run-program (list (executable password-interface)
-                            "clip"
-                            (password-file password-interface)
-                            password-name
-                            ;; Timeout for password
-                            (format nil "~a" (sleep-timer password-interface)))
-                      :input st :output '(:string :stripped t))))
+    (execute password-interface (list "clip"
+                                      (password-file password-interface)
+                                      password-name
+                                      ;; Timeout for password
+                                      (format nil "~a" (sleep-timer password-interface)))
+             :input st :output '(:string :stripped t))))
 
 (defmethod save-password ((password-interface keepassxc-interface) &key password-name password service)
   (declare (ignore service))
   (with-input-from-string (st (format nil "~a~C~a"
                                       (master-password password-interface)
                                       #\newline password))
-    (uiop:run-program (list (executable password-interface)
-                            "add" "--password-prompt" (password-file password-interface)
-                            (if (str:emptyp password-name)
-                                "--generate"
-                                password-name))
-                      :input st)))
+    (execute password-interface (list "add" "--password-prompt" (password-file password-interface)
+                                      (if (str:emptyp password-name)
+                                          "--generate"
+                                          password-name))
+             :input st)))
 
 (defmethod password-correct-p ((password-interface keepassxc-interface))
   (when (master-password password-interface)
     (handler-case
         (let* ((st (make-string-input-stream (master-password password-interface)))
-               (output (uiop:run-program (list (executable password-interface)
-                                               "ls" (password-file password-interface))
-                                         :input st :output '(:string :stripped t))))
+               (output (execute password-interface (list (executable password-interface)
+                                                         "ls" (password-file password-interface))
+                                :input st :output '(:string :stripped t))))
           (remove "Recycle Bin/" (rest (cl-ppcre:split "\\n" output)) :test #'equal))
       (uiop/run-program:subprocess-error ()
         nil))))

--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -4,12 +4,9 @@
 (in-package :password)
 
 (define-class keepassxc-interface (password-interface)
-  ((executable :initform (executable-find "keepassxc-cli"))
-   (password-file :accessor password-file
-                  :initarg :file)
-   (master-password :accessor master-password
-                    :initarg :master-password
-                    :initform nil))
+  ((executable (executable-find "keepassxc-cli"))
+   (password-file)
+   (master-password :initform nil))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))

--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -11,12 +11,6 @@
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'make-keepassxc-interface))
-(defun make-keepassxc-interface ()
-  (make-instance 'keepassxc-interface))
-(push #'make-keepassxc-interface interface-list)
-
 (defmethod list-passwords ((password-interface keepassxc-interface))
   (let* ((st (make-string-input-stream (master-password password-interface)))
          (output (execute password-interface (list "ls" (password-file password-interface))

--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -3,22 +3,22 @@
 
 (in-package :password)
 
-(defclass keepassxc-interface (password-interface)
-  ((password-file :accessor password-file
+(define-class keepassxc-interface (password-interface)
+  ((executable :initform (executable-find "keepassxc-cli"))
+   (password-file :accessor password-file
                   :initarg :file)
    (master-password :accessor master-password
                     :initarg :master-password
-                    :initform nil)))
+                    :initform nil))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'make-keepassxc-interface))
 (defun make-keepassxc-interface ()
   (make-instance 'keepassxc-interface))
 (push #'make-keepassxc-interface interface-list)
-
-(defmethod initialize-instance :after ((password-interface keepassxc-interface))
-  (unless (slot-boundp password-interface 'executable)
-    (setf (executable password-interface) (executable-find "keepassxc-cli"))))
 
 (defmethod list-passwords ((password-interface keepassxc-interface))
   (let* ((st (make-string-input-stream (master-password password-interface)))

--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -44,8 +44,7 @@
   (when (master-password password-interface)
     (handler-case
         (let* ((st (make-string-input-stream (master-password password-interface)))
-               (output (execute password-interface (list (executable password-interface)
-                                                         "ls" (password-file password-interface))
+               (output (execute password-interface (list "ls" (password-file password-interface))
                                 :input st :output '(:string :stripped t))))
           (remove "Recycle Bin/" (rest (cl-ppcre:split "\\n" output)) :test #'equal))
       (uiop/run-program:subprocess-error ()

--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -7,8 +7,8 @@
   ((executable (executable-find "pass"))
    (sleep-timer (or (uiop:getenv "PASSWORD_STORE_CLIP_TIME") 45))
    (password-directory (or (uiop:getenv "PASSWORD_STORE_DIR")
-                                     (namestring (format nil "~a/.password-store"
-                                                         (uiop:getenv "HOME"))))
+                           (namestring (format nil "~a/.password-store"
+                                               (uiop:getenv "HOME"))))
                        :reader password-directory))
   (:export-class-name-p t)
   (:export-accessor-names-p t)

--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -14,6 +14,8 @@
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
+(push 'password-store-interface *interfaces*)
+
 (defmethod list-passwords ((password-interface password-store-interface))
   ;; Special care must be taken for symlinks. Say `~/.password-store/work`
   ;; points to `~/work/pass`, would we follow symlinks, we would not be able to

--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -41,17 +41,17 @@
 
 (defmethod clip-password ((password-interface password-store-interface) &key password-name service)
   (declare (ignore service))
-  (uiop:run-program (list (executable password-interface) "show" "--clip" password-name)
-                    :output '(:string :stripped t)))
+  (execute password-interface (list "show" "--clip" password-name)
+    :output '(:string :stripped t)))
 
 (defmethod save-password ((password-interface password-store-interface)
                           &key password-name password service)
   (declare (ignore service))
   (if (str:emptyp password)
-      (uiop:run-program (list (executable password-interface) "generate" password-name))
+      (execute password-interface (list "generate" password-name))
       (with-open-stream (st (make-string-input-stream password))
-        (uiop:run-program (list (executable password-interface) "insert" "--echo" password-name)
-                          :input st))))
+        (execute password-interface (list "insert" "--echo" password-name)
+          :input st))))
 
 (defmethod password-correct-p ((password-interface password-store-interface))
   t)

--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -14,12 +14,6 @@
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'make-password-store-interface))
-(defun make-password-store-interface ()
-  (make-instance 'password-store-interface))
-(push #'make-password-store-interface interface-list)
-
 (defmethod list-passwords ((password-interface password-store-interface))
   ;; Special care must be taken for symlinks. Say `~/.password-store/work`
   ;; points to `~/work/pass`, would we follow symlinks, we would not be able to

--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -3,23 +3,23 @@
 
 (in-package :password)
 
-(defclass password-store-interface (password-interface)
-  ((password-directory :reader password-directory
+(define-class password-store-interface (password-interface)
+  ((executable (executable-find "pass"))
+   (sleep-timer (or (uiop:getenv "PASSWORD_STORE_CLIP_TIME") 45))
+   (password-directory :reader password-directory
                        :initarg :directory
                        :initform (or (uiop:getenv "PASSWORD_STORE_DIR")
                                      (namestring (format nil "~a/.password-store"
-                                                         (uiop:getenv "HOME")))))))
+                                                         (uiop:getenv "HOME"))))))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'make-password-store-interface))
 (defun make-password-store-interface ()
   (make-instance 'password-store-interface))
 (push #'make-password-store-interface interface-list)
-
-(defmethod initialize-instance :after ((password-interface password-store-interface) &key)
-  (setf (sleep-timer password-interface) (or (uiop:getenv "PASSWORD_STORE_CLIP_TIME") 45))
-  (unless (slot-boundp password-interface 'executable)
-    (setf (executable password-interface) (executable-find "pass"))))
 
 (defmethod list-passwords ((password-interface password-store-interface))
   ;; Special care must be taken for symlinks. Say `~/.password-store/work`

--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -6,11 +6,10 @@
 (define-class password-store-interface (password-interface)
   ((executable (executable-find "pass"))
    (sleep-timer (or (uiop:getenv "PASSWORD_STORE_CLIP_TIME") 45))
-   (password-directory :reader password-directory
-                       :initarg :directory
-                       :initform (or (uiop:getenv "PASSWORD_STORE_DIR")
+   (password-directory (or (uiop:getenv "PASSWORD_STORE_DIR")
                                      (namestring (format nil "~a/.password-store"
-                                                         (uiop:getenv "HOME"))))))
+                                                         (uiop:getenv "HOME"))))
+                       :reader password-directory))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -7,7 +7,7 @@
 ;;; on BSD and Darwin systems to interface with the system keychain
 
 (define-class security-interface (password-interface)
-  ((executable :initform (executable-find "security")))
+  ((executable (executable-find "security")))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -6,7 +6,11 @@
 ;;; Provide an interface to the command line "security" program used
 ;;; on BSD and Darwin systems to interface with the system keychain
 
-(defclass security-interface (password-interface) ())
+(define-class security-interface (password-interface)
+  ((executable :initform (executable-find "security")))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'make-security-interface))
@@ -14,10 +18,6 @@
   (make-instance 'security-interface))
 
 (push #'make-security-interface interface-list)
-
-(defmethod initialize-instance :after ((password-interface security-interface) &key)
-  (unless (slot-boundp password-interface 'executable)
-    (setf (executable password-interface) (executable-find "security"))))
 
 (defmethod list-passwords ((password-interface security-interface))
   (error "Listing passwords not supported by security interface."))

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -23,7 +23,7 @@
   (error "Listing passwords not supported by security interface."))
 
 (defmethod clip-password ((password-interface security-interface) &key password-name service)
-  (clip-password-string
+  (clip-password-string password-interface
    (str:replace-all
     "\"" ""
     (str:replace-first

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -6,21 +6,18 @@
 ;;; Provide an interface to the command line "security" program used
 ;;; on BSD and Darwin systems to interface with the system keychain
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export '*security-cli-program*))
-(defvar *security-cli-program* nil
-  "The path to the executable.")
-
 (defclass security-interface (password-interface) ())
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'make-security-interface))
 (defun make-security-interface ()
-  (unless *security-cli-program*
-    (setf *security-cli-program* (executable-find "security")))
-  (when *security-cli-program*
-    (make-instance 'security-interface)))
+  (make-instance 'security-interface))
+
 (push #'make-security-interface interface-list)
+
+(defmethod initialize-instance :after ((password-interface security-interface) &key)
+  (unless (slot-boundp password-interface 'executable)
+    (setf (executable password-interface) (executable-find "security"))))
 
 (defmethod list-passwords ((password-interface security-interface))
   (error "Listing passwords not supported by security interface."))
@@ -33,7 +30,7 @@
      "password: " ""
      (nth-value 1
                 (uiop:run-program
-                 (list *security-cli-program* "find-internet-password"
+                 (list (executable password-interface) "find-internet-password"
                        "-a" password-name "-s" service "-g")
                  :error-output '(:string :stripped t)))))))
 

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -12,6 +12,8 @@
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
+(push 'security-interface *interfaces*)
+
 (defmethod list-passwords ((password-interface security-interface))
   (error "Listing passwords not supported by security interface."))
 

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -29,9 +29,9 @@
     (str:replace-first
      "password: " ""
      (nth-value 1
-                (uiop:run-program
-                 (list (executable password-interface) "find-internet-password"
-                       "-a" password-name "-s" service "-g")
-                 :error-output '(:string :stripped t)))))))
+                (execute password-interface
+                  (list "find-internet-password"
+                        "-a" password-name "-s" service "-g")
+                  :error-output '(:string :stripped t)))))))
 
 (defmethod password-correct-p ((password-interface security-interface)) t)

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -12,13 +12,6 @@
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'make-security-interface))
-(defun make-security-interface ()
-  (make-instance 'security-interface))
-
-(push #'make-security-interface interface-list)
-
 (defmethod list-passwords ((password-interface security-interface))
   (error "Listing passwords not supported by security interface."))
 

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -61,3 +61,7 @@ Return nil if COMMAND is not found anywhere."
        (uiop:run-program (format nil "command -v ~A" command)
                          :output '(:string :stripped t)))
     path))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (export '*interfaces*))
+(defvar *interfaces* (list))

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -3,12 +3,11 @@
 
 (in-package :password)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export '*sleep-timer*))
-(defvar *sleep-timer* 15)
-
 (defclass password-interface ()
-  ())
+  ((executable :accessor executable :initarg :executable
+               :documentation "The program to query for password information.")
+   (sleep-timer :accessor sleep-timer :initarg :sleep-timer :initform 15
+                :documentation "The amount of time to sleep, in seconds.")))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'list-passwords))

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -30,6 +30,9 @@ If PASSWORD-NAME is empty, then generate a new password."))
 (defgeneric password-correct-p (password-interface)
   (:documentation "Return T if set password is correct, NIL otherwise."))
 
+(defmacro execute (interface arguments &body body)
+  `(uiop:run-program (append (list (executable ,interface)) ,arguments) ,@body))
+
 (defun safe-clipboard-text ()
   "Return clipboard content, or \"\" if the content is not textual."
   ;; xclip errors out when the clipboard contains non-text:

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -37,11 +37,11 @@ If PASSWORD-NAME is empty, then generate a new password."))
   (ignore-errors (trivial-clipboard:text)))
 
 ;;; Prerequisite Functions
-(defun clip-password-string (pass)
+(defmethod clip-password-string ((password-interface password-interface) pass)
   (trivial-clipboard:text pass)
   (bt:make-thread
    (lambda ()
-     (sleep *sleep-timer*)
+     (sleep (sleep-timer password-interface))
      (when (string= (safe-clipboard-text) pass)
        ;; Reset the clipboard so that the user does not accidentally paste
        ;; something else.

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -61,16 +61,3 @@ Return nil if COMMAND is not found anywhere."
        (uiop:run-program (format nil "command -v ~A" command)
                          :output '(:string :stripped t)))
     path))
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'interface-list))
-(defvar interface-list '()
-  "List of interface intializing functions.
-`make' returns the first non-nil value which is returned by an invocation of one
-of the functions.")
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'make))
-(defun make ()
-  "Initalize the first interface in `interface-list' that returns non-nil."
-  (some #'funcall interface-list))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -270,7 +270,8 @@
                cl-ppcre
                str
                trivial-clipboard
-               uiop)
+               uiop
+               nyxt/class-star)
   :pathname "libraries/password-manager/"
   :components ((:file "package")
                (:file "password")

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -55,8 +55,7 @@ under your user profile.")
                   :documentation "Thread that listens on socket.
 See `*socket-path*'.
 This slot is mostly meant to clean up the thread if necessary.")
-   (password-interface (password:make)
-                       :export nil)
+   (password-interface :export nil)
    (messages-content '()
                      :export nil
                      :documentation "A list of all echoed messages.

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -55,7 +55,8 @@ under your user profile.")
                   :documentation "Thread that listens on socket.
 See `*socket-path*'.
 This slot is mostly meant to clean up the thread if necessary.")
-   (password-interface :export nil)
+   (password-interface (make-password-interface)
+                       :export nil)
    (messages-content '()
                      :export nil
                      :documentation "A list of all echoed messages.

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -236,12 +236,16 @@ with " (:code "nyxt --data-profile dev") ".")
     (:p "Nyxt provides a uniform interface to some password managers including "
         (:a :href "https://keepassxc.org/" "KeepassXC")
         " and " (:a :href "https://www.passwordstore.org/" "Password Store") ". "
-        "The installed password manager is automatically detected.  If you want
-to force, say, KeepassXC, add the following to your configuration file:")
-    (:pre (:code
-           "(push #'password:make-keepassxc-interface password:interface-list)"))
-    (:p "See the " (:code "password:interface-list") " for the list of registered
+        "The installed password manager is automatically
+detected. Use " (:code "make-password-interface") " to automatically
+return the first password interface with a non-nil executable
+path (e.g. the executable was found on your system).")
+    (:p "See the " (:code "password:*interfaces*") " for the list of registered
 password manager interfaces.")
+    (:p "You may use the " (:code "define-configuration") " macro with
+any of the password interfaces to configure them. Please make sure to
+use the package prefixed class name/slot designators within
+the " (:code "define-configuration") " macro.")
     (:ul
      (:li (command-markup 'save-new-password) ": Query for name and new password to persist in the database.")
      (:li (command-markup 'copy-password) ": Copy selected password to the clipboard."))

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -32,10 +32,10 @@ make/return."
       (fuzzy-match (input-buffer minibuffer) password-list))))
 
 (defun password-debug-info ()
-  (log:debug "Password interface ~a uses executable ~s."
-             (when (password-interface *browser*)
-               (class-name (class-of (password-interface *browser*))))
-             (password:executable (password-interface *browser*))))
+  (when (password-interface *browser*)
+    (log:debug "Password interface ~a uses executable ~s."
+               (class-name (class-of (password-interface *browser*)))
+               (password:executable (password-interface *browser*)))))
 
 (defun has-method-p (object generic-function)
   "Return non-nil if OBJECT is a specializer of a method of GENERIC-FUNCTION."

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -81,5 +81,5 @@
                               (password-suggestion-filter
                                (password-interface *browser*)))))
           (password:clip-password (password-interface *browser*) :password-name password-name)
-          (echo "Password saved to clipboard for ~a seconds." password:*sleep-timer*)))
+          (echo "Password saved to clipboard for ~a seconds." (sleep-timer (password-interface *browser*)))))
       (echo-warning "No password manager found.")))

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -16,11 +16,7 @@
   (log:debug "Password interface ~a uses executable ~s."
              (when (password-interface *browser*)
                (class-name (class-of (password-interface *browser*))))
-             (match (symbol-name (class-name (class-of (password-interface *browser*))))
-               ;; With `symbol-name' we remove the package prefix.
-               ("KEEPASSXC-INTERFACE" password:*keepassxc-cli-program*)
-               ("SECURITY-INTERFACE" password:*security-cli-program*)
-               ("PASSWORD-STORE-INTERFACE" password:*password-store-program*))))
+             (password:executable (password-interface *browser*))))
 
 (defun has-method-p (object generic-function)
   "Return non-nil if OBJECT is a specializer of a method of GENERIC-FUNCTION."
@@ -81,5 +77,5 @@
                               (password-suggestion-filter
                                (password-interface *browser*)))))
           (password:clip-password (password-interface *browser*) :password-name password-name)
-          (echo "Password saved to clipboard for ~a seconds." (sleep-timer (password-interface *browser*)))))
+          (echo "Password saved to clipboard for ~a seconds." (password:sleep-timer (password-interface *browser*)))))
       (echo-warning "No password manager found.")))

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -5,15 +5,22 @@
 
 ;;; define user classes so that users may apply define-configuration
 ;;; macro to change slot values
-(define-user-class password:security-interface)
-(define-user-class password:keepassxc-interface)
-(define-user-class password:password-store-interface)
+(loop for interface in password:*interfaces* do
+         (eval `(define-user-class ,(intern (symbol-name interface)
+                                            (package-name (symbol-package interface))))))
 
-(defun make-password-interface (class)
-  (match class
-    ('password:security-interface (make-instance 'password:user-security-interface))
-    ('password:keepassxc-interface (make-instance 'password:user-keepassxc-interface))
-    ('password:password-store-interface (make-instance 'password:user-password-store-interface))))
+(defun make-password-interface ()
+  "Make a password interface for all user classes, the first one with
+a non-nil value of executable is considered to be the interface to
+make/return."
+  (labels ((user-password-interface-symbols ()
+             (loop for interface in password:*interfaces*
+                   collect (intern (str:concat "USER-" (symbol-name interface))
+                                   (package-name (symbol-package interface)))))
+           (user-password-interfaces ()
+             (loop for interface-symbol in (user-password-interface-symbols)
+                   collect (make-instance interface-symbol))))
+    (find-if #'password:executable (user-password-interfaces))))
 
 (defun password-suggestion-filter (password-instance)
   (let ((password-list (password:list-passwords password-instance))

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -3,6 +3,18 @@
 
 (in-package :nyxt)
 
+;;; define user classes so that users may apply define-configuration
+;;; macro to change slot values
+(define-user-class password:security-interface)
+(define-user-class password:keepassxc-interface)
+(define-user-class password:password-store-interface)
+
+(defun make-password-interface (class)
+  (match class
+    ('password:security-interface (make-instance 'password:user-security-interface))
+    ('password:keepassxc-interface (make-instance 'password:user-keepassxc-interface))
+    ('password:password-store-interface (make-instance 'password:user-password-store-interface))))
+
 (defun password-suggestion-filter (password-instance)
   (let ((password-list (password:list-passwords password-instance))
         (domain (quri:uri-domain (url (current-buffer)))))

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -39,9 +39,9 @@ make/return."
 
 (defun has-method-p (object generic-function)
   "Return non-nil if OBJECT is a specializer of a method of GENERIC-FUNCTION."
-  (find (class-of object)
-        (alex:mappend #'closer-mop:method-specializers
-                      (closer-mop:generic-function-methods generic-function))))
+  (find-if (alex:curry #'typep object)
+           (alex:mappend #'closer-mop:method-specializers
+                         (closer-mop:generic-function-methods generic-function))))
 
 (define-command save-new-password ()
   "Save password to password interface."


### PR DESCRIPTION
Several improvements to the interface:

+ Use slots within class to denote the location of the CLI (executable) program
+ Turn the sleep-timer into a slot so that it may be configured per password manager
+ Simplify the `make-xyz` methods for each password-interface
+ Enable the use of define-configuration macro for consistent configuration of password interfaces