### PR TITLE
Fix for 1173, uses glib:g-set-prgname

### DIFF
--- a/source/renderer-gobject-gtk.lisp
+++ b/source/renderer-gobject-gtk.lisp
@@ -19,7 +19,7 @@
   (defmethod ffi-initialize ((browser gtk-browser) urls startup-timestamp)
     (log:info "Initializing Gobject-GTK Interface")
     (bt:make-thread (lambda ()
-                      (gdk:gdk-set-program-class "nyxt")
+                      (glib:g-set-prgname "nyxt")
                       (gir:invoke ((gir:ffi "Gtk") 'main)))
                     :name "main thread")
     (finalize browser urls startup-timestamp)))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -146,8 +146,8 @@ not return."
       #-darwin
       (progn
         (setf gtk-running-p t)
+	(glib:g-set-prgname "nyxt")
         (gtk:within-main-loop
-          (glib:g-set-prgname "nyxt")
           (finalize browser urls startup-timestamp))
         (unless *keep-alive*
           (gtk:join-gtk-main)))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -147,14 +147,14 @@ not return."
       (progn
         (setf gtk-running-p t)
         (gtk:within-main-loop
-          (gdk:gdk-set-program-class "nyxt")
+          (glib:g-set-prgname "nyxt")
           (finalize browser urls startup-timestamp))
         (unless *keep-alive*
           (gtk:join-gtk-main)))
       #+darwin
       (progn
         (setf gtk-running-p t)
-        (gdk:gdk-set-program-class "nyxt")
+        (glib:g-set-prgname "nyxt")
         (finalize browser urls startup-timestamp)
         (gtk:gtk-main))))
 


### PR DESCRIPTION
As recommended in the issue, changed to use the
glib:g-set-prgname. The WM_CLASS after the change is reported as:

WM_CLASS(STRING) = "nyxt", "Sbcl"