### PR TITLE
WIP: Add process-mode.

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -134,6 +134,7 @@
                (:file "os-package-manager-mode")
                (:file "visual-mode")
                (:file "process-mode")
+               (:file "repeat-mode")
                (:file "watch-mode")
                (:file "preview-mode")
                (:file "diff-mode")

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -133,7 +133,9 @@
                (:file "reduce-tracking-mode")
                (:file "os-package-manager-mode")
                (:file "visual-mode")
+               (:file "action-mode")
                (:file "watch-mode")
+               (:file "preview-mode")
                (:file "diff-mode")
                ;; Web-mode commands
                (:file "bookmarklets")

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -133,7 +133,7 @@
                (:file "reduce-tracking-mode")
                (:file "os-package-manager-mode")
                (:file "visual-mode")
-               (:file "action-mode")
+               (:file "process-mode")
                (:file "watch-mode")
                (:file "preview-mode")
                (:file "diff-mode")

--- a/source/action-mode.lisp
+++ b/source/action-mode.lisp
@@ -1,0 +1,209 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package :nyxt/action-mode
+  (:use :common-lisp :trivia :nyxt)
+  (:import-from #:class-star #:define-class)
+  (:documentation "Act on file/directory based on a certain condition."))
+(in-package :nyxt/action-mode)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
+  (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
+  (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
+
+;; REVIEW: `action' and `cleanup' resemble `constructor' and `destructor'.
+;; TODO: Maybe subclass `action-mode' instead?
+;; This will sacrifice the flexibility of `action's, though...
+(define-class action ()
+  ((firing-condition t
+                         :type (or boolean function)
+                         :documentation "The condition for the action firing.
+Can be boolean (T to always fire, NIL to never fire), or function over URL and mode.")
+   (action nil
+           :type (or (function (quri:uri root-mode)) null)
+           :documentation "The action (function) to do with file URL and action-mode.")
+   (cleanup nil
+            :type (or (function (quri:uri root-mode)) null)
+            :documentation "Function to run when action ends.
+Accepts the path to the acted-on document and action-mode instance."))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:export-predicate-name-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+
+(defmethod nyxt:object-string ((action action))
+  (str:downcase (symbol-name (sera:class-name-of action))))
+
+(defmethod nyxt:object-display ((action action))
+  (str:downcase (symbol-name (sera:class-name-of action))))
+
+(defun updated-file-p (path-url mode)
+  (and
+   (quri:uri-file-p path-url)
+   (or (null (last-access (action mode)))
+       (local-time:timestamp>
+        (local-time:universal-to-timestamp
+         (file-attributes:modification-time (quri:uri-path path-url)))
+        (last-access (action mode))))))
+
+(define-class preview-action (action)
+  ((firing-condition #'updated-file-p)
+   (action
+    #'(lambda (path-url mode)
+        (buffer-load path-url :buffer (buffer mode))
+        (setf (last-access (action mode)) (local-time:now))))
+   (last-access nil
+                :type (or local-time:timestamp null)
+                :documentation "The time `path-url' file was last accessed."))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+
+(define-class server-action (preview-action)
+  ((action #'(lambda (path-url mode)
+               (setf (acceptor (action mode))
+                     (if (acceptor (action mode))
+                         (hunchentoot:start
+                          (hunchentoot:stop (acceptor (action mode))))
+                         (hunchentoot:start
+                          (or (acceptor (action mode))
+                              (make-instance 'hunchentoot:easy-acceptor
+                                             :document-root (uiop:pathname-directory-pathname
+                                                             (pathname (quri:uri-path path-url)))
+                                             :address (address (action mode))
+                                             :port (port (action mode)))))))
+               (buffer-load (quri:make-uri :host (address (action mode))
+                                           :port (port (action mode)))
+                            :buffer (buffer mode))))
+   (cleanup #'(lambda (path-url mode)
+                (declare (ignore path-url))
+                (when (acceptor (action mode))
+                  (hunchentoot:stop (acceptor (action mode))))))
+   (acceptor nil
+             :type (or hunchentoot:acceptor null)
+             :export nil
+             :documentation "Current server acceptor.")
+   (address "localhost"
+            :type (or string null)
+            :documentation "What address to set the server listening on.
+Listens on all machine IPs if not set (see `hunchentoot:acceptor'.)")
+   (port 8080
+         :type integer
+         :documentation "The port server starts on."))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+
+(defun seconds-from-user-input ()
+  "Read from the minibuffer numerical time inputs and collate them into
+seconds."
+  (let* ((time-units '("days" "hours" "minutes" "seconds"))
+         (to-seconds-alist (pairlis time-units '(86400 3600 60 1)))
+         (active-time-units (prompt-minibuffer
+                             :input-prompt "Time unit(s)"
+                             :multi-selection-p t
+                             :suggestion-function (lambda (minibuffer)
+                                                    (fuzzy-match
+                                                     (input-buffer minibuffer)
+                                                     time-units))))
+         (times (mapcar (lambda (unit)
+                          (parse-integer
+                           (prompt-minibuffer
+                            :input-prompt (format nil "Time interval (~a)" unit)
+                            :hide-suggestion-count-p t)
+                           :junk-allowed t))
+                        active-time-units))
+         (to-seconds-multipliers
+           (mapcar
+            (lambda (elem) (cdr (assoc elem to-seconds-alist :test 'string-equal)))
+            active-time-units)))
+    (echo "Refreshing every ~:@{~{~d ~}~a~:@}"
+          (list times active-time-units))
+    (apply '+ (mapcar (lambda (time multiplier) (* time multiplier))
+                      times to-seconds-multipliers))))
+
+(define-class watch-action (action)
+  ((action #'(lambda (path-url mode)
+               (unless (sleep-time (action mode))
+                 (setf (sleep-time (action mode)) (seconds-from-user-input)))
+               (loop
+                 (if (quri:uri= path-url (url (buffer mode)))
+                     (reload-current-buffer (buffer mode))
+                     (buffer-load path-url :buffer (buffer mode)))
+                 (sleep (sleep-time mode)))))
+   (sleep-time :documentation "The amount of time to sleep between reloads."))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+
+(define-class line-count-action (nyxt/action-mode:preview-action)
+  ((action
+    #'(lambda (path-url mode)
+        (let ((lines (length (uiop:read-file-lines (quri:uri-path path-url)))))
+          (when (\= (lines (action mode)) lines)
+            (nyxt:echo "~a has ~a lines of text." (quri:uri-path path-url) lines)))))
+   (lines :documentation "The number of lines that file had the last time it was checked."))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+
+(defun initialize-action-mode (mode)
+  (sera:and-let* ((url (quri:uri (prompt-minibuffer
+                                  :input-prompt "URL of the document to act on"
+                                  :input-buffer (object-string (url (current-buffer)))))))
+    (setf (path-url mode) url
+          (thread mode) (bt:make-thread
+                         #'(lambda ()
+                             (loop
+                               with condition = (firing-condition (action mode))
+                               when (typecase condition
+                                      (function (funcall condition url mode))
+                                      (boolean condition))
+                                 do (funcall (action (action mode)) url mode)))))))
+
+(defun clean-up-action-mode (mode)
+  (and (cleanup (action mode))
+       (funcall (cleanup (action mode)) (path-url mode) mode))
+  (bt:destroy-thread (thread mode)))
+
+(define-mode action-mode ()
+  "Conditional execution a file/directory-related actions in a separate thread.
+
+Possible applications:
+- Web server (`server-action').
+- Live preview of documents (`preview-action').
+- Refreshing the website at regular intervals (`watch-action').
+- Live tracking of filesystem/data in a file/directory."
+  ((path-url nil
+             :type (or quri:uri null)
+             :documentation "The path to where `display-mode' needs to track things at.
+Is not necessarily the same as current buffer URL.")
+   (possible-actions (list (make-instance 'preview-action)
+                           (make-instance 'server-action)
+                           (make-instance 'watch-action))
+                     :type list
+                     :documentation "The list of action symbols to choose suitable action from.
+Customize this to add your own action to the list.")
+   (action (make-instance 'preview-action)
+           :type action
+           :documentation "Action to run when `action-mode' is activated.
+Defaults to `preview-action'.")
+   (thread nil
+           :type (or bt:thread null)
+           :export nil
+           :documentation "The thread that actions happen in.")
+   (constructor #'initialize-action-mode)
+   (destructor #'clean-up-action-mode)))
+
+(in-package :nyxt)
+
+(define-command action-mode-with-action (&optional (buffer (current-buffer)))
+  "Enable `action-mode' in BUFFER and prompt about the action to use with it."
+  ;; There seems to be no better way to get the list of actions.
+  (let* ((mode (make-instance 'nyxt/action-mode:action-mode))
+         (action (prompt-minibuffer :input-prompt "Action to use"
+                                    :suggestion-function (lambda (minibuffer)
+                                                           (fuzzy-match
+                                                            (input-buffer minibuffer)
+                                                            (nyxt/action-mode:possible-actions mode))))))
+    (nyxt/action-mode:action-mode :buffer buffer :activate t :action action)))

--- a/source/action-mode.lisp
+++ b/source/action-mode.lisp
@@ -11,32 +11,6 @@
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
   (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
 
-;; REVIEW: `action' and `cleanup' resemble `constructor' and `destructor'.
-;; TODO: Maybe subclass `action-mode' instead?
-;; This will sacrifice the flexibility of `action's, though...
-(define-class action ()
-  ((firing-condition t
-                         :type (or boolean function)
-                         :documentation "The condition for the action firing.
-Can be boolean (T to always fire, NIL to never fire), or function over URL and mode.")
-   (action nil
-           :type (or (function (quri:uri root-mode)) null)
-           :documentation "The action (function) to do with file URL and action-mode.")
-   (cleanup nil
-            :type (or (function (quri:uri root-mode)) null)
-            :documentation "Function to run when action ends.
-Accepts the path to the acted-on document and action-mode instance."))
-  (:export-class-name-p t)
-  (:export-accessor-names-p t)
-  (:export-predicate-name-p t)
-  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
-
-(defmethod nyxt:object-string ((action action))
-  (str:downcase (symbol-name (sera:class-name-of action))))
-
-(defmethod nyxt:object-display ((action action))
-  (str:downcase (symbol-name (sera:class-name-of action))))
-
 (defun updated-file-p (path-url mode)
   (and
    (quri:uri-file-p path-url)
@@ -46,106 +20,16 @@ Accepts the path to the acted-on document and action-mode instance."))
          (file-attributes:modification-time (quri:uri-path path-url)))
         (last-access (action mode))))))
 
-(define-class preview-action (action)
-  ((firing-condition #'updated-file-p)
-   (action
-    #'(lambda (path-url mode)
-        (buffer-load path-url :buffer (buffer mode))
-        (setf (last-access (action mode)) (local-time:now))))
-   (last-access nil
-                :type (or local-time:timestamp null)
-                :documentation "The time `path-url' file was last accessed."))
-  (:export-class-name-p t)
-  (:export-accessor-names-p t)
-  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
-
-(define-class server-action (preview-action)
-  ((action #'(lambda (path-url mode)
-               (setf (acceptor (action mode))
-                     (if (acceptor (action mode))
-                         (hunchentoot:start
-                          (hunchentoot:stop (acceptor (action mode))))
-                         (hunchentoot:start
-                          (or (acceptor (action mode))
-                              (make-instance 'hunchentoot:easy-acceptor
-                                             :document-root (uiop:pathname-directory-pathname
-                                                             (pathname (quri:uri-path path-url)))
-                                             :address (address (action mode))
-                                             :port (port (action mode)))))))
-               (buffer-load (quri:make-uri :host (address (action mode))
-                                           :port (port (action mode)))
-                            :buffer (buffer mode))))
-   (cleanup #'(lambda (path-url mode)
-                (declare (ignore path-url))
-                (when (acceptor (action mode))
-                  (hunchentoot:stop (acceptor (action mode))))))
-   (acceptor nil
-             :type (or hunchentoot:acceptor null)
-             :export nil
-             :documentation "Current server acceptor.")
-   (address "localhost"
-            :type (or string null)
-            :documentation "What address to set the server listening on.
-Listens on all machine IPs if not set (see `hunchentoot:acceptor'.)")
-   (port 8080
-         :type integer
-         :documentation "The port server starts on."))
-  (:export-class-name-p t)
-  (:export-accessor-names-p t)
-  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
-
-(defun seconds-from-user-input ()
-  "Read from the minibuffer numerical time inputs and collate them into
-seconds."
-  (let* ((time-units '("days" "hours" "minutes" "seconds"))
-         (to-seconds-alist (pairlis time-units '(86400 3600 60 1)))
-         (active-time-units (prompt-minibuffer
-                             :input-prompt "Time unit(s)"
-                             :multi-selection-p t
-                             :suggestion-function (lambda (minibuffer)
-                                                    (fuzzy-match
-                                                     (input-buffer minibuffer)
-                                                     time-units))))
-         (times (mapcar (lambda (unit)
-                          (parse-integer
-                           (prompt-minibuffer
-                            :input-prompt (format nil "Time interval (~a)" unit)
-                            :hide-suggestion-count-p t)
-                           :junk-allowed t))
-                        active-time-units))
-         (to-seconds-multipliers
-           (mapcar
-            (lambda (elem) (cdr (assoc elem to-seconds-alist :test 'string-equal)))
-            active-time-units)))
-    (echo "Refreshing every ~:@{~{~d ~}~a~:@}"
-          (list times active-time-units))
-    (apply '+ (mapcar (lambda (time multiplier) (* time multiplier))
-                      times to-seconds-multipliers))))
-
-(define-class watch-action (action)
-  ((action #'(lambda (path-url mode)
-               (unless (sleep-time (action mode))
-                 (setf (sleep-time (action mode)) (seconds-from-user-input)))
-               (loop
-                 (if (quri:uri= path-url (url (buffer mode)))
-                     (reload-current-buffer (buffer mode))
-                     (buffer-load path-url :buffer (buffer mode)))
-                 (sleep (sleep-time mode)))))
-   (sleep-time :documentation "The amount of time to sleep between reloads."))
-  (:export-class-name-p t)
-  (:export-accessor-names-p t)
-  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
-
-(define-class line-count-action (nyxt/action-mode:preview-action)
-  ((action
-    #'(lambda (path-url mode)
-        (let ((lines (length (uiop:read-file-lines (quri:uri-path path-url)))))
-          (when (\= (lines (action mode)) lines)
-            (nyxt:echo "~a has ~a lines of text." (quri:uri-path path-url) lines)))))
-   (lines :documentation "The number of lines that file had the last time it was checked."))
-  (:export-class-name-p t)
-  (:export-accessor-names-p t)
-  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+;; (define-class line-count-action (nyxt/action-mode:preview-action)
+;;   ((action
+;;     #'(lambda (path-url mode)
+;;         (let ((lines (length (uiop:read-file-lines (quri:uri-path path-url)))))
+;;           (when (\= (lines (action mode)) lines)
+;;             (nyxt:echo "~a has ~a lines of text." (quri:uri-path path-url) lines)))))
+;;    (lines :documentation "The number of lines that file had the last time it was checked."))
+;;   (:export-class-name-p t)
+;;   (:export-accessor-names-p t)
+;;   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))l
 
 (defun initialize-action-mode (mode)
   (sera:and-let* ((url (quri:uri (prompt-minibuffer
@@ -154,56 +38,44 @@ seconds."
     (setf (path-url mode) url
           (thread mode) (bt:make-thread
                          #'(lambda ()
-                             (loop
-                               with condition = (firing-condition (action mode))
-                               when (typecase condition
-                                      (function (funcall condition url mode))
-                                      (boolean condition))
-                                 do (funcall (action (action mode)) url mode)))))))
+                             (loop with cond = (firing-condition mode)
+                                   with cond-func = (typecase cond
+                                                      (function cond)
+                                                      (boolean (constantly cond)))
+                                   when (funcall cond-function url mode)
+                                     do (funcall (action mode) url mode)))))))
 
 (defun clean-up-action-mode (mode)
-  (and (cleanup (action mode))
-       (funcall (cleanup (action mode)) (path-url mode) mode))
+  (and (cleanup mode)
+       (funcall (cleanup mode) (path-url mode) mode))
   (bt:destroy-thread (thread mode)))
 
 (define-mode action-mode ()
   "Conditional execution a file/directory-related actions in a separate thread.
 
 Possible applications:
-- Web server (`server-action').
-- Live preview of documents (`preview-action').
-- Refreshing the website at regular intervals (`watch-action').
+- Web server.
+- Live preview of documents (`preview-mode').
+- Refreshing the website at regular intervals (`watch-mode').
 - Live tracking of filesystem/data in a file/directory."
   ((path-url nil
              :type (or quri:uri null)
-             :documentation "The path to where `display-mode' needs to track things at.
+             :documentation "The path to where `action-mode' needs to track things at.
 Is not necessarily the same as current buffer URL.")
-   (possible-actions (list (make-instance 'preview-action)
-                           (make-instance 'server-action)
-                           (make-instance 'watch-action))
-                     :type list
-                     :documentation "The list of action symbols to choose suitable action from.
-Customize this to add your own action to the list.")
-   (action (make-instance 'preview-action)
-           :type action
-           :documentation "Action to run when `action-mode' is activated.
-Defaults to `preview-action'.")
+   (firing-condition t
+                     :type (or boolean function)
+                     :documentation "The condition for the action firing.
+Can be boolean (T to always fire, NIL to never fire), or function over URL and mode instance.")
+   (action nil
+           :type (or (function (quri:uri root-mode)) null)
+           :documentation "The action (function) to do with file URL and `action-mode' instance.")
+   (cleanup nil
+            :type (or (function (quri:uri root-mode)) null)
+            :documentation "Function to run when action ends.
+Accepts the path to the acted-on document and action-mode instance.")
    (thread nil
            :type (or bt:thread null)
            :export nil
-           :documentation "The thread that actions happen in.")
+           :documentation "The thread that `actions' happen in.")
    (constructor #'initialize-action-mode)
    (destructor #'clean-up-action-mode)))
-
-(in-package :nyxt)
-
-(define-command action-mode-with-action (&optional (buffer (current-buffer)))
-  "Enable `action-mode' in BUFFER and prompt about the action to use with it."
-  ;; There seems to be no better way to get the list of actions.
-  (let* ((mode (make-instance 'nyxt/action-mode:action-mode))
-         (action (prompt-minibuffer :input-prompt "Action to use"
-                                    :suggestion-function (lambda (minibuffer)
-                                                           (fuzzy-match
-                                                            (input-buffer minibuffer)
-                                                            (nyxt/action-mode:possible-actions mode))))))
-    (nyxt/action-mode:action-mode :buffer buffer :activate t :action action)))

--- a/source/preview-mode.lisp
+++ b/source/preview-mode.lisp
@@ -1,0 +1,32 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package :nyxt/preview-mode
+  (:use :common-lisp :trivia :nyxt)
+  (:import-from #:class-star #:define-class)
+  (:documentation "Refresh file when changed on disk."))
+(in-package :nyxt/preview-mode)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
+  (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
+  (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
+
+(define-mode preview-mode (nyxt/action-mode:action-mode)
+  "Refreshes the buffer when associated local file is changed."
+  ((firing-condition #'updated-file-p)
+   (action
+    #'(lambda (path-url mode)
+        (buffer-load path-url :buffer (buffer mode))
+        (setf (last-access mode) (local-time:now))))
+   (last-access nil
+                :type (or local-time:timestamp null)
+                :documentation "The time file was last accessed.")))
+
+(in-package :nyxt)
+
+(define-command preview-file (&optional file (buffer (current-buffer)))
+  "Open a file in the current buffer and call `preview-mode' to continuously
+watch and refresh it."
+  (sera:and-let* ((file (or file (prompt :prompt "File to preview"))))
+    (buffer-load (quri.uri.file:make-uri-file :path file) :buffer buffer)
+    (preview-mode)))

--- a/source/preview-mode.lisp
+++ b/source/preview-mode.lisp
@@ -11,7 +11,16 @@
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
   (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
 
-(define-mode preview-mode (nyxt/action-mode:action-mode)
+(defun updated-file-p (path-url mode)
+  (and
+   (quri:uri-file-p path-url)
+   (or (null (last-access mode))
+       (local-time:timestamp>
+        (local-time:universal-to-timestamp
+         (file-attributes:modification-time (quri:uri-path path-url)))
+        (last-access mode)))))
+
+(define-mode preview-mode (nyxt/process-mode:process-mode)
   "Refreshes the buffer when associated local file is changed."
   ((firing-condition #'updated-file-p)
    (action
@@ -29,4 +38,4 @@
 watch and refresh it."
   (sera:and-let* ((file (or file (prompt :prompt "File to preview"))))
     (buffer-load (quri.uri.file:make-uri-file :path file) :buffer buffer)
-    (preview-mode)))
+    (nyxt/preview-mode:preview-mode)))

--- a/source/preview-mode.lisp
+++ b/source/preview-mode.lisp
@@ -35,7 +35,7 @@
 (define-command preview-file (&optional file (buffer (current-buffer)))
   "Open a file in the current buffer and call `preview-mode' to continuously
 watch and refresh it."
-  (sera:and-let* ((file (or file (prompt :prompt "File to preview"
+  (alex:when-let ((file (or file (prompt :prompt "File to preview"
                                          :input (quri:uri-path (url (current-buffer)))
                                          :sources (list (make-instance 'file-source))))))
     (buffer-load (quri.uri.file:make-uri-file :path file) :buffer buffer)

--- a/source/preview-mode.lisp
+++ b/source/preview-mode.lisp
@@ -36,6 +36,8 @@
 (define-command preview-file (&optional file (buffer (current-buffer)))
   "Open a file in the current buffer and call `preview-mode' to continuously
 watch and refresh it."
-  (sera:and-let* ((file (or file (prompt :prompt "File to preview"))))
+  (sera:and-let* ((file (or file (prompt :prompt "File to preview"
+                                         :input (quri:uri-path (url (current-buffer)))
+                                         :sources (list (make-instance 'file-source))))))
     (buffer-load (quri.uri.file:make-uri-file :path file) :buffer buffer)
     (nyxt/preview-mode:preview-mode)))

--- a/source/preview-mode.lisp
+++ b/source/preview-mode.lisp
@@ -21,8 +21,8 @@
 
 (define-mode preview-mode (nyxt/process-mode:process-mode)
   "Refreshes the buffer when associated local file is changed."
-  ((firing-condition #'updated-file-p)
-   (action
+  ((nyxt/process-mode:firing-condition #'updated-file-p)
+   (nyxt/process-mode:action
     #'(lambda (path-url mode)
         (buffer-load path-url :buffer (buffer mode))
         (setf (last-access mode) (local-time:now))))

--- a/source/preview-mode.lisp
+++ b/source/preview-mode.lisp
@@ -8,7 +8,6 @@
 (in-package :nyxt/preview-mode)
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
-  (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
   (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
 
 (defun updated-file-p (path-url mode)

--- a/source/preview-mode.lisp
+++ b/source/preview-mode.lisp
@@ -7,8 +7,7 @@
   (:documentation "Refresh file when changed on disk."))
 (in-package :nyxt/preview-mode)
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
-  (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria))
 
 (defun updated-file-p (path-url mode)
   (and
@@ -16,7 +15,8 @@
    (or (null (last-access mode))
        (local-time:timestamp>
         (local-time:universal-to-timestamp
-         (file-attributes:modification-time (quri:uri-path path-url)))
+         (sb-posix:stat-mtime
+          (sb-posix:stat (quri:uri-path path-url))))
         (last-access mode)))))
 
 (define-mode preview-mode (nyxt/process-mode:process-mode)

--- a/source/preview-mode.lisp
+++ b/source/preview-mode.lisp
@@ -2,7 +2,7 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (uiop:define-package :nyxt/preview-mode
-  (:use :common-lisp :trivia :nyxt)
+    (:use :common-lisp :trivia :nyxt)
   (:import-from #:class-star #:define-class)
   (:documentation "Refresh file when changed on disk."))
 (in-package :nyxt/preview-mode)
@@ -10,14 +10,12 @@
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria))
 
 (defun updated-file-p (path-url mode)
-  (and
-   (quri:uri-file-p path-url)
-   (or (null (last-access mode))
-       (local-time:timestamp>
-        (local-time:universal-to-timestamp
-         (sb-posix:stat-mtime
-          (sb-posix:stat (quri:uri-path path-url))))
-        (last-access mode)))))
+  (when (quri:uri-file-p path-url)
+    (or (null (last-access mode))
+        (local-time:timestamp>
+         (local-time:universal-to-timestamp
+          (uiop:safe-file-write-date (quri:uri-path path-url)))
+         (last-access mode)))))
 
 (define-mode preview-mode (nyxt/process-mode:process-mode)
   "Refreshes the buffer when associated local file is changed."

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -1,40 +1,20 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-(uiop:define-package :nyxt/action-mode
+(uiop:define-package :nyxt/process-mode
   (:use :common-lisp :trivia :nyxt)
   (:import-from #:class-star #:define-class)
   (:documentation "Act on file/directory based on a certain condition."))
-(in-package :nyxt/action-mode)
+(in-package :nyxt/process-mode)
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
   (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
 
-(defun updated-file-p (path-url mode)
-  (and
-   (quri:uri-file-p path-url)
-   (or (null (last-access (action mode)))
-       (local-time:timestamp>
-        (local-time:universal-to-timestamp
-         (file-attributes:modification-time (quri:uri-path path-url)))
-        (last-access (action mode))))))
-
-;; (define-class line-count-action (nyxt/action-mode:preview-action)
-;;   ((action
-;;     #'(lambda (path-url mode)
-;;         (let ((lines (length (uiop:read-file-lines (quri:uri-path path-url)))))
-;;           (when (\= (lines (action mode)) lines)
-;;             (nyxt:echo "~a has ~a lines of text." (quri:uri-path path-url) lines)))))
-;;    (lines :documentation "The number of lines that file had the last time it was checked."))
-;;   (:export-class-name-p t)
-;;   (:export-accessor-names-p t)
-;;   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))l
-
-(defun initialize-action-mode (mode)
-  (sera:and-let* ((url (quri:uri (prompt-minibuffer
-                                  :input-prompt "URL of the document to act on"
-                                  :input-buffer (object-string (url (current-buffer)))))))
+(defun initialize-process-mode (mode)
+  (sera:and-let* ((url (quri:uri (prompt
+                                  :prompt "URL of the document to act on"
+                                  :input (object-string (url (current-buffer)))))))
     (setf (path-url mode) url
           (thread mode) (bt:make-thread
                          #'(lambda ()
@@ -42,15 +22,15 @@
                                    with cond-func = (typecase cond
                                                       (function cond)
                                                       (boolean (constantly cond)))
-                                   when (funcall cond-function url mode)
-                                     do (funcall (action mode) url mode)))))))
+                                   when (funcall cond-func url mode)
+                                     do (funcall mode url mode)))))))
 
-(defun clean-up-action-mode (mode)
+(defun clean-up-process-mode (mode)
   (and (cleanup mode)
        (funcall (cleanup mode) (path-url mode) mode))
   (bt:destroy-thread (thread mode)))
 
-(define-mode action-mode ()
+(define-mode process-mode ()
   "Conditional execution a file/directory-related actions in a separate thread.
 
 Possible applications:
@@ -60,7 +40,7 @@ Possible applications:
 - Live tracking of filesystem/data in a file/directory."
   ((path-url nil
              :type (or quri:uri null)
-             :documentation "The path to where `action-mode' needs to track things at.
+             :documentation "The path to where `process-mode' needs to track things at.
 Is not necessarily the same as current buffer URL.")
    (firing-condition t
                      :type (or boolean function)
@@ -68,14 +48,14 @@ Is not necessarily the same as current buffer URL.")
 Can be boolean (T to always fire, NIL to never fire), or function over URL and mode instance.")
    (action nil
            :type (or (function (quri:uri root-mode)) null)
-           :documentation "The action (function) to do with file URL and `action-mode' instance.")
+           :documentation "The action (function) to do with file URL and `process-mode' instance.")
    (cleanup nil
             :type (or (function (quri:uri root-mode)) null)
-            :documentation "Function to run when action ends.
-Accepts the path to the acted-on document and action-mode instance.")
+            :documentation "Function to run when process ends.
+Accepts the path to the acted-on document and `process-mode' instance.")
    (thread nil
            :type (or bt:thread null)
            :export nil
-           :documentation "The thread that `actions' happen in.")
-   (constructor #'initialize-action-mode)
-   (destructor #'clean-up-action-mode)))
+           :documentation "The thread that `action' happen in.")
+   (constructor #'initialize-process-mode)
+   (destructor #'clean-up-process-mode)))

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -23,7 +23,7 @@
                                                       (function cond)
                                                       (boolean (constantly cond)))
                                    when (funcall cond-func url mode)
-                                     do (funcall mode url mode)))))))
+                                     do (funcall (action mode) url mode)))))))
 
 (defun clean-up-process-mode (mode)
   (and (cleanup mode)

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -8,16 +8,15 @@
 (in-package :nyxt/process-mode)
 
 (defun initialize-process-mode (mode)
-  (let ((url (url (current-buffer))))
-    (setf (path-url mode) url
-          (thread mode) (bt:make-thread
-                         #'(lambda ()
-                             (loop with cond = (firing-condition mode)
-                                   with cond-func = (typecase cond
-                                                      (function cond)
-                                                      (boolean (constantly cond)))
-                                   when (funcall cond-func url mode)
-                                     do (funcall (action mode) url mode)))))))
+  (setf (path-url mode) (url (current-buffer))
+        (thread mode) (bt:make-thread
+                       #'(lambda ()
+                           (loop with cond = (firing-condition mode)
+                                 with cond-func = (typecase cond
+                                                    (function cond)
+                                                    (boolean (constantly cond)))
+                                 when (funcall cond-func (path-url mode) mode)
+                                   do (funcall (action mode) (path-url mode) mode))))))
 
 (defun clean-up-process-mode (mode)
   (and (cleanup mode)

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -12,9 +12,7 @@
   (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
 
 (defun initialize-process-mode (mode)
-  (sera:and-let* ((url (quri:uri (prompt
-                                  :prompt "URL of the document to act on"
-                                  :input (object-string (url (current-buffer)))))))
+  (let ((url (url (current-buffer))))
     (setf (path-url mode) url
           (thread mode) (bt:make-thread
                          #'(lambda ()

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -6,10 +6,6 @@
   (:import-from #:class-star #:define-class)
   (:documentation "Act on file/directory based on a certain condition."))
 (in-package :nyxt/process-mode)
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
-  (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
-  (trivial-package-local-nicknames:add-package-local-nickname :file-attributes :org.shirakumo.file-attributes))
 
 (defun initialize-process-mode (mode)
   (let ((url (url (current-buffer))))

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -35,14 +35,14 @@ Possible applications:
              :documentation "The path to where `process-mode' needs to track things at.
 Is not necessarily the same as current buffer URL.")
    (firing-condition t
-                     :type (or boolean function)
+                     :type (or boolean (function (quri:uri process-mode)))
                      :documentation "The condition for the action firing.
 Can be boolean (T to always fire, NIL to never fire), or function over URL and mode instance.")
    (action nil
-           :type (or (function (quri:uri root-mode)) null)
+           :type (or (function (quri:uri process-mode)) null)
            :documentation "The action (function) to do with file URL and `process-mode' instance.")
    (cleanup nil
-            :type (or (function (quri:uri root-mode)) null)
+            :type (or (function (quri:uri process-mode)) null)
             :documentation "Function to run when process ends.
 Accepts the path to the acted-on document and `process-mode' instance.")
    (thread nil

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -9,7 +9,7 @@
 
 (defun initialize-process-mode (mode)
   (setf (path-url mode) (or (path-url mode) (url (current-buffer)))
-        (thread mode) (run-tread
+        (thread mode) (run-thread
                        (loop with cond = (firing-condition mode)
                              with cond-func = (typecase cond
                                                 (function cond)

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -9,19 +9,18 @@
 
 (defun initialize-process-mode (mode)
   (setf (path-url mode) (or (path-url mode) (url (current-buffer)))
-        (thread mode) (bt:make-thread
-                       #'(lambda ()
-                           (loop with cond = (firing-condition mode)
-                                 with cond-func = (typecase cond
-                                                    (function cond)
-                                                    (boolean (constantly cond)))
-                                 when (funcall cond-func (path-url mode) mode)
-                                   do (funcall (action mode) (path-url mode) mode))))))
+        (thread mode) (run-tread
+                       (loop with cond = (firing-condition mode)
+                             with cond-func = (typecase cond
+                                                (function cond)
+                                                (boolean (constantly cond)))
+                             when (funcall cond-func (path-url mode) mode)
+                               do (funcall (action mode) (path-url mode) mode)))))
 
 (defun clean-up-process-mode (mode)
   (and (cleanup mode)
        (funcall (cleanup mode) (path-url mode) mode))
-  (bt:destroy-thread (thread mode)))
+  (bt:join-thread (thread mode)))
 
 (define-mode process-mode ()
   "Conditional execution a file/directory-related actions in a separate thread.

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -20,7 +20,7 @@
 (defun clean-up-process-mode (mode)
   (and (cleanup mode)
        (funcall (cleanup mode) (path-url mode) mode))
-  (bt:join-thread (thread mode)))
+  (bt:destroy-thread (thread mode)))
 
 (define-mode process-mode ()
   "Conditional execution a file/directory-related actions in a separate thread.

--- a/source/process-mode.lisp
+++ b/source/process-mode.lisp
@@ -8,7 +8,7 @@
 (in-package :nyxt/process-mode)
 
 (defun initialize-process-mode (mode)
-  (setf (path-url mode) (url (current-buffer))
+  (setf (path-url mode) (or (path-url mode) (url (current-buffer)))
         (thread mode) (bt:make-thread
                        #'(lambda ()
                            (loop with cond = (firing-condition mode)

--- a/source/repeat-mode.lisp
+++ b/source/repeat-mode.lisp
@@ -8,17 +8,21 @@
 
 (serapeum:export-always 'repeat-seconds)
 (defun repeat-seconds (seconds)
-  (lambda (&rest args)
-    (declare (ignore args))
-    (sleep seconds)
-    t))
+  #'(lambda (&rest args)
+      (declare (ignore args))
+      (sleep seconds)
+      t))
 
 (defun initialize-repeat-mode (mode)
   (unless (repetitive-action mode)
-    (setf (repetitive-action mode)
-          (first
-           (prompt :prompt "Command to repeat"
-                   :sources (list (make-instance 'nyxt:command-source))))))
+    (let ((prompted-action
+            (first
+             (prompt :prompt "Command to repeat"
+                     :sources (list (make-instance 'nyxt:command-source))))))
+      (setf (repetitive-action mode)
+            #'(lambda (mode)
+                (declare (ignore mode))
+                (nyxt::run prompted-action)))))
   (nyxt/process-mode::initialize-process-mode mode))
 
 (define-mode repeat-mode (nyxt/process-mode:process-mode)

--- a/source/repeat-mode.lisp
+++ b/source/repeat-mode.lisp
@@ -23,11 +23,12 @@
 
 (define-mode repeat-mode (nyxt/process-mode:process-mode)
   "Mode to repeat a simple action/function repetitively until stopped."
-  ((firing-condition (repeat-seconds 5))
-   (action #'(lambda (path-url mode)
-               (declare (ignore path-url))
-               (when (repetitive-action mode)
-                 (funcall (repetitive-action mode) mode))))
+  ((nyxt/process-mode:firing-condition (repeat-seconds 5))
+   (nyxt/process-mode:action
+    #'(lambda (path-url mode)
+        (declare (ignore path-url))
+        (when (repetitive-action mode)
+          (funcall (repetitive-action mode) mode))))
    (repetitive-action nil
                       :type (or null (function (repeat-mode)))
                       :documentation "The action to repeat.

--- a/source/repeat-mode.lisp
+++ b/source/repeat-mode.lisp
@@ -37,7 +37,7 @@ Function taking a repeat-mode instance.")))
   "Repeat a command every SECONDS (prompts if SECONDS are not set)."
   (let ((seconds (or seconds
                      (ignore-errors
-                      (parse-int
+                      (parse-integer
                        (first (prompt :prompt "Repeat every X seconds"
                                       :input "5"
                                       :sources (list (make-instance 'prompter:raw-source)))))))))

--- a/source/repeat-mode.lisp
+++ b/source/repeat-mode.lisp
@@ -6,18 +6,6 @@
   (:documentation "Mode to infinitely repeat commands."))
 (in-package :nyxt/repeat-mode)
 
-(defun initialize-repeat-mode (mode)
-  (unless (repetitive-action mode)
-    (let ((prompted-action
-            (first
-             (prompt :prompt "Command to repeat"
-                     :sources (list (make-instance 'nyxt:command-source))))))
-      (setf (repetitive-action mode)
-            #'(lambda (mode)
-                (declare (ignore mode))
-                (funcall prompted-action)))))
-  (nyxt/process-mode::initialize-process-mode mode))
-
 (define-mode repeat-mode (nyxt/process-mode:process-mode)
   "Mode to repeat a simple action/function repetitively until stopped."
   ((nyxt/process-mode:firing-condition
@@ -28,17 +16,29 @@
    (nyxt/process-mode:action
     #'(lambda (path-url mode)
         (declare (ignore path-url))
-        (when (repetitive-action mode)
-          (funcall (repetitive-action mode) mode))))
+        (when (repeat-action mode)
+          (funcall (repeat-action mode) mode))))
    (repeat-interval 1
                     :type number
-                    :documentation "The interval (in seconds) to repeat `repetitive-action' at.
+                    :documentation "The interval (in seconds) to repeat `repeat-action' at.
 Defaults to one second.")
-   (repetitive-action nil
-                      :type (or null (function (repeat-mode)))
-                      :documentation "The action to repeat.
+   (repeat-action nil
+                  :type (or null (function (repeat-mode)))
+                  :documentation "The action to repeat.
 Function taking a `repeat-mode' instance.")
-   (constructor #'initialize-repeat-mode)))
+   (constructor #'initialize)))
+
+(defmethod initialize ((mode repeat-mode))
+  (unless (repeat-action mode)
+    (let ((prompted-action
+            (first
+             (prompt :prompt "Command to repeat"
+                     :sources (list (make-instance 'nyxt:command-source))))))
+      (setf (repeat-action mode)
+            #'(lambda (mode)
+                (declare (ignore mode))
+                (funcall prompted-action)))))
+  (nyxt/process-mode::initialize mode))
 
 (define-command-global repeat-every (&optional seconds function)
   "Repeat a FUNCTION every SECONDS (prompts if SECONDS and/or FUNCTION are not provided)."
@@ -50,4 +50,4 @@ Function taking a `repeat-mode' instance.")
                                       :sources (list (make-instance 'prompter:raw-source)))))))))
     (when seconds
       (enable-modes 'repeat-mode (current-buffer)
-                    (list :repeat-interval seconds :repetitive-action function)))))
+                    (list :repeat-interval seconds :repeat-action function)))))

--- a/source/repeat-mode.lisp
+++ b/source/repeat-mode.lisp
@@ -1,0 +1,45 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package :nyxt/repeat-mode
+    (:use :common-lisp :nyxt)
+  (:documentation "Mode to infinitely repeat commands."))
+(in-package :nyxt/repeat-mode)
+
+(serapeum:export-always 'repeat-seconds)
+(defun repeat-seconds (seconds)
+  (lambda (&rest args)
+    (declare (ignore args))
+    (sleep seconds)
+    t))
+
+(defun initialize-repeat-mode (mode)
+  (unless (repetitive-action mode)
+    (setf (repetitive-action mode)
+          (first
+           (prompt :prompt "Command to repeat"
+                   :sources (list (make-instance 'nyxt:command-source))))))
+  (nyxt/process-mode::initialize-process-mode mode))
+
+(define-mode repeat-mode (nyxt/process-mode:process-mode)
+  "Mode to repeat a simple action/function repetitively until stopped."
+  ((firing-condition (repeat-seconds 5))
+   (action #'(lambda (path-url mode)
+               (declare (ignore path-url))
+               (when (repetitive-action mode)
+                 (funcall (repetitive-action mode) mode))))
+   (repetitive-action nil
+                      :type (or null (function (repeat-mode)))
+                      :documentation "The action to repeat.
+Function taking a repeat-mode instance.")))
+
+(define-command-global repeat-every (&optional seconds)
+  "Repeat a command every SECONDS (prompts if SECONDS are not set)."
+  (let ((seconds (or seconds
+                     (ignore-errors
+                      (parse-int
+                       (first (prompt :prompt "Repeat every X seconds"
+                                      :input "5"
+                                      :sources (list (make-instance 'prompter:raw-source)))))))))
+    (when seconds
+      (enable-modes 'repeat-mode (current-buffer) (list :firing-condition (repeat-seconds seconds))))))

--- a/source/watch-mode.lisp
+++ b/source/watch-mode.lisp
@@ -33,14 +33,14 @@
     (apply '+ (mapcar (lambda (time multiplier) (* time multiplier))
                       times to-seconds-multipliers))))
 
-(define-mode watch-mode (nyxt/action-mode:action-mode)
+(define-mode watch-mode (nyxt/process-mode:process-mode)
   "Reload the current buffer at regular time intervals."
   ((action #'(lambda (path-url mode)
                (unless (sleep-time mode)
                  (setf (sleep-time mode) (seconds-from-user-input)))
                (loop
                  (if (quri:uri= path-url (url (buffer mode)))
-                     (reload-current-buffer (buffer mode))
+                     (nyxt::reload-buffer (buffer mode))
                      (buffer-load path-url :buffer (buffer mode)))
                  (sleep (sleep-time mode)))))
    (sleep-time :documentation "The amount of time to sleep between reloads.")))

--- a/source/watch-mode.lisp
+++ b/source/watch-mode.lisp
@@ -36,7 +36,7 @@
 (define-mode watch-mode (nyxt/repeat-mode:repeat-mode)
   "Reload the current buffer at regular time intervals."
   ;; Reload every 5 minutes by default.
-  ((nyxt/process-mode:firing-condition (nyxt/repeat-mode:repeat-seconds 300))
+  ((nyxt/repeat-mode:repeat-interval 300)
    (nyxt/repeat-mode:repetitive-action
     #'(lambda (mode)
         (buffer-load (nyxt/process-mode:path-url mode) :buffer (buffer mode))))))
@@ -44,5 +44,4 @@
 (define-command-global watch-buffer (&optional (buffer (current-buffer)))
   "Reload BUFFER at a prompted interval, instead of default 5 minutes."
   (let ((interval (seconds-from-user-input)))
-    (enable-modes 'watch-mode buffer
-                  (list :firing-condition (nyxt/repeat-mode:repeat-seconds (or interval 300))))))
+    (enable-modes 'watch-mode buffer (list :repeat-interval interval))))

--- a/source/watch-mode.lisp
+++ b/source/watch-mode.lisp
@@ -39,7 +39,7 @@
   ((firing-condition (nyxt/repeat-mode:repeat-seconds 300))
    (nyxt/repeat-mode:repetitive-action
     #'(lambda (mode)
-        (buffer-load (path-url mode) :buffer (buffer mode))))))
+        (buffer-load (nyxt/process-mode:path-url mode) :buffer (buffer mode))))))
 
 (define-command-global watch-buffer (&optional (buffer (current-buffer)))
   "Reload BUFFER at a prompted interval, instead of default 5 minutes."

--- a/source/watch-mode.lisp
+++ b/source/watch-mode.lisp
@@ -36,7 +36,7 @@
 (define-mode watch-mode (nyxt/repeat-mode:repeat-mode)
   "Reload the current buffer at regular time intervals."
   ;; Reload every 5 minutes by default.
-  ((firing-condition (nyxt/repeat-mode:repeat-seconds 300))
+  ((nyxt/process-mode:firing-condition (nyxt/repeat-mode:repeat-seconds 300))
    (nyxt/repeat-mode:repetitive-action
     #'(lambda (mode)
         (buffer-load (nyxt/process-mode:path-url mode) :buffer (buffer mode))))))

--- a/source/watch-mode.lisp
+++ b/source/watch-mode.lisp
@@ -37,7 +37,7 @@
   "Reload the current buffer at regular time intervals."
   ;; Reload every 5 minutes by default.
   ((nyxt/repeat-mode:repeat-interval 300)
-   (nyxt/repeat-mode:repetitive-action
+   (nyxt/repeat-mode:repeat-action
     #'(lambda (mode)
         (buffer-load (nyxt/process-mode:path-url mode) :buffer (buffer mode))))))
 


### PR DESCRIPTION
This adds a general conditional action-running mode -- `process-mode`. Some kind of Cron inside Nyxt :)

# What's New
- `process-mode` that basically executes its `action` when its `firing-condition` is true.
- Derived `preview-mode` that looks at whether the file was changed and reloads the buffer if necessary.
- Derived `repeat-mode` that repeats its own `repetitive-action` (usually a command, like `nyxt/web-mode:scroll-down`) every `repeat-interval` seconds.
- `watch-mode`, now derived from `repeat-mode`, with the only difference that it has a `repetitive-action` set to `buffer-load` by default.

# Things To Discuss
- Do we need e.g. `watch-mode` now that one can basically do `repeat-every` and choose repetition interval and command to execute?
- Currently, `preview-mode` relies on `sb-posix` instead of removed dependency on `file-attributes`. What's the right way to look at mtime of a file now?

# How Has This Been Tested?
- Compiles.
- Runs.
- `repeat-mode` scrolls page down, `watch-mode` reloads it.

EDIT: All questions resolved, what's left is testing.
EDIT: Pre-final PR message form.