### PR TITLE
nyxt.desktop: group nyxt windows under the same wm-class

### DIFF
--- a/assets/nyxt.desktop
+++ b/assets/nyxt.desktop
@@ -13,4 +13,4 @@ Categories=GTK;Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
 StartupNotify=true
 Actions=NewWindow;
-StartupWMClass=sbcl
+StartupWMClass=nyxt


### PR DESCRIPTION
Now that the WM class is properly set for both X and Wayland we can set
it to "nyxt" so that all windows are grouped together under the same
class.

See github issue #1107 and pull requests #1141 and #1174.

--

Just is just a minor follow-up to #1174.

EDIT: I tested on GNOME wayland, and it's working fine.