### PR TITLE
buffer.lisp: move box-style, highlighted-box-style, hints-alphabet

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -160,25 +160,6 @@ distance scroll-left or scroll-right will scroll.")
                       :documentation "The ratio of the page to scroll.
 A value of 0.95 means that the bottom 5% will be the top 5% when scrolling
 down.")
-   (box-style (cl-css:css
-               '((".nyxt-hint"
-                  :background "linear-gradient(#fcff9e, #efcc00)"
-                  :color "black"
-                  :border "1px black solid"
-                  :padding "1px 3px 1px 3px"
-                  :border-radius "2px"
-                  :z-index #.(1- (expt 2 31)))))
-              :documentation "The style of the boxes, e.g. link hints.")
-   (highlighted-box-style (cl-css:css
-                           '((".nyxt-hint.nyxt-highlight-hint"
-                              :font-weight "500"
-                              :background "#fcff9e")))
-                          :documentation "The style of highlighted boxes, e.g. link hints.")
-   (hints-alphabet "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                   :type string
-                   :documentation "The alphabet (charset) to use for hints.
-Order matters -- the ones that go first are more likely to appear more often
-and to index the top of the page.")
    (buffer-load-hook (make-hook-uri->uri
                       :combination #'hooks:combine-composed-hook)
                      :type hook-uri->uri

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -373,9 +373,10 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                 :color "rgb(230, 230, 230)"
                 :text-align "right"
                 :padding-right "5px"
-                :text-overflow "ellipsis"
-                :overflow-x "hidden"
+                :overflow-x "scroll"
                 :white-space "nowrap")
+               ("#modes::-webkit-scrollbar"
+                :display "none")
                (.button
                 :color "rgb(250, 250, 250)"
                 :text-decoration "none"

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -20,8 +20,8 @@
     (unless (qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
-                 (box-style (ps:lisp (box-style (current-buffer))))
-                 (highlighted-style (ps:lisp (highlighted-box-style (current-buffer)))))
+                 (box-style (ps:lisp (box-style (current-web-mode))))
+                 (highlighted-style (ps:lisp (highlighted-box-style (current-web-mode)))))
          (setf (ps:@ style-element id) "nyxt-stylesheet")
          (ps:chain document head (append-child style-element))
          (ps:chain style-element sheet (insert-rule box-style 0))
@@ -105,7 +105,7 @@ identifier for every hinted element."
 
   (defun hints-generate (length)
     "Generates hints that will appear on the elements"
-    (ps:let ((alphabet (ps:lisp (hints-alphabet (current-buffer)))))
+    (ps:let ((alphabet (ps:lisp (hints-alphabet (current-web-mode)))))
       (strings-generate length alphabet)))
 
   (defun strings-generate (length alphabet)

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -21,8 +21,8 @@
     (unless (qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
-                 (box-style (ps:lisp (box-style (current-buffer))))
-                 (highlighted-style (ps:lisp (highlighted-box-style (current-buffer)))))
+                 (box-style (ps:lisp (box-style (current-web-mode))))
+                 (highlighted-style (ps:lisp (highlighted-box-style (current-web-mode)))))
          (setf (ps:@ style-element id) "nyxt-stylesheet")
          (ps:chain document head (append-child style-element))
          (ps:chain style-element sheet (insert-rule box-style 0))

--- a/source/visual-mode.lisp
+++ b/source/visual-mode.lisp
@@ -101,8 +101,8 @@
     (unless (qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
-                 (box-style (ps:lisp (box-style (current-buffer))))
-                 (highlighted-style (ps:lisp (highlighted-box-style (current-buffer)))))
+                 (box-style (ps:lisp (nyxt/web-mode::box-style (nyxt/web-mode::current-web-mode))))
+                 (highlighted-style (ps:lisp (nyxt/web-mode::highlighted-box-style (nyxt/web-mode::current-web-mode)))))
          (setf (ps:@ style-element id) "nyxt-stylesheet")
          (ps:chain document head (append-child style-element))
          (ps:chain style-element sheet (insert-rule box-style 0))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -32,6 +32,25 @@ search.")
     nil
     :type boolean
     :documentation "Whether history navigation is restricted by buffer-local history.")
+   (box-style (cl-css:css
+               '((".nyxt-hint"
+                  :background "linear-gradient(#fcff9e, #efcc00)"
+                  :color "black"
+                  :border "1px black solid"
+                  :padding "1px 3px 1px 3px"
+                  :border-radius "2px"
+                  :z-index #.(1- (expt 2 31)))))
+              :documentation "The style of the boxes, e.g. link hints.")
+   (highlighted-box-style (cl-css:css
+                           '((".nyxt-hint.nyxt-highlight-hint"
+                              :font-weight "500"
+                              :background "#fcff9e")))
+                          :documentation "The style of highlighted boxes, e.g. link hints.")
+   (hints-alphabet "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                   :type string
+                   :documentation "The alphabet (charset) to use for hints.
+Order matters -- the ones that go first are more likely to appear more often
+and to index the top of the page.")
    (keymap-scheme
     (define-scheme "web"
       scheme:cua
@@ -157,6 +176,9 @@ search.")
        "s-space" 'scroll-page-up
        "pageup" 'scroll-page-up
        "pagedown" 'scroll-page-down)))))
+
+(defun current-web-mode ()
+  (find-submode (current-buffer) 'web-mode))
 
 (sera:export-always '%clicked-in-input?)
 (define-parenscript %clicked-in-input? ()


### PR DESCRIPTION
buffer.lisp: move box-style, highlighted-box-style, hints-alphabet

makes it more logical. The buffer should not have slots relating to the int alphabet, etc. Ideally we would make a hint-mode as well. I tried doing this, but it ended up being a gigantic rearchitecture that involved tweaking search-buffer, visual-mode, and all element-hints. I will save that for another time (after I think more about how to generalize the hinting facilities).