### PR TITLE
ffi-buffer-enable-sound gets a sane definition

### DIFF
--- a/source/nosound-mode.lisp
+++ b/source/nosound-mode.lisp
@@ -10,7 +10,7 @@
   "Disable sound in current buffer."
   ((destructor
     (lambda (mode)
-      (ffi-buffer-enable-sound (buffer mode) nil)))
+      (ffi-buffer-enable-sound (buffer mode) t)))
    (constructor
     (lambda (mode)
-      (ffi-buffer-enable-sound (buffer mode) t)))))
+      (ffi-buffer-enable-sound (buffer mode) nil)))))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -851,7 +851,7 @@ requested a reload."
 
 #+webkit2-mute
 (defmethod ffi-buffer-enable-sound ((buffer gtk-buffer) value)
-  (webkit:webkit-web-view-set-is-muted (gtk-object buffer) value))
+  (webkit:webkit-web-view-set-is-muted (gtk-object buffer) (not value)))
 
 (defmethod ffi-buffer-download ((buffer gtk-buffer) uri)
   (let* ((webkit-download (webkit:webkit-web-view-download-uri (gtk-object buffer) uri))


### PR DESCRIPTION
Minor fix so that the behaviour matches the method's name.

--

Already discussed with @jmercouris.