### PR TITLE
Format modes status bar glyph support

### DIFF
--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -6,7 +6,8 @@
 (define-mode base-mode ()
   "Bind general-purpose commands defined by `define-command'.
 This mode is a good candidate to be passed to `make-buffer'."
-  ((keymap-scheme (define-scheme "base"
+  ((visible-in-status-p nil)
+   (keymap-scheme (define-scheme "base"
                     scheme:cua
                     (list
                      "C-q" 'quit

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -352,6 +352,9 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
   ((height 20
            :type integer
            :documentation "The height of the status buffer in pixels.")
+   (glyph-mode-presentation-p
+    nil
+    :documentation "Display the modes as a list of glyphs.")
    (style #.(cl-css:css
              '((body
                 :background "rgb(200, 200, 200)"

--- a/source/emacs-mode.lisp
+++ b/source/emacs-mode.lisp
@@ -16,7 +16,8 @@ Example:
 
 \(define-configuration buffer
   ((default-modes (append '(emacs-mode) %slot-default))))"
-  ((previous-keymap-scheme-name nil
+  ((glyph "ε")
+   (previous-keymap-scheme-name nil
     :type (or keymap:scheme-name null)
     :documentation "The previous keymap scheme that will be used when ending
 this mode.")

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -131,11 +131,21 @@ It is run before the destructor.")
    (keymap-scheme (make-hash-table :size 0)
                   :type keymap:scheme)))
 
-(defmethod object-string ((mode root-mode))
-  (symbol-name (class-name (class-of mode))))
-
 (defmethod prompter:object-properties ((mode root-mode))
   (list :name (mode-name mode)))
+
+(defmethod glyph ((mode root-mode))
+  "Return the glyph for a mode, or if unset, return a standard formatted mode."
+  (or (slot-value mode 'glyph)
+      (format-mode mode)))
+
+(defmethod (setf glyph) (glyph (mode root-mode))
+  (setf (slot-value mode 'glyph) glyph))
+
+(defmethod format-mode ((mode root-mode))
+  "Produce a string representation of a mode suitable for use in a status
+  buffer."
+  (str:replace-all "-mode" "" (str:downcase (mode-name mode))))
 
 (export-always 'find-mode)
 (defmethod find-mode ((buffer buffer) mode-symbol)

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -101,6 +101,7 @@ Example:
   ((buffer nil
            :type (or buffer null))
    (glyph nil :type (or string null)
+              :accessor nil
               :documentation "A glyph used to represent this mode, if unset, it
               will be dynamically calculated as the first letters of the mode
               name.")
@@ -134,6 +135,7 @@ It is run before the destructor.")
 (defmethod prompter:object-properties ((mode root-mode))
   (list :name (mode-name mode)))
 
+(export-always 'glyph)
 (defmethod glyph ((mode root-mode))
   "Return the glyph for a mode, or if unset, return a standard formatted mode."
   (or (slot-value mode 'glyph)

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -100,6 +100,13 @@ Example:
   "All modes inherit from `root-mode'."
   ((buffer nil
            :type (or buffer null))
+   (glyph nil :type (or string null)
+              :documentation "A glyph used to represent this mode, if unset, it
+              will be dynamically calculated as the first letters of the mode
+              name.")
+   (visible-in-status-p
+    t
+    :documentation "Should this mode be visible within the status line?")
    (activate :accessor activate :initarg :activate) ; TODO: This can be used in the future to temporarily turn off modes without destroying the object.
    (constructor nil ; TODO: Make constructor / destructor methods?  Then we can use initialize-instance, etc.
                 :type (or function null)


### PR DESCRIPTION
Add glyph presentation support for status buffers. This is a feature requested by a few users.
Also:

+ whether a mode is visible or not is within its own configuration
+ the glyph of a mode is defined within its own configuration
+ whether a status buffer uses glyphs or full names is defined within a status-buffer configuration