### PR TITLE
Nosave buffers

### DIFF
--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -22,6 +22,7 @@
                      "C-l" 'set-url-from-current-url
                      "C-u C-l" 'set-url ; `set-url' is listed in the tutorial, so it should be bound.
                      "M-l" 'set-url-new-buffer
+                     "C-u M-l" 'set-url-nosave-buffer
                      "f5" 'reload-current-buffer
                      "C-r" 'reload-current-buffer
                      "C-R" 'reload-buffer
@@ -75,6 +76,7 @@
                      "C-pagedown" 'switch-buffer-next
                      "C-l" 'set-url
                      "M-l" 'set-url-new-buffer
+                     "C-u M-l" 'set-url-nosave-buffer
                      "C-t" 'make-buffer-focus
                      "C-r" 'reload-current-buffer
                      "C-R" 'reload-buffer
@@ -118,6 +120,7 @@
                      "B" 'make-buffer-focus
                      "o" 'set-url
                      "O" 'set-url-new-buffer
+                     ;; TODO: vim-ish set-url-nosave-buffer keybinding?
                      "m u" 'bookmark-url
                      "m d" 'bookmark-delete
                      "R" 'reload-current-buffer

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -874,10 +874,8 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
     (when history
       (containers:insert-item history (url (current-buffer))))
     (let ((url (prompt-minibuffer
-                :input-prompt (format nil "Open URL in ~A buffer"
-                                      (if new-buffer-p
-                                          "new"
-                                          "current"))
+                :input-prompt (format nil "Open URL in ~:[current~;new~]~:[~; nosave~] buffer"
+                                      new-buffer-p nosave-buffer-p)
                 :input-buffer (if prefill-current-url-p
                                   (object-string (url (current-buffer))) "")
                 :default-modes '(set-url-mode minibuffer-mode)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -274,6 +274,17 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
   (when (expand-path (cookies-path buffer))
     (ensure-parent-exists (expand-path (cookies-path buffer)))))
 
+(define-class nosave-buffer (user-web-buffer)
+  ((data-profile (make-instance 'nosave-data-profile))
+   (default-modes '(reduce-tracking-mode certificate-exception-mode
+                    web-mode base-mode)))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:export-predicate-name-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+
+(define-user-class nosave-buffer)
+
 (define-class internal-buffer (user-buffer)
   ((style #.(cl-css:css
              '((body
@@ -516,6 +527,23 @@ LOAD-URL-P controls whether to load URL right at buffer creation."
           (setf (url buffer) (quri:uri url))))
     buffer))
 
+(define-command make-nosave-buffer (&key (title "") modes (url "") (load-url-p t))
+  "Create a new buffer that won't save anything to the filesystem.
+MODES is a list of mode symbols.
+If URL is `:default', use `default-new-buffer-url'.
+LOAD-URL-P controls whether to load URL right at buffer creation."
+  (let* ((buffer (buffer-make *browser* :title title
+                                        :default-modes modes
+                                        :nosave-buffer-p t))
+         (url (if (eq url :default)
+                  (default-new-buffer-url buffer)
+                  url)))
+    (unless (url-empty-p url)
+      (if load-url-p
+          (buffer-load url :buffer buffer)
+          (setf (url buffer) (quri:uri url))))
+    buffer))
+
 (define-command make-internal-buffer (&key (title "") modes
                                       no-history-p)
   "Create a new buffer.
@@ -528,13 +556,14 @@ If URL is `:default', use `default-new-buffer-url'."
                                    (:data-profile data-profile)
                                    (:default-modes list)
                                    (:dead-buffer buffer)
+                                   (:nosave-buffer-p boolean)
                                    (:internal-buffer-p boolean)
                                    (:parent-buffer buffer)
                                    (:no-history-p boolean)))
                 buffer-make))
 (defun buffer-make (browser &key data-profile title default-modes
-                              dead-buffer internal-buffer-p parent-buffer
-                              no-history-p)
+                              dead-buffer nosave-buffer-p internal-buffer-p
+                              parent-buffer no-history-p)
   "Make buffer with title TITLE and modes DEFAULT-MODES.
 Run `*browser*'s `buffer-make-hook' over the created buffer before returning it.
 If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
@@ -543,9 +572,10 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
                        ;; Dead buffer ID must be renewed before calling `ffi-buffer-make'.
                        (setf (id dead-buffer) (get-unique-buffer-identifier *browser*))
                        (ffi-buffer-make dead-buffer))
-                     (apply #'make-instance (if internal-buffer-p
-                                                'user-internal-buffer
-                                                'user-web-buffer)
+                     (apply #'make-instance (cond
+                                              (internal-buffer-p 'user-internal-buffer)
+                                              (nosave-buffer-p 'user-nosave-buffer)
+                                              (t 'user-web-buffer))
                             :id (get-unique-buffer-identifier *browser*)
                             (append (when title `(:title ,title))
                                     (when default-modes `(:default-modes ,default-modes))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -757,10 +757,12 @@ proceeding."
         (set-current-buffer (first matching-buffers))
         (switch-buffer-domain :domain domain))))
 
-(define-command make-buffer-focus (&key (url :default) parent-buffer)
+(define-command make-buffer-focus (&key (url :default) parent-buffer nosave-buffer-p)
   "Switch to a new buffer.
 See `make-buffer'."
-  (let ((buffer (make-buffer :url url :parent-buffer parent-buffer)))
+  (let ((buffer (if nosave-buffer-p
+                    (make-nosave-buffer :url url)
+                    (make-buffer :url url :parent-buffer parent-buffer))))
     (set-current-buffer buffer)
     buffer))
 
@@ -853,9 +855,9 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
             (ffi-buffer-evaluate-javascript buffer (quri:url-decode (quri:uri-path url)))
             (ffi-buffer-load buffer url))))))
 
-(define-command set-url (&key new-buffer-p prefill-current-url-p)
+(define-command set-url (&key new-buffer-p prefill-current-url-p nosave-buffer-p)
   "Set the URL for the current buffer, completing with history."
-  (let ((history (minibuffer-set-url-history *browser*)))
+  (let ((history (unless nosave-buffer-p (minibuffer-set-url-history *browser*))))
     (when history
       (containers:insert-item history (url (current-buffer))))
     (let ((url (prompt-minibuffer
@@ -880,7 +882,7 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
                                    ;; Make empty buffer, or else there might be
                                    ;; a race condition between the URL that's
                                    ;; loaded and the default one.
-                                   (make-buffer-focus :url "")
+                                   (make-buffer-focus :url "" :nosave-buffer-p nosave-buffer-p)
                                    (current-buffer))))))
 
 (define-command set-url-from-current-url ()
@@ -890,6 +892,10 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
 (define-command set-url-new-buffer ()
   "Prompt for a URL and set it in a new focused buffer."
   (set-url :new-buffer-p t))
+
+(define-command set-url-nosave-buffer ()
+  "Prompt for a URL and set it in a new focused nosave buffer."
+  (set-url :new-buffer-p t :nosave-buffer-p t))
 
 (define-command reload-current-buffer (&optional (buffer (current-buffer)))
   "Reload of BUFFER or current buffer if unspecified."

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -101,15 +101,15 @@ means the store operations are systematically delayed."))
   (:export-class-name-p t)
   (:documentation "With the default profile all data is persisted to the standard locations."))
 
-(define-class private-data-profile (data-profile)
-  ((name :initform "private")
+(define-class nosave-data-profile (data-profile)
+  ((name :initform "nosave")
    (user-data-cache (make-hash-table :test #'equal)
                     :type hash-table
-                    :documentation "Buffer-local `user-data-cache' to isolate the data of a private buffer."))
+                    :documentation "Buffer-local `user-data-cache' to isolate the data of a nosave buffer."))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))
-  (:documentation "With the private profile no data should be persisted to disk.
+  (:documentation "With the nosave profile no data should be persisted to disk.
 No data should be shared with other buffers either."))
 
 (export-always '*global-data-profile*)
@@ -199,16 +199,16 @@ Return NIL when path must not be used.  This makes it possible to use the
 function result as a boolean in conditions."
   (expand-default-path path))
 
-(defmethod expand-data-path ((profile private-data-profile) (path cookies-data-path))
-  "We shouldn't store cookies for `private-data-profile'."
+(defmethod expand-data-path ((profile nosave-data-profile) (path cookies-data-path))
+  "We shouldn't store cookies for `nosave-data-profile'."
   nil)
 
-(defmethod expand-data-path ((profile private-data-profile) (path standard-output-data-path))
-  "We shouldn't store `*standard-output*' for `private-data-profile'."
+(defmethod expand-data-path ((profile nosave-data-profile) (path standard-output-data-path))
+  "We shouldn't store `*standard-output*' for `nosave-data-profile'."
   nil)
 
-(defmethod expand-data-path ((profile private-data-profile) (path error-output-data-path))
-  "We shouldn't store `*error-output*' for `private-data-profile'."
+(defmethod expand-data-path ((profile nosave-data-profile) (path error-output-data-path))
+  "We shouldn't store `*error-output*' for `nosave-data-profile'."
   nil)
 
 (export-always 'ensure-parent-exists)
@@ -233,12 +233,12 @@ Define a method for your `data-path' type to make it storable."))
   (:documentation "The generic way to restore data from the given path type.
 Define a method for your `data-path' type to make it restorable."))
 
-(defmethod store ((profile private-data-profile) (path data-path) &key &allow-other-keys)
-  "This method guarantees PATH will not be persisted to disk in PRIVATE-DATA-PROFILE."
+(defmethod store ((profile nosave-data-profile) (path data-path) &key &allow-other-keys)
+  "This method guarantees PATH will not be persisted to disk in NOSAVE-DATA-PROFILE."
   nil)
 
-(defmethod restore ((profile private-data-profile) (path data-path) &key &allow-other-keys)
-  "This method guarantees PATH will not be loaded from disk in PRIVATE-DATA-PROFILE."
+(defmethod restore ((profile nosave-data-profile) (path data-path) &key &allow-other-keys)
+  "This method guarantees PATH will not be loaded from disk in NOSAVE-DATA-PROFILE."
   nil)
 
 (defmethod store :around ((profile data-profile) (path async-data-path) &key &allow-other-keys)
@@ -288,8 +288,8 @@ This function can be used on browser-less globals like `*init-file-path*'."
 (defgeneric get-user-data (profile path)
   (:documentation "Access the browsing-related data depending on the `data-profile'."))
 
-(defmethod get-user-data ((profile private-data-profile) (path data-path))
-  "Look up the buffer-local data in case of `private-data-profile'."
+(defmethod get-user-data ((profile nosave-data-profile) (path data-path))
+  "Look up the buffer-local data in case of `nosave-data-profile'."
   (%get-user-data profile path (user-data-cache profile)))
 
 (export-always 'get-data)

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -342,6 +342,18 @@ I.e. the grey text initially seen in it."))
   (declare (ignore parent-buffer))
   (echo "Unsupported operation for hint: can't open in new buffer."))
 
+(defmethod %follow-hint-nosave-buffer-focus ((link-hint link-hint))
+  (make-buffer-focus :url (url link-hint) :nosave-buffer-p t))
+
+(defmethod %follow-hint-nosave-buffer-focus ((hint hint))
+  (echo "Unsupported operation for hint: can't open in new buffer."))
+
+(defmethod %follow-hint-nosave-buffer ((link-hint link-hint))
+  (make-nosave-buffer :url (url link-hint)))
+
+(defmethod %follow-hint-nosave-buffer ((hint hint))
+  (echo "Unsupported operation for hint: can't open in new buffer."))
+
 (defmethod %copy-hint-url ((link-hint link-hint))
   (trivial-clipboard:text (url link-hint)))
 
@@ -403,6 +415,24 @@ visible active buffer."
                            (rest result)))
                  :multi-selection-p t
                  :annotate-visible-only-p annotate-visible-only-p)))
+
+(define-command follow-hint-nosave-buffer (&key annotate-visible-only-p)
+  "Show a set of element hints, and open the user inputted one in a new
+nosave buffer (not set to visible active buffer)."
+  (query-hints "Open element in new buffer"
+               (lambda (result) (mapcar #'%follow-hint-nosave-buffer result))
+               :multi-selection-p t
+               :annotate-visible-only-p annotate-visible-only-p))
+
+(define-command follow-hint-nosave-buffer-focus (&key annotate-visible-only-p)
+  "Show a set of element hints, and open the user inputted one in a new
+visible nosave active buffer."
+  (query-hints "Go to element in new buffer"
+               (lambda (result)
+                 (%follow-hint-nosave-buffer-focus (first result))
+                 (mapcar #'%follow-hint-nosave-buffer (rest result)))
+               :multi-selection-p t
+               :annotate-visible-only-p annotate-visible-only-p))
 
 (define-command copy-hint-url (&key annotate-visible-only-p)
   "Show a set of element hints, and copy the URL of the user inputted one."

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -329,7 +329,9 @@ I.e. the grey text initially seen in it."))
   (focus-element :nyxt-identifier (identifier focusable-hint)))
 
 (defmethod %follow-hint-new-buffer-focus ((link-hint link-hint) &optional parent-buffer)
-  (make-buffer-focus :url (url link-hint) :parent-buffer parent-buffer))
+  (make-buffer-focus :url (url link-hint)
+                     :parent-buffer parent-buffer
+                     :nosave-buffer-p (nosave-buffer-p parent-buffer)))
 
 (defmethod %follow-hint-new-buffer-focus ((hint hint) &optional parent-buffer)
   (declare (ignore parent-buffer))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -274,7 +274,7 @@ existing instance instead of a separate instance that exits immediately.")
 instance must be non-nil.")
     (:p "To let know a private instance of Nyxt to load a foo.lisp script and run it's
 `foo' function:")
-    (:pre (:code "nyxt --data-profile private --remote --load foo.lisp --eval '(foo)'"))
+    (:pre (:code "nyxt --data-profile nosave --remote --load foo.lisp --eval '(foo)'"))
 
     (:h2 "Troubleshooting")
     (:h3 "Playing videos")

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -167,8 +167,8 @@ not return."
   (:export-class-name-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(defmethod expand-data-path ((profile private-data-profile) (path data-manager-data-path))
-  "We shouldn't store any `data-manager' data for `private-data-profile'."
+(defmethod expand-data-path ((profile nosave-data-profile) (path data-manager-data-path))
+  "We shouldn't store any `data-manager' data for `nosave-data-profile'."
   nil)
 
 (defun make-web-view (&key context-buffer)

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -9,7 +9,8 @@
 
 (export-always 'format-status-modes)
 (defun format-status-modes (&optional (buffer (current-buffer)))
-  (format nil "~{~a~^ ~}"
+  (format nil "~:[~;⚠ nosave ~]~{~a~^ ~}"
+          (nosave-buffer-p buffer)
           (mapcar (lambda (m) (str:replace-all "-mode" "" m))
                   (set-difference
                    (mapcar (alex:compose #'str:downcase #'mode-name) (modes buffer))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -184,7 +184,8 @@ search.")
       (if (and (input-tag-p response) url-empty)
           (funcall-safely #'paste)
           (unless url-empty
-            (make-buffer-focus :url (url-at-point buffer)))))))
+            (make-buffer-focus :url (url-at-point buffer)
+                               :nosave-buffer-p (nosave-buffer-p buffer)))))))
 
 (define-command maybe-scroll-to-bottom (&optional (buffer (current-buffer)))
   "Scroll to bottom if no input element is active, forward event otherwise."

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -49,6 +49,8 @@ search.")
        "C-g" 'follow-hint
        "M-g" 'follow-hint-new-buffer-focus
        "C-u M-g" 'follow-hint-new-buffer
+       "C-M-g" 'follow-hint-nosave-buffer-focus
+       "C-u C-M-g" 'follow-hint-nosave-buffer
        "C-x C-w" 'copy-hint-url
        "C-c" 'copy
        "button9" 'history-forwards
@@ -100,6 +102,8 @@ search.")
        "M-g g" 'follow-hint-new-buffer-focus
        "C-u M-g M-g" 'follow-hint-new-buffer
        "C-u M-g g" 'follow-hint-new-buffer
+       "C-M-g C-M-g" 'follow-hint-nosave-buffer-focus
+       "C-M-g g" 'follow-hint-nosave-buffer
        "C-x C-w" 'copy-hint-url
        "C-y" 'paste
        "M-w" 'copy
@@ -133,6 +137,7 @@ search.")
        "f" 'follow-hint
        "F" 'follow-hint-new-buffer-focus
        "; f" 'follow-hint-new-buffer
+       ;; TODO: vim-ish keybindings for follow-hint-nosave-buffer(-focus)?
        "button9" 'history-forwards
        "button8" 'history-backwards
        "+" 'zoom-in-page

--- a/tests/test-global-history.lisp
+++ b/tests/test-global-history.lisp
@@ -9,9 +9,9 @@
 
 (subtest "Global history"
   (let* ((*browser* (make-instance 'user-browser)))
-    ;; Set profile to private to inhibit serialization / deserialization.
+    ;; Set profile to nosave to inhibit serialization / deserialization.
     ;; TODO: We should still test serialization and deserialization.
-    (setf *global-data-profile* (make-instance 'private-data-profile))
+    (setf *global-data-profile* (make-instance 'nosave-data-profile))
     (let ((buffer (nyxt::make-internal-buffer)))
       (nyxt:with-current-buffer buffer
         (let ((path (history-path buffer)))


### PR DESCRIPTION
This is a second attempt at nosave buffers (supersedes #1093).

# What's new:

- `private-data-profile` renamed to `nosave-data-profile` for clarity and obvious relation to `nosave-buffer`.
- `nosave-buffer` class that has `nosave-data-profile` set by default but behaves like `web-buffer` otherwise.
  - All `nosave-buffer`s have separate ephemeral WebKit contexts and data managers.
  - `set-url` minibuffer history and all the data is isolated, so no data is leaking.
  - `nosave-buffer` cannot be parent to any other buffer.
  - History of `nosave-buffer` is not saved (although I checked restored buffers only and haven't looked an owners' IDs in the history file).
- Lots of places where we access data while being in between two buffers now use `with-current-buffer` to explicitly state the buffer to `expand-path` in.
- `set-url` and `follow-hint` versions for `nosave-buffer`

# Things To Discuss:

- VI bindings for `nosave-buffer` commands? I need help here, as I'm not familliar with VI keybinding mnemonics principles.
- `follow-hint-new-buffer` from the `nosave-buffer` is contagious: instead of new `web-buffer`, a new `nosave-buffer` is created. Should it be this way?
- There's quite a complex format-string used in `set-url` that I introduced. Maybe it's better to stick to older form (i.e., explicit `if`s instead of `format` DSL conditionals)?
- Make `nosave-buffer` visually noticeable? We discussed painting mode-line in a darker palette to emphasize `nosave-buffer` before.

# How Has This Been Tested
- I've ran Nyxt and used `nosave-buffer`s on several social media websites (logging in, out, browsing, and closing the buffer). No cookies, user-data, or any other trail of `nosave-buffer`s was noticed after their deletion.
- I believe it's merge-ready, but could've not seen some bugs, so review and testing is welcome :)

Closes #247

EDIT: Add question about noticeability of `nosave-buffer`s.