### PR TITLE
remove dependency on usocket

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -35,7 +35,6 @@
                :trivial-package-local-nicknames
                :trivial-types
                :unix-opts
-               :usocket
                ;; Local systems:
                :nyxt/user-interface
                :nyxt/text-buffer

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -57,7 +57,7 @@ On errors, return URL."
               ;; support "localhost" and the current system hostname.
               ;; get-host-by-name may signal a ns-try-again-condition which is
               ;; not an error, so we can't use `ignore-errors' here.
-              (handler-case (usocket:get-host-by-name (quri:uri-host uri))
+              (handler-case (iolib/sockets:lookup-hostname (quri:uri-host uri) :ipv6 iolib/sockets:*ipv6*)
                 (t () nil)))))))
 
 (declaim (ftype (function (t) quri:uri) ensure-url))


### PR DESCRIPTION
it is enough to test a hostname with iolib. that said, I do not believe we will be able to easily get rid of iolib...!