### PR TITLE
Add :mode property to command-properties.

### DIFF
--- a/source/command-commands.lisp
+++ b/source/command-commands.lisp
@@ -36,7 +36,11 @@
              (first (str:split +newline+ string))))
       (list :name (string-downcase (name command))
             :bindings (format nil "~{~a~^, ~}" bindings)
-            :docstring (first-line (nyxt::docstring command))))))
+            :docstring (first-line (nyxt::docstring command))
+            :mode (let ((package-name (str:downcase (uiop:symbol-package-name (name command)))))
+                    (if (sera:in package-name "nyxt" "nyxt-user")
+                        ""
+                        (str:replace-first "nyxt/" "" package-name)))))))
 
 (defmethod prompter:object-properties ((command command))
   (command-properties command))


### PR DESCRIPTION
This adds a "Mode" column to the `execute-command` prompt, as it was before `prompter` merge. It seems this mode column is the most reliable and simple way to understand which mode command belongs to, as [this Reddit post](https://www.reddit.com/r/Nyxt/comments/mhil6l/keybindings_problem_where_to_find_the_module/) says.

Does that look alright?
What was the reason to remove mode names, in the first place?