### PR TITLE
Fix for window class, use gdk-set-program-class

### DIFF
--- a/source/renderer-gobject-gtk.lisp
+++ b/source/renderer-gobject-gtk.lisp
@@ -21,6 +21,7 @@
     (setf gtk-running-p t)
     (let ((main-thread (bt:make-thread (lambda ()
                                          (glib:g-set-prgname "nyxt")
+                                         (gdk:gdk-set-program-class "Nyxt")
                                          (gir:invoke ((gir:ffi "Gtk") 'main)))
                                        :name "main thread")))
       (finalize browser urls startup-timestamp)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -150,6 +150,7 @@ not return."
       (progn
         (setf gtk-running-p t)
         (glib:g-set-prgname "nyxt")
+        (gdk:gdk-set-program-class "Nyxt")
         (gtk:within-main-loop
           (finalize browser urls startup-timestamp))
         (unless *keep-alive*
@@ -158,6 +159,7 @@ not return."
       (progn
         (setf gtk-running-p t)
         (glib:g-set-prgname "nyxt")
+        (gdk:gdk-set-program-class "Nyxt")
         (finalize browser urls startup-timestamp)
         (gtk:gtk-main))))
 


### PR DESCRIPTION
Fix for #1227

xprop reports: WM_CLASS(STRING) = "nyxt", "Nyxt"
app_id in Sway (Wayland): "nyxt"