### PR TITLE
Remove osicat

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -179,7 +179,7 @@
        ("mk-string-metrics" ,cl-mk-string-metrics)
        ("moptilities" ,cl-moptilities)
        ("named-readtables" ,cl-named-readtables)
-       ("osicat" ,cl-osicat)
+       ;; ("osicat" ,cl-osicat) ; Not needed for SBCL.
        ("parenscript" ,cl-parenscript)
        ("plump" ,cl-plump)
        ("quri" ,cl-quri)

--- a/libraries/ospm/ospm-guix.lisp
+++ b/libraries/ospm/ospm-guix.lisp
@@ -271,13 +271,20 @@ value.
                                 :date (local-time:parse-timestring date)
                                 :path path))
 
+(defun read-link (path)
+  "Resolve PATH symlink once."
+  #+sbcl
+  (sb-posix:readlink path)
+  #-sbcl
+  (osicat:read-link profile))
+
 (defun guix-expand-profile-symlink (profile)
   "Return the path the PROFILE link points too.
 This function is mostly useful for the standard profile and the Guix checkout profile.
 
 If the result is not absolute, return PROFILE untouched.  This is what we want
 for non-standard profiles."
-  (let ((result (osicat:read-link profile)))
+  (let ((result (read-link profile)))
     (if (uiop:relative-pathname-p result)
         profile
         result)))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -314,6 +314,7 @@
                cl-ppcre
                local-time
                named-readtables
+               #-sbcl
                osicat
                serapeum
                str

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -23,6 +23,8 @@
                :local-time
                :log4cl
                :mk-string-metrics
+               #-sbcl
+               osicat
                :parenscript
                :quri
                :serapeum


### PR DESCRIPTION
This specializes some code to use SBCL extensions instead of Osicat.  It still falls back to Osicat when not using SBCL.

 This allows us to get rid of Osicat, which is a bit harder to package than the rest because the `.so` is generated within the Osicat package.

@jmercouris Can you test to make sure I didn't break it for you?
