### PR TITLE
Restore history safely

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -147,9 +147,10 @@ non-new-page requests, buffer URL is not altered."
 (defun auto-mode-handler (request-data)
   (with-data-unsafe (previous-url (history-path (buffer request-data))
                      :key #'(lambda (history)
-                              (sera:and-let* ((history history) ;; history should be non-nil
-                                              (owner (htree:current-owner-node history))
-                                              (parent (htree:parent owner))
+                              (sera:and-let* ((hist history) ;; history should be non-nil
+                                              (owner (htree:current-owner hist))
+                                              (current (htree:current owner))
+                                              (parent (htree:parent current))
                                               (url (url (htree:data parent))))
                                 url)))
     (let* ((auto-mode (find-submode (buffer request-data) 'auto-mode))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -349,16 +349,10 @@ We keep this variable as a means to import the old format to the new one.")
                  (when (htree:owner history new-id)
                    (htree:set-current-owner history new-id)))
                (setf (htree:owners history) new-owners))
-             ;; TODO: Focus last buffer.
-             ;; (let ((latest-id (id (htree:current
-             ;;                       (first (sort (alex:hash-table-values (htree:owners history))
-             ;;                                    #'local-time:timestamp>
-             ;;                                    :key #'htree:last-access))))
-             ;;                  ;; (sort (mapcar #'id (buffer-list))
-             ;;                  ;;       (lambda ()))
-             ;;                  ))
-             ;;   (switch-buffer :id latest-id))
-             )
+             (let ((latest-id (first (first (sort (alex:hash-table-alist (htree:owners history))
+                                                  #'local-time:timestamp>
+                                                  :key (alex:compose #'htree:last-access #'cdr))))))
+               (switch-buffer :id latest-id)))
 
            (restore-history-tree (history)
              (echo "Loading history of ~a URLs from ~s."

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -413,7 +413,12 @@ We keep this variable as a means to import the old format to the new one.")
 
 (defun histories-list (&optional (buffer (current-buffer)))
   (mapcar #'pathname-name
-          (uiop:directory-files (dirname (history-path buffer)))))
+          (remove-if
+           #'(lambda (pathname)
+               (let ((type (pathname-type pathname)))
+                 (or (not (stringp type))
+                  (not (string-equal "lisp" type)))))
+           (uiop:directory-files (dirname (history-path buffer))))))
 
 (defun history-name-suggestion-filter (minibuffer)
   (fuzzy-match (input-buffer minibuffer) (histories-list)))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -439,7 +439,9 @@ Useful for session snapshots, as `restore-history-bu-name' will restore opened b
       (store (data-profile (current-buffer)) path))))
 
 (define-command restore-history-by-name ()
-  "Delete all the buffers of the current session/history and restore the history chosen by user."
+  "Delete all the buffers of the current session/history and restore the history chosen by user.
+The new history rewrites the current one, so make a backup of the history file
+if you want it preserved!"
   ;; TODO: backup current history?
   (sera:and-let* ((name (prompt-minibuffer
                          :input-prompt "The name of the history to restore"

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -290,8 +290,13 @@ To change the default buffer, e.g. set it to a given URL:
       (let ((buffer (current-buffer)))
         ;; Restore session before opening command line URLs, otherwise it will
         ;; reset the session with the new URLs.
-        ;; TODO: Select which history file to load.
-        (get-user-data (data-profile buffer) (history-path buffer))
+        (match (session-restore-prompt *browser*)
+          (:always-ask (restore-history-by-name))
+          (:always-restore (restore (data-profile buffer) (history-path buffer)
+                                    :restore-buffers-p t))
+          (:never-restore (progn
+                            (log:info "Not restoring session.")
+                            (restore (data-profile buffer) (history-path buffer)))))
         (cond
           (urls (open-urls urls))
           (buffer-fn


### PR DESCRIPTION
This ticks a bunch of boxes in #1117, namely:
- Last opened buffer is restored, and
- Named sessions are restored at startup if user wishes them to.

# Things To Discuss:
- Do we need to prompt the user on `Restore session?`, actually? Maybe it's simpler and faster to just present a list of sessions to pick from, as we did before?

# How Has This Been Tested
- I've ran Nyxt for some time. You can see quite a complex `htree:set-current-owner` in `restore`. It's there because I've been getting errors like "owner with identifier X does not exist" because of outdated `htree:current-owner-id`. Not sure errors are gone, though ¯\\\_(ツ)\_/¯

How does it look to you?