### PR TITLE
Fix auto mode previous url

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -356,7 +356,7 @@ For the storage format see the comment in the head of your `auto-mode-rules-data
 (defmethod serialize-object ((rule auto-mode-rule) stream)
   (flet ((write-if-present (slot &key modes-p)
            (when (funcall slot rule)
-             (format t " :~a ~s"
+             (format t " :~a ~a"
                      slot
                      (let ((value (funcall slot rule)))
                        (if modes-p

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -162,7 +162,7 @@ non-new-page requests, buffer URL is not altered."
       (cond
         ((and (not rule) (new-page-request-p request-data))
          (reapply-last-active-modes auto-mode))
-        ((and rule (not (equalp rule previous-rule)))
+        ((and rule (not (eq rule previous-rule)))
          (enable-matching-modes (url request-data) (buffer request-data))))))
   request-data)
 

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -72,6 +72,7 @@ If the mode specifier is not known, it's omitted from the results."
              :type (or (cons mode-invocation *) null)
              :documentation "The list of `mode-invocation's to disable on rule activation.")
    (exact-p nil
+            :type boolean
             :documentation "If non-nil, enable the INCLUDED modes exclusively.
 Enable INCLUDED modes plus the already present ones, and disable EXCLUDED modes, if nil."))
   (:export-class-name-p t)

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -266,11 +266,21 @@ Be careful with deleting the defaults -- it can be harmful for your browsing.")
                           :type (or quri:uri null)
                           :documentation "The last URL that the active modes were saved for.
 We need to store this to not overwrite the `last-active-modes' for a given URL,
-if `auto-mode-handler' will fire more than once.")
+if `auto-mode-handler' is fired more than once.")
    (last-active-modes '()
                       :type (or (cons mode-invocation *) null)
                       :documentation "The list of `mode-invocation's that were enabled
-on the last URL not covered by `auto-mode'.")
+on the last URL not covered by `auto-mode'.
+This is useful when alternative between rule-less and ruled pages.
+Example browse sequence:
+
+- https://example.org (noscript-mode noimage-mode) ; No rule.
+- https://nyxt.atlas.engineer (dark-mode) ; Rule
+- https://en.wikipedia.org (noscript-mode noimage-mode) ; No rule.
+
+In the above, when browsing from nyxt.atlas.engineer to en.wikipedia.org, the
+modes that were in place before the nyxt.atlas.engineer rule was applied are
+restored.")
    (destructor #'clean-up-auto-mode)
    (constructor #'initialize-auto-mode)))
 

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -932,7 +932,8 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
    (prompter:filter-preprocessor nil)   ; Don't remove non-exact results.
    (prompter:multi-selection-p t)       ; TODO: Disable once tested OK.
    (prompter:must-match-p nil)
-   (prompter:actions '(buffer-load))))
+   (prompter:actions '(buffer-load)))
+  (:export-class-name-p t))
 
 (define-command set-url (&key (prefill-current-url-p t))
   "Set the URL for the current buffer, completing with history."


### PR DESCRIPTION
@aartaka I've replaced the previous-url query with a dedicated slot.
Does that make sense to you?

Something else: can you explain a use case why we need last-active-modes-url, I don't understand the thing with the multiple applications of `auto-mode-handler`.

Should fix #1095 for good.