### PR TITLE
WIP: diffs in nyxt

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -163,6 +163,7 @@
        ("cl-containers" ,cl-containers)
        ("cl-css" ,cl-css)
        ("cl-custom-hash-table" ,cl-custom-hash-table)
+       ("cl-html-diff" ,sbcl-cl-html-diff)
        ("cl-json" ,cl-json)
        ("cl-markup" ,cl-markup)
        ("cl-ppcre" ,cl-ppcre)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -35,6 +35,7 @@
                :trivial-package-local-nicknames
                :trivial-types
                :unix-opts
+               :cl-html-diff
                ;; Local systems:
                :nyxt/user-interface
                :nyxt/text-buffer
@@ -114,6 +115,7 @@
                (:file "os-package-manager-mode")
                (:file "visual-mode")
                (:file "watch-mode")
+               (:file "diff-mode")
                ;; Web-mode commands
                (:file "bookmarklets")
                (:file "input-edit")

--- a/source/diff-mode.lisp
+++ b/source/diff-mode.lisp
@@ -1,0 +1,77 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package :nyxt/diff-mode
+    (:use :common-lisp :nyxt)
+  (:documentation "Mode for displaying web-buffer diffs."))
+(in-package :nyxt/diff-mode)
+
+;; colours based on the modus-operandi theme by Protesilaos Stavrou, which
+;; follows the highest standard on accessibility
+(defvar html-diff-style
+  "<style>
+  ins
+  {background-color: #bbeabb;
+   text-decoration: none}
+  del
+  {background-color: #efcbcf;
+   text-decoration: none}
+</style>
+"
+  "TODO")
+
+;; this is the right way, but the I can't define a background-colour for the del
+;; and ins tag within the nyxt-diff-replace class
+;; (defvar html-diff-style
+;;   "<style>
+;;   .nyxt-diff-insert
+;;   {background-color: #bbeabb;
+;;    text-decoration: none}
+;;   .nyxt-diff-delete
+;;   {background-color: #efcbcf;
+;;    text-decoration: none}
+;;   .nyxt-diff-replace
+;;   {background-color: #ecdfbf;
+;;    text-decoration: none}
+;; </style>"
+;;   "TODO")
+
+;; this doesn't contemplate if buffer *diff* already exists
+;; add a proper title perhaps?  (*diff* + old buffer name + new buffer name)
+(defun make-diff-buffer (html-diff-string html-diff-style)
+  "TODO"
+  (with-current-html-buffer (buffer "*diff*" 'base-mode)
+    ;; FIXME title isn't overridden when the html contains the title tag
+    (str:concat html-diff-style
+                (if (str:contains? "<title>" html-diff-string)
+                    (ppcre:regex-replace "<title>.*</title>" html-diff-string "")
+                    html-diff-string))))
+
+(defun diff-buffers ()
+  "TODO"
+  ;; facilitates the following use case:
+  ;; the user wants to make a diff between the current-buffer and last inactive
+  ;; buffer
+  (let* ((old-html (ffi-buffer-get-document
+                    (prompt-minibuffer
+                     :input-prompt "Old buffer"
+                     :suggestion-function (buffer-suggestion-filter))))
+         (new-html (ffi-buffer-get-document
+                    (prompt-minibuffer
+                     :input-prompt "New buffer"
+                     :suggestion-function (buffer-suggestion-filter
+                                           :current-is-last-p t))))
+         (diff-html (html-diff:html-diff old-html
+                                         new-html
+                                         :insert-class "nyxt-diff-insert"
+                                         :delete-class "nyxt-diff-delete"
+                                         :replace-class "nyxt-diff-replace")))
+    (make-diff-buffer (princ diff-html) html-diff-style)))
+
+;; (define-mode diff-mode ()
+;;   "TODO"
+;;   ((new-html :documentation "TODO")
+;;    (old-html :documentation "TODO")
+;;    (default-display-diff-view :documentation "TODO")
+;;    (destructor (lambda (mode) TODO))
+;;    (constructor (lambda (mode) TODO))))

--- a/source/diff-mode.lisp
+++ b/source/diff-mode.lisp
@@ -3,75 +3,63 @@
 
 (uiop:define-package :nyxt/diff-mode
     (:use :common-lisp :nyxt)
+  (:import-from #:keymap #:define-key #:define-scheme)
   (:documentation "Mode for displaying web-buffer diffs."))
+
 (in-package :nyxt/diff-mode)
 
-;; colours based on the modus-operandi theme by Protesilaos Stavrou, which
-;; follows the highest standard on accessibility
-(defvar html-diff-style
-  "<style>
-  ins
-  {background-color: #bbeabb;
-   text-decoration: none}
-  del
-  {background-color: #efcbcf;
-   text-decoration: none}
-</style>
-"
-  "TODO")
-
-;; this is the right way, but the I can't define a background-colour for the del
-;; and ins tag within the nyxt-diff-replace class
-;; (defvar html-diff-style
-;;   "<style>
-;;   .nyxt-diff-insert
-;;   {background-color: #bbeabb;
-;;    text-decoration: none}
-;;   .nyxt-diff-delete
-;;   {background-color: #efcbcf;
-;;    text-decoration: none}
-;;   .nyxt-diff-replace
-;;   {background-color: #ecdfbf;
-;;    text-decoration: none}
-;; </style>"
-;;   "TODO")
-
-;; this doesn't contemplate if buffer *diff* already exists
-;; add a proper title perhaps?  (*diff* + old buffer name + new buffer name)
-(defun make-diff-buffer (html-diff-string html-diff-style)
-  "TODO"
-  (with-current-html-buffer (buffer "*diff*" 'base-mode)
-    ;; FIXME title isn't overridden when the html contains the title tag
-    (str:concat html-diff-style
-                (if (str:contains? "<title>" html-diff-string)
-                    (ppcre:regex-replace "<title>.*</title>" html-diff-string "")
-                    html-diff-string))))
-
-(defun diff-buffers ()
-  "TODO"
-  ;; facilitates the following use case:
-  ;; the user wants to make a diff between the current-buffer and last inactive
-  ;; buffer
-  (let* ((old-html (ffi-buffer-get-document
-                    (prompt-minibuffer
-                     :input-prompt "Old buffer"
-                     :suggestion-function (buffer-suggestion-filter))))
-         (new-html (ffi-buffer-get-document
-                    (prompt-minibuffer
-                     :input-prompt "New buffer"
-                     :suggestion-function (buffer-suggestion-filter
-                                           :current-is-last-p t))))
-         (diff-html (html-diff:html-diff old-html
-                                         new-html
-                                         :insert-class "nyxt-diff-insert"
-                                         :delete-class "nyxt-diff-delete"
-                                         :replace-class "nyxt-diff-replace")))
-    (make-diff-buffer (princ diff-html) html-diff-style)))
-
-;; (define-mode diff-mode ()
-;;   "TODO"
-;;   ((new-html :documentation "TODO")
-;;    (old-html :documentation "TODO")
-;;    (default-display-diff-view :documentation "TODO")
-;;    (destructor (lambda (mode) TODO))
-;;    (constructor (lambda (mode) TODO))))
+(define-mode diff-mode ()
+  "Diff mode is used to view the diffs between two buffers."
+  (;; (buffer (make-internal-buffer :title "*diff*"
+   ;;                               :modes '(base-mode))
+   ;;         :documentation "TODO")
+   (old-html :documentation "TODO")
+   (new-html :documentation "TODO")
+   (diff-html :documentation "TODO")
+   (diff-style (cl-css:css
+                '((".nyxt-diff-insert"
+                   :text-decoration "none"
+                   :background-color "#bbeabb")
+                  ("ins.nyxt-diff-replace"
+                   :text-decoration "none"
+                   :background-color "#bbeabb")
+                  (".nyxt-diff-delete"
+                   :text-decoration "none"
+                   :background-color "#efcbcf")
+                  ("del.nyxt-diff-replace"
+                   :text-decoration "none"
+                   :background-color "#efcbcf")))
+               :documentation "Colours based on the modus-operandi theme by
+Protesilaos Stavrou, which follows the highest standard on accessibility.")
+   (keymap-scheme (define-scheme "diff"
+                    scheme:cua
+                    (list "q" 'delete-current-buffer))
+                  :type keymap:scheme)
+   (destructor (lambda (mode) (nyxt::buffer-delete (buffer mode))))
+   (constructor (lambda (mode)
+                  ;; TODO device a smart way to let users choose from buffers
+                  ;; and/or files
+                  (setf (old-html mode)
+                        (ffi-buffer-get-document
+                         (prompt-minibuffer
+                          :input-prompt "Old buffer"
+                          :suggestion-function (buffer-suggestion-filter))))
+                  (setf (new-html mode)
+                        (ffi-buffer-get-document
+                         (prompt-minibuffer
+                          :input-prompt "New buffer"
+                          :suggestion-function (buffer-suggestion-filter
+                                                :current-is-last-p t))))
+                  (setf (diff-html mode)
+                        (html-diff:html-diff (old-html mode)
+                                             (new-html mode)
+                                             :insert-class "nyxt-diff-insert"
+                                             :delete-class "nyxt-diff-delete"
+                                             :replace-class "nyxt-diff-replace"))
+                  (nyxt::html-set
+                   (str:concat (markup:markup (:style (diff-style mode)))
+                               (diff-html mode))
+                   (buffer mode))
+                  ;; dirty fix to set the title
+                  (setf (title (buffer mode)) "diff")
+                  (set-current-buffer (buffer mode))))))

--- a/source/diff-mode.lisp
+++ b/source/diff-mode.lisp
@@ -49,9 +49,7 @@ the highest standard on accessibility.")
                   ;; a temporary fix below
                   (ffi-buffer-evaluate-javascript
                    (buffer instance)
-                   "document.title = '*diff*'")
-                  ;; (ps:ps (ps:chain document title))
-                  ))))
+                   (ps:ps (setf (ps:chain document title) "*diff*")))))))
 
 (defun prompt-old-html ()
   "Extract the string html representation of the old buffer.
@@ -74,12 +72,12 @@ The last visited buffer appears at the top of the minibuffer prompt."
   "Create a buffer showing a diff between 2 html documents."
   ;; users should be able to choose from buffers and/or files.  to be expanded
   ;; when file-manager-mode is fixed.
-  (set-current-buffer
+  (set-current-buffer               ; change buffer here, not at the constructor
    (diff-mode :old-html (prompt-old-html)
               :new-html (prompt-new-html)
               :buffer (make-internal-buffer
                        ;; it's sensible to set the title here but it will be
-                       ;; overridden anyway by `html-set`
+                       ;; overridden anyway by html-set
                        :title "*diff*"
                        ;; only cua-mode keybindings work, why?
                        :modes '(base-mode)))))

--- a/source/diff-mode.lisp
+++ b/source/diff-mode.lisp
@@ -1,12 +1,7 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-(uiop:define-package :nyxt/diff-mode
-  (:use :common-lisp :nyxt)
-  (:import-from #:keymap #:define-key #:define-scheme)
-  (:export :diff)
-  (:documentation "Mode for displaying web-buffer diffs."))
-(in-package :nyxt/diff-mode)
+(in-package :nyxt)
 
 (define-mode diff-mode ()
   "Diff mode is used to view the diffs between two buffers."
@@ -75,7 +70,6 @@ The last visited buffer appears at the top of the minibuffer prompt."
     :suggestion-function (buffer-suggestion-filter
                           :current-is-last-p t))))
 
-;; how to export this command so that it's available in the minibuffer?
 (define-command diff ()
   "Create a buffer showing a diff between 2 html documents."
   ;; users should be able to choose from buffers and/or files.  to be expanded

--- a/source/diff-mode.lisp
+++ b/source/diff-mode.lisp
@@ -24,7 +24,7 @@
                   ("del.nyxt-diff-replace"
                    :text-decoration "none"
                    :background-color "#efcbcf")))
-                 :documentation "Diff colours for its visual representation.
+               :documentation "Diff colours for its visual representation.
 They're based on the modus-operandi theme by Protesilaos Stavrou, which follows
 the highest standard on accessibility.")
    (keymap-scheme (define-scheme "diff"
@@ -51,33 +51,27 @@ the highest standard on accessibility.")
                    (buffer instance)
                    (ps:ps (setf (ps:chain document title) "*diff*")))))))
 
-(defun prompt-old-html ()
-  "Extract the string html representation of the old buffer.
-The current buffer appears at the top of the minibuffer prompt."
-  (ffi-buffer-get-document
-   (prompt-minibuffer
-    :input-prompt "Old buffer"
-    :suggestion-function (buffer-suggestion-filter))))
-
-(defun prompt-new-html ()
-  "Extract the string html representation of the new buffer.
-The last visited buffer appears at the top of the minibuffer prompt."
-  (ffi-buffer-get-document
-   (prompt-minibuffer
-    :input-prompt "New buffer"
-    :suggestion-function (buffer-suggestion-filter
-                          :current-is-last-p t))))
-
 (define-command diff ()
   "Create a buffer showing a diff between 2 html documents."
   ;; users should be able to choose from buffers and/or files.  to be expanded
   ;; when file-manager-mode is fixed.
-  (set-current-buffer               ; change buffer here, not at the constructor
-   (diff-mode :old-html (prompt-old-html)
-              :new-html (prompt-new-html)
-              :buffer (make-internal-buffer
-                       ;; it's sensible to set the title here but it will be
-                       ;; overridden anyway by html-set
-                       :title "*diff*"
-                       ;; only cua-mode keybindings work, why?
-                       :modes '(base-mode)))))
+  (flet ((fetch-html-from-buffer (&key prompt current-is-last-p)
+           (ffi-buffer-get-document
+            (prompt-minibuffer
+             :input-prompt prompt
+             :suggestion-function (buffer-suggestion-filter
+                                   :current-is-last-p current-is-last-p)))))
+    ;; change buffer here, not at the constructor
+    (set-current-buffer
+     (diff-mode :old-html (fetch-html-from-buffer
+                           :prompt "Old buffer"
+                           :current-is-last-p nil)
+                :new-html (fetch-html-from-buffer
+                           :prompt "New buffer"
+                           :current-is-last-p t)
+                :buffer (make-internal-buffer
+                         ;; it's sensible to set the title here but it will be
+                         ;; overridden anyway by html-set
+                         :title "*diff*"
+                         ;; only cua-mode keybindings work, why?
+                         :modes '(base-mode))))))


### PR DESCRIPTION
This is a first draft on implementing diff-like interfaces in Nyxt.

What's a diff?  We inevitably think of GNU diff &#x2013; a tool that compares
plain text files line by line.  Roughly, it computes the longest common
substring between the lines of each of the 2 files.

There are two lessons to take from here.  A diff is a procedure that
operates on two entities and returns nil when, within a certain meaning
of sameness, they're the same.  Also, it operates in a certain level of
granularity.  In the case of GNU diff, that level is defined to be the
line.  Newlines seem to be a sensible way to partition plain text files.

Let's think about some examples.  Programmers use diffs to compare
changes in source code.  In this case the meaning of sameness is "two
plain text files are the same when they don't differ by any characters".
The level of granularity is the line.  Notice, however, that one could
think of the following meaning of sameness "two source code files are
the same if they produce the same result".  In the case of LISP, the
following two entities would be the same.

```lisp
    (+ 1 1)
```
```lisp
    (+
     1
     1)
```

In such a case, the unit of granularity couldn't be the line anymore,
but the s-exps.  And probably newlines would need to be transformed in
spaces for obvious reasons.  Disregard some abuse of language and/or
imprecisions.

The above thought experiment suffices to understand that our idea of GNU
diff is hopeless for the purpose in Nyxt, in the context of web buffers.
In this case, the idea of sameness is "those things that leave the
visual aspect of the page invariant" and the level of granularity is the
html tag, i.e. things bounded by `<foo>` and `</foo>`.

For now, we focus on textual differences between web pages.  We
disregard differences in terms of fonts, images or other visual aspects.

The above I understood relatively fast.  I had an idea on how to
implement such a diff, but luckily I came across cl-html-diff by John
Wiseman that already does most of the job!

From now on, by diff we mean html diff.  Such a diff takes 2 strings
(i.e. tags, including nested tags) and outputs a new modified tag.  This
modified tag includes substrings enclosed by `ins` or `del` tags, which
serve the purpose of visually marking text as deleted or added.

Example:

Say our inputs are (notice that the order matters!):
`<p>Hello World!</p>`
`<p>Bye World!</p>`

then the output would like that in html:

<p><del class=\"nyxt-diff\">Hello </del><ins class=\"nyxt-diff\">Bye </ins>World!</p>

The style of the `ins` and `del` tags can be modified with the `style`
tag, and that can be included anywhere in an html file.  Such a style
can have classes so that the `ins` and `del` tags inserted by the diff
don't interfere with those already present in the original html file.

Let's talk about user interfaces.  Again, I emphasise that any tag-like
input is accepted by diff.  That means that a whole html page can be
provided, or any subset, say a paragraph.  John recently implemented a
method `ffi-buffer-get-document` that fetches the html of a given
buffer.  Perhaps the most common use case is that the user will be
prompted to choose two buffers (notice again that the order matters) and
this will spawn a new diff buffer.

Diff mode, to my mind, is the mode in which diff buffers by default are
instantiated.  Such a mode can include keybindings to easily close the
buffer (say by pressing `q`), or it could center the buffer while
navigating through diff blocks by pressing `n` and `p`.  Just as a side
note, perhaps sooner or later, we should think about narrowing buffers
(narrow to heading, paragraph, etc).

Since the order matters, I suggest using terminology such as "new" and
"old" instead of a neutral naming such as "A" and "B".

Though the html-diff as is doesn't export this method, it provides a
side-by-side view as an option.  Although I didn't find any
inconsistencies or strange behaviour, I didn't test it enough.

![2021-02-23_14:10:45](https://user-images.githubusercontent.com/45483512/109397358-35f7c000-7947-11eb-8a0b-634fe1399454.png)

There should also be an interface to select html files from the user's
filesystem, and perhaps an easy way for the user to choose tags within
buffers (say we want to compare a given paragraph of a README from the
master branch against an older branch).

In general, the options are vast.  We should focus in what users most
expect and use.

I have a bunch of issues to address.  You can get a sense of them by
looking at commit e98f694a.

Feedback is welcome so that I can get this ("[damn deal](https://invidious.snopyta.org/watch?v=3H4FjCDYtcw)") done.

Here's a preview &#x2013; the diff between the master and 1.0.0 tag of nyxt's
github page.

![Screenshot from 2021-02-27 19-21-11](https://user-images.githubusercontent.com/45483512/109397285-1496d400-7947-11eb-8b42-2712034f2902.png)

-- 

I put myself into troubles while trying to set this up with quicklisp.
Maybe someone can help me with that.  I tried to package this into guix
but I'm having an issue.  For some reason the test asd file is being
loaded before the asd.  Pierre will help me sure!  You can take a look
at what I already did [here](https://git.sr.ht/~aadcg/aadcg-guix-channel/tree/master/item/packages/aadcg-lisp-xyz.scm).
