### PR TITLE
buffer.lisp: add command to focus the first input field.

### DIFF
--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -58,7 +58,8 @@
                      "C-shift-t" 'reopen-buffer
                      "C-T" 'reopen-buffer
                      "C-p" 'print-buffer
-                     "C-x C-f" 'open-file)
+                     "C-x C-f" 'open-file
+                     "M-i" 'focus-first-input-field)
 
                     scheme:emacs
                     (list

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1099,3 +1099,12 @@ ARGS are passed to the mode command."
   "Print the current buffer."
   (pflet ((print-buffer () (print)))
          (print-buffer)))
+
+(define-command focus-first-input-field (&key (buffer (current-buffer)))
+  "Move the focus to the first input field of `buffer'."
+  (pflet ((focus () (ps:chain document
+                              (get-elements-by-tag-name "INPUT")
+                              (item 0)
+                              (focus))))
+    (with-current-buffer buffer
+      (focus))))


### PR DESCRIPTION
As request in #1233.

Notice that TAB can't be used as a keybinding since this key is already bounded in GTK.

As usually this misbehaves on duckduckgo. Users can hit the "h" key to get to the search bar though.