### PR TITLE
Catch all errors! O.o

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -65,6 +65,7 @@
                (:file "user-interface")
                ;; Core functionality
                (:file "global")
+               (:file "concurrency")
                (:file "data-storage")
                (:file "configuration")
                (:file "command")

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -88,7 +88,7 @@ Enable INCLUDED modes plus the already present ones, and disable EXCLUDED modes,
                   (or (position (first test2) priority-list) 4)))))
       (first (sort (remove-if-not
                     #'(lambda (rule)
-                        (funcall-safely
+                        (funcall
                          ;; REVIEW: Use `eval'?
                          (apply (first (test rule)) (rest (test rule))) url))
                     rules)

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -437,7 +437,7 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
     (echo "Saved ~a auto-mode rules to ~s." (length rules) (expand-path path)))))
 
 (defmethod restore ((profile data-profile) (path auto-mode-rules-data-path) &key &allow-other-keys)
-  (with-muffled-body ("Failed to load auto-mode-rules from ~s: ~a"
+  (with-protect ("Failed to load auto-mode-rules from ~s: ~a"
                       (expand-path path) :condition)
     (let ((data (with-data-file (file path
                                       :direction :input

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -73,11 +73,10 @@ If HOSTLIST has a `path', persist it locally."
 (defvar update-lock (bt:make-lock))
 
 (defmethod update-hostlist-with-lock ((hostlist hostlist))
-  (bt:make-thread
-   (lambda ()
-     (when (bt:acquire-lock update-lock nil)
+  (run-thread
+    (when (bt:acquire-lock update-lock nil)
        (update hostlist)
-       (bt:release-lock update-lock)))))
+       (bt:release-lock update-lock))))
 
 (defmethod read-hostlist ((hostlist hostlist))
   "Return hostlist file as a string.

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -230,7 +230,7 @@ editor executable."))
   (ffi-within-renderer-thread
    browser
    (lambda ()
-     (pexec ()
+     (run-thread ()
        (funcall-safely (startup-function browser) urls))))
   ;; Set 'init-time at the end of finalize to take the complete startup time
   ;; into account.
@@ -290,9 +290,8 @@ current buffer."
                (setf (destination-path download-render)
                      (download-manager:filename download))
                (push download-render (downloads *browser*))
-               (bt:make-thread
-                (lambda ()
-                  (download-watch download-render download))))
+               (run-thread
+                 (download-watch download-render download)))
              download)))))
     (:renderer
      (ffi-buffer-download buffer (object-string url))))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -231,7 +231,7 @@ editor executable."))
    browser
    (lambda ()
      (run-thread
-       (funcall-safely (startup-function browser) urls))))
+       (funcall (startup-function browser) urls))))
   ;; Set 'init-time at the end of finalize to take the complete startup time
   ;; into account.
   (setf (slot-value *browser* 'init-time)
@@ -395,7 +395,7 @@ Deal with REQUEST-DATA with the following rules:
          nil)
         (bound-function
          (log:debug "Resource request key sequence ~a" (keyspecs-with-optional-keycode keys))
-         (funcall-safely bound-function :url url :buffer buffer)
+         (funcall bound-function :url url :buffer buffer)
          nil)
         ((new-window-p request-data)
          (log:debug "Load URL in new buffer: ~a" (object-display url))
@@ -457,10 +457,10 @@ The following example does a few things:
   (make-handler-resource
    #'(lambda (request-data)
        (let ((url (url request-data)))
-         (if (funcall-safely test url)
+         (if (funcall test url)
              (etypecase action
                (function
-                (let* ((new-url (funcall-safely action url)))
+                (let* ((new-url (funcall action url)))
                   (log:info "Applied ~s URL-dispatcher on ~s and got ~s"
                             (symbol-name name)
                             (object-display url)
@@ -473,7 +473,7 @@ The following example does a few things:
                                           (format nil action
                                                   (object-string url)))
                                          nil)))
-                         (funcall-safely action url)
+                         (funcall action url)
                          (log:info "Applied ~s shell-command URL-dispatcher on ~s"
                             (symbol-name name)
                             (object-display url)))))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -277,7 +277,7 @@ current buffer."
        (when (eq proxy-address :auto)
          (setf proxy-address (proxy-address buffer :downloads-only t)))
        (let* ((download nil))
-         (with-muffled-body ("Download error: ~a" :condition)
+         (with-protect ("Download error: ~a" :condition)
            (with-data-access (downloads path)
              (setf download
                    (download-manager:resolve url
@@ -323,7 +323,7 @@ This is useful to tell REPL instances from binary ones."
 (defun open-urls (urls &key no-focus)
   "Create new buffers from URLs.
 First URL is focused if NO-FOCUS is nil."
-  (with-muffled-body ("Could not make buffer to open ~a: ~a" urls :condition)
+  (with-protect ("Could not make buffer to open ~a: ~a" urls :condition)
     (let ((first-buffer (first (mapcar
                                 (lambda (url) (make-buffer :url url))
                                 urls))))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -230,7 +230,7 @@ editor executable."))
   (ffi-within-renderer-thread
    browser
    (lambda ()
-     (run-thread ()
+     (run-thread
        (funcall-safely (startup-function browser) urls))))
   ;; Set 'init-time at the end of finalize to take the complete startup time
   ;; into account.

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -314,7 +314,7 @@ This is useful to tell REPL instances from binary ones."
     (setf title (if (str:emptyp title) "" title))
     (setf url (if (url-empty-p url) "<no url/name>" (object-display url)))
     (ffi-window-set-title window
-                          (str:concat "Nyxt" (when *keep-alive* " REPL") " - "
+                          (str:concat "Nyxt" (when *run-from-repl-p* " REPL") " - "
                                        title (unless (str:emptyp title) " - ")
                                        url))))
 

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1005,7 +1005,7 @@ MODES should be a list symbols, each possibly returned by `mode-name'."
   (dolist (mode (uiop:ensure-list modes))
     (let ((command (mode-command mode)))
       (if command
-          (funcall-safely command :buffer buffer :activate nil)
+          (funcall command :buffer buffer :activate nil)
           (log:warn "Mode command ~a not found." mode)))))
 
 (export-always 'enable-modes)
@@ -1016,7 +1016,7 @@ ARGS are passed to the mode command."
   (dolist (mode (uiop:ensure-list modes))
     (let ((command (mode-command mode)))
       (if command
-          (apply #'funcall-safely command :buffer buffer :activate t args)
+          (apply #'funcall command :buffer buffer :activate t args)
           (log:warn "Mode command ~a not found." mode)))))
 
 (define-class active-mode-source (prompter:source)

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -338,7 +338,7 @@ extra fiddling."
   "Run COMMAND over ARGS and return its result.
 This is blocking, see `run-async' for an asynchronous way to run commands."
   (let ((channel (make-channel 1)))
-    (pexec ()
+    (run-thread ()
       (calispel:! channel
                ;; Bind current buffer for the duration of the command.  This
                ;; way, if the user switches buffer after running a command
@@ -352,7 +352,7 @@ This is blocking, see `run-async' for an asynchronous way to run commands."
   "Run COMMAND over ARGS asynchronously.
 See `run' for a way to run commands in a synchronous fashion and return the
 result."
-  (pexec ()
+  (run-thread ()
     (with-current-buffer (current-buffer) ; See `run' for why we bind current buffer.
       (apply #'funcall-safely command args))))
 

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -345,7 +345,10 @@ This is blocking, see `run-async' for an asynchronous way to run commands."
                ;; but before command termination, `current-buffer' will
                ;; return the buffer from which the command was invoked.
                (with-current-buffer (current-buffer)
-                 (apply #'funcall-safely command args))))
+                 (handler-case (apply #'funcall command args)
+                   (nyxt-prompt-buffer-canceled ()
+                     (log:debug "Prompt buffer interrupted")
+                     nil)))))
     (calispel:? channel)))
 
 (defun run-async (command &rest args)
@@ -354,7 +357,10 @@ See `run' for a way to run commands in a synchronous fashion and return the
 result."
   (run-thread
     (with-current-buffer (current-buffer) ; See `run' for why we bind current buffer.
-      (apply #'funcall-safely command args))))
+      (handler-case (apply #'funcall command args)
+        (nyxt-prompt-buffer-canceled ()
+          (log:debug "Prompt buffer interrupted")
+          nil)))))
 
 (define-command noop ()                 ; TODO: Replace with ESCAPE special command that allows dispatched to cancel current key stack.
   "A command that does nothing.

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -338,7 +338,7 @@ extra fiddling."
   "Run COMMAND over ARGS and return its result.
 This is blocking, see `run-async' for an asynchronous way to run commands."
   (let ((channel (make-channel 1)))
-    (run-thread ()
+    (run-thread
       (calispel:! channel
                ;; Bind current buffer for the duration of the command.  This
                ;; way, if the user switches buffer after running a command
@@ -352,7 +352,7 @@ This is blocking, see `run-async' for an asynchronous way to run commands."
   "Run COMMAND over ARGS asynchronously.
 See `run' for a way to run commands in a synchronous fashion and return the
 result."
-  (run-thread ()
+  (run-thread
     (with-current-buffer (current-buffer) ; See `run' for why we bind current buffer.
       (apply #'funcall-safely command args))))
 

--- a/source/concurrency.lisp
+++ b/source/concurrency.lisp
@@ -1,0 +1,65 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nyxt)
+
+(export-always 'with-muffled-body)      ; TODO: Rename to `with-protect'?
+(defmacro with-muffled-body ((format-string &rest args) &body body)
+  "Run body with muffled condition when `*keep-alive*' is nil, run normally otherwise.
+Then the condition is muffled, a warning is reported to the user as per
+FORMAT-STRING and ARGS.
+As a special case, the first `:condition' keyword in ARGS is replaced with the
+condition."
+  (alex:with-gensyms (c)
+    `(if *keep-alive*
+         (progn ,@body)
+         (handler-case (progn ,@body)
+           (error (,c)
+             (declare (ignorable ,c))
+             ,(let* ((condition-index (position :condition args))
+                     (new-args (if condition-index
+                                   (append (subseq args 0 condition-index)
+                                           `(,c)
+                                           (subseq args (1+ condition-index)))
+                                   args)))
+                `(handler-case
+                     (echo-warning ,format-string ,@new-args)
+                   (t ()
+                     (log:error ,format-string ,@new-args)))))))))
+
+(defun make-channel (&optional size)
+  "Return a channel of capacity SIZE.
+If SIZE is NIL, capicity is infinite."
+  (cond
+    ((null size)
+     (make-instance 'calispel:channel
+                    :buffer (make-instance 'jpl-queues:unbounded-fifo-queue)))
+    ((= 0 size)
+     (make-instance 'calispel:channel))
+    ((< 0 size)
+     (make-instance 'calispel:channel
+                    :buffer (make-instance 'jpl-queues:bounded-fifo-queue :capacity size)))))
+
+(defun drain-channel (channel &optional timeout)
+  "Listen to CHANNEL until a value is available, then return all CHANNEL values
+as a list.
+TIMEOUT specifies how long to wait when draining values after the first one.
+This is a blocking operation."
+  (labels ((fetch ()
+             (multiple-value-bind (value received?)
+                 (calispel:? channel 0)
+               (if received?
+                   (cons value (fetch))
+                   nil))))
+    (cons (calispel:? channel timeout)
+          (nreverse (fetch)))))
+
+(export-always 'run-thread)
+(defmacro run-thread (&body body)
+  "Run body in a new protected new thread.
+This supersedes `bt:make-thread' in Nyxt.  Don't use the latter unless you know
+what you are doing!"
+  `(bt:make-thread
+    (lambda ()
+      (with-muffled-body ("Error on separate thead: ~a" :condition)
+        ,@body))))

--- a/source/concurrency.lisp
+++ b/source/concurrency.lisp
@@ -3,8 +3,8 @@
 
 (in-package :nyxt)
 
-(export-always 'with-muffled-body)      ; TODO: Rename to `with-protect'?
-(defmacro with-muffled-body ((format-string &rest args) &body body)
+(export-always 'with-protect)
+(defmacro with-protect ((format-string &rest args) &body body)
   "Run body with muffled condition when `*keep-alive*' is nil, run normally otherwise.
 Then the condition is muffled, a warning is reported to the user as per
 FORMAT-STRING and ARGS.
@@ -61,5 +61,5 @@ This supersedes `bt:make-thread' in Nyxt.  Don't use the latter unless you know
 what you are doing!"
   `(bt:make-thread
     (lambda ()
-      (with-muffled-body ("Error on separate thead: ~a" :condition)
+      (with-protect ("Error on separate thead: ~a" :condition)
         ,@body))))

--- a/source/concurrency.lisp
+++ b/source/concurrency.lisp
@@ -5,13 +5,13 @@
 
 (export-always 'with-protect)
 (defmacro with-protect ((format-string &rest args) &body body)
-  "Run body with muffled condition when `*keep-alive*' is nil, run normally otherwise.
+  "Run body with muffled condition when `*run-from-repl-p*' is nil, run normally otherwise.
 Then the condition is muffled, a warning is reported to the user as per
 FORMAT-STRING and ARGS.
 As a special case, the first `:condition' keyword in ARGS is replaced with the
 condition."
   (alex:with-gensyms (c)
-    `(if *keep-alive*
+    `(if *run-from-repl-p*
          (progn ,@body)
          (handler-case (progn ,@body)
            (error (,c)

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -9,9 +9,9 @@
 
 (export-always 'funcall-safely)
 (defun funcall-safely (f &rest args)    ; TODO: Delete now that we have `thread'?
-  "Like `funcall' except that if `*keep-alive*' is nil (e.g. the program is run
+  "Like `funcall' except that if `*run-from-repl-p*' is nil (e.g. the program is run
 from a binary) then any condition is logged instead of triggering the debugger."
-  (if *keep-alive*
+  (if *run-from-repl-p*
       (handler-case (apply f args)
         (nyxt-prompt-buffer-canceled ()
           (log:debug "Prompt buffer interrupted")

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -8,7 +8,7 @@
   "The path of the generated configuration file.")
 
 (export-always 'funcall-safely)
-(defun funcall-safely (f &rest args)
+(defun funcall-safely (f &rest args)    ; TODO: Delete now that we have `thread'?
   "Like `funcall' except that if `*keep-alive*' is nil (e.g. the program is run
 from a binary) then any condition is logged instead of triggering the debugger."
   (if *keep-alive*
@@ -23,58 +23,6 @@ from a binary) then any condition is logged instead of triggering the debugger."
         (error (c)
           (log:error "In ~a: ~a" f c)
           nil))))
-
-(export-always 'with-muffled-body)
-(defmacro with-muffled-body ((format-string &rest args) &body body)
-  "Run body with muffled condition when `*keep-alive*' is nil, run normally otherwise.
-Then the condition is muffled, a warning is reported to the user as per
-FORMAT-STRING and ARGS.
-As a special case, the first `:condition' keyword in ARGS is replaced with the
-condition."
-  `(if ,*keep-alive*
-       (progn
-         ,@body)
-       (handler-case (progn ,@body)
-         (error (c)
-           (declare (ignorable c))
-           ,(let ((condition-index (position :condition args)))
-              `(apply #'echo-warning ,format-string
-                      ,@(if condition-index
-                            (append (subseq args 0 condition-index)
-                                    '(c)
-                                    (subseq args (1+ condition-index)))
-                            args)))))))
-
-(defun make-channel (&optional size)
-  "Return a channel of capacity SIZE.
-If SIZE is NIL, capicity is infinite."
-  (cond
-    ((null size)
-     (make-instance 'calispel:channel
-                    :buffer (make-instance 'jpl-queues:unbounded-fifo-queue)))
-    ((= 0 size)
-     (make-instance 'calispel:channel))
-    ((< 0 size)
-     (make-instance 'calispel:channel
-                    :buffer (make-instance 'jpl-queues:bounded-fifo-queue :capacity size)))))
-
-(defun drain-channel (channel &optional timeout)
-  "Listen to CHANNEL until a value is available, then return all CHANNEL values
-as a list.
-TIMEOUT specifies how long to wait when draining values after the first one.
-This is a blocking operation."
-  (labels ((fetch ()
-             (multiple-value-bind (value received?)
-                 (calispel:? channel 0)
-               (if received?
-                   (cons value (fetch))
-                   nil))))
-    (cons (calispel:? channel timeout)
-          (nreverse (fetch)))))
-
-(defmacro pexec (&body body)
-  "Shorthand for (bt:make-thread (lambda () ...))"
-  `(bt:make-thread (lambda () ,@body)))
 
 (defparameter %buffer nil)              ; TODO: Make a monad?
 

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -37,11 +37,13 @@ condition."
        (handler-case (progn ,@body)
          (error (c)
            (declare (ignorable c))
-           (let ((condition-index (position :condition ',args)))
-             (apply #'echo-warning ,format-string
-                    (if condition-index
-                        (replace ',args (list c) :start1 condition-index)
-                        ',args)))))))
+           ,(let ((condition-index (position :condition args)))
+              `(apply #'echo-warning ,format-string
+                      ,@(if condition-index
+                            (append (subseq args 0 condition-index)
+                                    '(c)
+                                    (subseq args (1+ condition-index)))
+                            args)))))))
 
 (defun make-channel (&optional size)
   "Return a channel of capacity SIZE.

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -7,23 +7,6 @@
 (defvar *auto-config-file-path* (make-instance 'data-path :basename "auto-config")
   "The path of the generated configuration file.")
 
-(export-always 'funcall-safely)
-(defun funcall-safely (f &rest args)    ; TODO: Delete now that we have `thread'?
-  "Like `funcall' except that if `*run-from-repl-p*' is nil (e.g. the program is run
-from a binary) then any condition is logged instead of triggering the debugger."
-  (if *run-from-repl-p*
-      (handler-case (apply f args)
-        (nyxt-prompt-buffer-canceled ()
-          (log:debug "Prompt buffer interrupted")
-          nil))
-      (handler-case (apply f args)
-        (nyxt-prompt-buffer-canceled ()
-          (log:debug "Prompt buffer interrupted")
-          nil)
-        (error (c)
-          (log:error "In ~a: ~a" f c)
-          nil))))
-
 (defparameter %buffer nil)              ; TODO: Make a monad?
 
 (export-always 'current-buffer)

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -250,7 +250,7 @@ Define a method for your `data-path' type to make it restorable."))
              (worker)))
     (unless (channel path)
       (setf (channel path) (make-channel))
-      (bt:make-thread #'worker))
+      (run-thread (worker)))
     ;; We pass `path', but anything would do since the value is ignored.
     (calispel:! (channel path) path)))
 

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -193,7 +193,7 @@ identifier for every hinted element."
                    (lambda ()
                      (with-current-buffer buffer
                        (remove-element-hints))))))
-      (funcall-safely function result))))
+      (funcall function result))))
 
 (defun elements-from-json (elements-json)
   (loop for element in (cl-json:decode-json-from-string elements-json)

--- a/source/external-editor.lisp
+++ b/source/external-editor.lisp
@@ -49,9 +49,8 @@ so invoke on a separate thread when possible."
 (define-command edit-with-external-editor ()
   "Edit the current input field using `external-editor-program'."
   (if (external-editor-program *browser*)
-      (bt:make-thread
-       (lambda ()
-         (select-input-field)
-         (%paste :input-text (%edit-with-external-editor (%copy)))
-         (set-caret-on-end)))
+      (run-thread
+        (select-input-field)
+        (%paste :input-text (%edit-with-external-editor (%copy)))
+        (set-caret-on-end))
       (echo-warning "Please set `external-editor-program' browser slot.")))

--- a/source/external-editor.lisp
+++ b/source/external-editor.lisp
@@ -15,7 +15,7 @@ so invoke on a separate thread when possible."
         (write-sequence input-text f)))
     (log:debug "External editor ~s opens ~s"
                (external-editor-program *browser*) p)
-    (with-muffled-body ("Failed editing: ~a" :condition)
+    (with-protect ("Failed editing: ~a" :condition)
       (uiop:run-program (list (external-editor-program *browser*)
                               (uiop:native-namestring p))
                         :ignore-error-status t))

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -8,7 +8,7 @@
 (defvar *options* '()
   "The list of command line options.")
 
-(defvar *keep-alive* t
+(defvar *run-from-repl-p* t
   "If non-nil, don't terminate the Lisp process when quitting the browser.
 This is useful when the browser is run from a REPL so that quitting does not
 close the connection.")

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -383,7 +383,7 @@ The list of values is useful when the last result is multi-valued, e.g. (values 
 You need not wrap multiple values in a PROGN, all top-level expression are
 evaluate in order."
   (let ((channel (make-channel 1)))
-    (pexec ()
+    (run-thread ()
       (calispel:!
        channel
        (with-input-from-string (input string)
@@ -396,7 +396,7 @@ evaluate in order."
 
 (defun evaluate-async (string)
   "Like `evaluate' but does not block and does not return the result."
-  (pexec ()
+  (run-thread ()
     (with-input-from-string (input string)
       (loop for object = (read input nil :eof)
             until (eq object :eof)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -400,7 +400,7 @@ evaluate in order."
     (with-input-from-string (input string)
       (loop for object = (read input nil :eof)
             until (eq object :eof)
-            collect (funcall-safely (lambda () (eval object)))))))
+            collect (funcall (lambda () (eval object)))))))
 
 (defun error-buffer (title text)
   "Print some help."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -383,7 +383,7 @@ The list of values is useful when the last result is multi-valued, e.g. (values 
 You need not wrap multiple values in a PROGN, all top-level expression are
 evaluate in order."
   (let ((channel (make-channel 1)))
-    (run-thread ()
+    (run-thread
       (calispel:!
        channel
        (with-input-from-string (input string)
@@ -396,7 +396,7 @@ evaluate in order."
 
 (defun evaluate-async (string)
   "Like `evaluate' but does not block and does not return the result."
-  (run-thread ()
+  (run-thread
     (with-input-from-string (input string)
       (loop for object = (read input nil :eof)
             until (eq object :eof)

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -384,7 +384,7 @@ We keep this variable as a means to import the old format to the new one.")
                             (htree:add-entry history data last-access)))
                         old-history)
                history)))
-    (with-muffled-body ("Failed to restore history from ~a: ~a"
+    (with-protect ("Failed to restore history from ~a: ~a"
                         (expand-path path) :condition)
       (let* ((path (if (uiop:file-exists-p (expand-path path))
                        path

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -77,7 +77,7 @@ Example:
                                                :buffer buffer
                                                args)))
                          (when (constructor ,new-mode)
-                           (funcall-safely (constructor ,new-mode) ,new-mode))
+                           (funcall (constructor ,new-mode) ,new-mode))
                          (push ,new-mode (modes buffer))
                          (hooks:run-hook (enable-hook ,new-mode) ,new-mode)
                          (hooks:run-hook (enable-mode-hook buffer) ,new-mode))
@@ -87,7 +87,7 @@ Example:
                        (hooks:run-hook (disable-hook ,existing-instance) ,existing-instance)
                        (hooks:run-hook (disable-mode-hook buffer) ,existing-instance)
                        (when (destructor ,existing-instance)
-                         (funcall-safely (destructor ,existing-instance) ,existing-instance))
+                         (funcall (destructor ,existing-instance) ,existing-instance))
                        (setf (modes buffer) (delete ,existing-instance
                                                     (modes buffer)))
                        (print-status)

--- a/source/notification.lisp
+++ b/source/notification.lisp
@@ -17,8 +17,7 @@
 (export-always 'launch-and-notify)
 (defun launch-and-notify (command &key (success-msg "Command succeded.") (error-msg "Command failed."))
   "Run this program asynchronously and notify when it is finished."
-  (bt:make-thread
-   (lambda ()
-     (let ((exit-code (uiop:wait-process
-                       (uiop:launch-program command))))
-       (notify (if (zerop exit-code) success-msg error-msg))))))
+  (run-thread
+    (let ((exit-code (uiop:wait-process
+                      (uiop:launch-program command))))
+      (notify (if (zerop exit-code) success-msg error-msg)))))

--- a/source/os-package-manager-mode.lisp
+++ b/source/os-package-manager-mode.lisp
@@ -282,7 +282,7 @@ OBJECTS can be a list of packages, a generation, etc."
           (uiop:process-alive-p process-info))
         (echo "An package operation is already running.  You can cancel it with `cancel-package-operation'.")
         (progn
-          (nyxt::pexec ()
+          (run-thread ()
                  (let ((process-info (funcall command objects profile))
                        (mode (find-submode buffer 'os-package-manager-mode)))
                    (setf (nyxt/os-package-manager-mode:current-process-info mode) process-info)

--- a/source/os-package-manager-mode.lisp
+++ b/source/os-package-manager-mode.lisp
@@ -282,33 +282,33 @@ OBJECTS can be a list of packages, a generation, etc."
           (uiop:process-alive-p process-info))
         (echo "An package operation is already running.  You can cancel it with `cancel-package-operation'.")
         (progn
-          (run-thread ()
-                 (let ((process-info (funcall command objects profile))
-                       (mode (find-submode buffer 'os-package-manager-mode)))
-                   (setf (nyxt/os-package-manager-mode:current-process-info mode) process-info)
-                   (nyxt::html-set "" buffer)      ; Reset content between operations.
-                   (nyxt::html-write
-                    (markup:markup
-                     (:style (style buffer))
-                     (:h1 title)
-                     (:p
-                      (:a :class "button"
-                          :href (lisp-url '(nyxt/os-package-manager-mode:cancel-package-operation))
-                          "Cancel")))
-                    buffer)
-                   (format-command-stream
-                    process-info
-                    (lambda (s)
-                      ;; TODO: Make shell formating function and add support for
-                      ;; special characters, e.g. progress bars.
-                      (nyxt::html-write
-                       (markup:markup
-                        (:code (str:replace-all " " " " s))
-                        (:br))
-                       buffer)))
-                   (nyxt::html-write
-                    (markup:markup (:p "Done."))
-                    buffer)))
+          (run-thread
+            (let ((process-info (funcall command objects profile))
+                  (mode (find-submode buffer 'os-package-manager-mode)))
+              (setf (nyxt/os-package-manager-mode:current-process-info mode) process-info)
+              (nyxt::html-set "" buffer) ; Reset content between operations.
+              (nyxt::html-write
+               (markup:markup
+                (:style (style buffer))
+                (:h1 title)
+                (:p
+                 (:a :class "button"
+                     :href (lisp-url '(nyxt/os-package-manager-mode:cancel-package-operation))
+                     "Cancel")))
+               buffer)
+              (format-command-stream
+               process-info
+               (lambda (s)
+                 ;; TODO: Make shell formating function and add support for
+                 ;; special characters, e.g. progress bars.
+                 (nyxt::html-write
+                  (markup:markup
+                   (:code (str:replace-all " " " " s))
+                   (:br))
+                  buffer)))
+              (nyxt::html-write
+               (markup:markup (:p "Done."))
+               buffer)))
           (set-current-buffer buffer)
           buffer))))
 

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -189,7 +189,7 @@ If STEPS is negative, go to next pages instead."
                          :sources (list (make-instance 'prompt-buffer-command-source
                                                        :parent-prompt-buffer prompt-buffer))))))
     (when command
-      (funcall-safely command))))
+      (funcall command))))
 
 (defun prompt-buffer-actions (&optional (window (current-window)))
   (sera:and-let* ((first-prompt-buffer (first (nyxt::active-prompt-buffers window))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -159,7 +159,7 @@ To access the suggestion instead, see `prompter:selected-suggestion'."
     (push prompt-buffer (active-prompt-buffers (window prompt-buffer)))
     (erase-document prompt-buffer)      ; TODO: When to erase?
     (update-display prompt-buffer)
-    (run-thread ()
+    (run-thread
       (watch-prompt prompt-buffer))
     (ffi-window-set-prompt-buffer-height
      (window prompt-buffer)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -159,7 +159,7 @@ To access the suggestion instead, see `prompter:selected-suggestion'."
     (push prompt-buffer (active-prompt-buffers (window prompt-buffer)))
     (erase-document prompt-buffer)      ; TODO: When to erase?
     (update-display prompt-buffer)
-    (pexec ()
+    (run-thread ()
       (watch-prompt prompt-buffer))
     (ffi-window-set-prompt-buffer-height
      (window prompt-buffer)

--- a/source/renderer-gobject-gtk.lisp
+++ b/source/renderer-gobject-gtk.lisp
@@ -21,7 +21,7 @@
     (setf gtk-running-p t)
     (let ((main-thread (bt:make-thread
                         (lambda ()
-                          (with-muffled-body ("Error on GTK thread: ~a" :condition)
+                          (with-protect ("Error on GTK thread: ~a" :condition)
                             (glib:g-set-prgname "nyxt")
                             (gdk:gdk-set-program-class "Nyxt")
                             (gir:invoke ((gir:ffi "Gtk") 'main))))

--- a/source/renderer-gobject-gtk.lisp
+++ b/source/renderer-gobject-gtk.lisp
@@ -19,11 +19,13 @@
   (defmethod ffi-initialize ((browser gtk-browser) urls startup-timestamp)
     (log:debug "Initializing Gobject-GTK Interface")
     (setf gtk-running-p t)
-    (let ((main-thread (bt:make-thread (lambda ()
-                                         (glib:g-set-prgname "nyxt")
-                                         (gdk:gdk-set-program-class "Nyxt")
-                                         (gir:invoke ((gir:ffi "Gtk") 'main)))
-                                       :name "main thread")))
+    (let ((main-thread (bt:make-thread
+                        (lambda ()
+                          (with-muffled-body ("Error on GTK thread: ~a" :condition)
+                            (glib:g-set-prgname "nyxt")
+                            (gdk:gdk-set-program-class "Nyxt")
+                            (gir:invoke ((gir:ffi "Gtk") 'main))))
+                        :name "main thread")))
       (finalize browser urls startup-timestamp)
       (unless *keep-alive*
         (bt:join-thread main-thread)))))

--- a/source/renderer-gobject-gtk.lisp
+++ b/source/renderer-gobject-gtk.lisp
@@ -27,5 +27,5 @@
                             (gir:invoke ((gir:ffi "Gtk") 'main))))
                         :name "main thread")))
       (finalize browser urls startup-timestamp)
-      (unless *keep-alive*
+      (unless *run-from-repl-p*
         (bt:join-thread main-thread)))))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -90,7 +90,7 @@ See https://github.com/atlas-engineer/nyxt/issues/740")
 (defmacro within-gtk-thread (&body body)
   "Protected `gtk:within-gtk-thread'."
   `(gtk:within-gtk-thread
-     (with-muffled-body ("Error on GTK thead: ~a" :condition)
+     (with-protect ("Error on GTK thead: ~a" :condition)
        ,@body)))
 
 (defmethod ffi-within-renderer-thread ((browser gtk-browser) thunk)
@@ -158,7 +158,7 @@ not return."
         (glib:g-set-prgname "nyxt")
         (gdk:gdk-set-program-class "Nyxt")
         (gtk:within-main-loop
-          (with-muffled-body ("Error on GTK thread: ~a" :condition)
+          (with-protect ("Error on GTK thread: ~a" :condition)
             (finalize browser urls startup-timestamp)))
         (unless *keep-alive*
           (gtk:join-gtk-main)))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -160,7 +160,7 @@ not return."
         (gtk:within-main-loop
           (with-protect ("Error on GTK thread: ~a" :condition)
             (finalize browser urls startup-timestamp)))
-        (unless *keep-alive*
+        (unless *run-from-repl-p*
           (gtk:join-gtk-main)))
       #+darwin
       (progn
@@ -171,7 +171,7 @@ not return."
         (gtk:gtk-main))))
 
 (define-ffi-method ffi-kill-browser ((browser gtk-browser))
-  (unless *keep-alive*
+  (unless *run-from-repl-p*
     (gtk:leave-gtk-main)))
 
 (define-class data-manager-data-path (data-path)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -470,7 +470,7 @@ Warning: This behaviour may change in the future."
        ;; Forward release event to the web view.
        nil)
       ((prompt-buffer-p prompt-buffer)
-       (run-thread ()
+       (run-thread
          (let ((input (ffi-prompt-buffer-evaluate-javascript
                        (current-window)
                        (ps:ps (ps:chain document (get-element-by-id "input")

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -304,9 +304,9 @@ To change the default buffer, e.g. set it to a given URL:
         (cond
           (urls (open-urls urls))
           (buffer-fn
-           (window-set-active-buffer window (funcall-safely buffer-fn))))))
+           (window-set-active-buffer window (funcall buffer-fn))))))
     (when (startup-error-reporter-function *browser*)
-      (funcall-safely (startup-error-reporter-function *browser*)))))
+      (funcall (startup-error-reporter-function *browser*)))))
 
 (export-always 'open-external-urls)
 (defun open-external-urls (urls)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -162,7 +162,7 @@ Example: --with-path bookmarks=/path/to/bookmarks
       (when (uiop:file-exists-p socket-path)
         (log:info "Deleting socket ~s." socket-path)
         (uiop:delete-file-if-exists socket-path))))
-  (unless *keep-alive*
+  (unless *run-from-repl-p*
     (uiop:quit 0 nil)))
 
 (define-command quit-after-clearing-session (&key confirmation-p) ; TODO: Rename?
@@ -205,7 +205,7 @@ Don't run this from a REPL, prefer `start' instead."
                      (opts:missing-arg #'handle-malformed-cli-arg)
                      (opts:arg-parser-failed #'handle-malformed-cli-arg))
         (opts:get-opts))
-    (setf *keep-alive* nil)             ; Not a REPL.
+    (setf *run-from-repl-p* nil)             ; Not a REPL.
     (apply #'start (append options (list :urls free-args)))))
 
 (declaim (ftype (function (trivial-types:pathname-designator &key (:package (or null package))))
@@ -224,7 +224,7 @@ Return the short error message and the full error message as second value."
                 (log:info "Loading Lisp file ~s." file)
                 (load file)))
              nil))
-      (if *keep-alive*
+      (if *run-from-repl-p*
           (unsafe-load)
           (handler-case
               (unsafe-load)
@@ -496,7 +496,7 @@ Examples:
      (with-protect ("Error: ~a" :condition)
        (start-browser urls))))
 
-  (unless *keep-alive* (uiop:quit)))
+  (unless *run-from-repl-p* (uiop:quit)))
 
 (defun load-or-eval (&key remote)
   (loop for (opt value . nil) on *options*

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -493,7 +493,7 @@ Examples:
      (start-load-or-eval))
 
     (t
-     (with-muffled-body ("Error: ~a" :condition)
+     (with-protect ("Error: ~a" :condition)
        (start-browser urls))))
 
   (unless *keep-alive* (uiop:quit)))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -392,7 +392,7 @@ Otherwise bind socket and return the listening thread."
       (t
        (log:info "Listening to socket ~s." socket-path)
        (uiop:delete-file-if-exists socket-path) ; Safe since socket-path is a :socket at this point.
-       (bt:make-thread #'listen-socket)))))
+       (run-thread (listen-socket))))))
 
 (defun remote-eval (expr)
   "If another Nyxt is listening on the socket, tell it to evaluate EXPR."
@@ -493,7 +493,8 @@ Examples:
      (start-load-or-eval))
 
     (t
-     (start-browser urls)))
+     (with-muffled-body ("Error: ~a" :condition)
+       (start-browser urls))))
 
   (unless *keep-alive* (uiop:quit)))
 

--- a/source/visual-mode.lisp
+++ b/source/visual-mode.lisp
@@ -268,7 +268,7 @@ identifier for every hinted element."
                     (lambda ()
                       (with-current-buffer buffer
                         (nyxt/web-mode::remove-element-hints)))))))
-      (funcall-safely #'follow-hint result))))
+      (funcall #'follow-hint result))))
 
 (define-parenscript is-collapsed ()
   ;; returns "true" if mark's start and end are the same value

--- a/source/watch-mode.lisp
+++ b/source/watch-mode.lisp
@@ -43,6 +43,7 @@
    (constructor (lambda (mode)
                   (setf (sleep-time mode) (seconds-from-user-input))
                   (setf (thread mode)
-                        (bt:make-thread (lambda () (loop while (buffer mode)
-                                                         do (nyxt::reload-buffer (buffer mode))
-                                                            (sleep (sleep-time mode))))))))))
+                        (run-thread
+                          (loop while (buffer mode)
+                                do (nyxt::reload-buffer (buffer mode))
+                                   (sleep (sleep-time mode)))))))))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -203,14 +203,14 @@ and to index the top of the page.")
         (ffi-generate-input-event
          window
          (nyxt::last-event buffer))
-        (funcall-safely command))))
+        (funcall command))))
 
 (define-command paste-or-set-url (&optional (buffer (current-buffer)))
   "Paste text if active element is an input tag, forward event otherwise."
   (let ((response (%clicked-in-input?)))
     (let ((url-empty (url-empty-p (url-at-point buffer))))
       (if (and (input-tag-p response) url-empty)
-          (funcall-safely #'paste)
+          (funcall #'paste)
           (unless url-empty
             (make-buffer-focus :url (url-at-point buffer)
                                :nosave-buffer-p (nosave-buffer-p buffer)))))))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -93,7 +93,7 @@ The handlers take the window as argument."))
       (ffi-print-status
        window
        (or status
-           (funcall-safely (status-formatter window) window))))))
+           (funcall (status-formatter window) window))))))
 
 (hooks:define-hook-type window (function (window)))
 


### PR DESCRIPTION
This is certainly one of my most important contributions: it catches hopefully all Lisp errors at runtime, which means no more Lisp-induced crashes for Nyxt!

2-pre-release-6 introduced many crash regressions for stupid mistakes that should not have crashed the browser anyways.

With this patchset, this kind of errors are reported, but won't crash the browser anymore!

This introduces a few changes:

- Removal of `funcall-safely`.  Hopefully OK, please test.
- Renamed `*keep-alive*` to the more meaningful `*run-from-repl-p*`.
- Renamed `with-muffled-body` to the more accurate `with-protect`.

Please test and let me know what you think! :)