### PR TITLE
Prompter attributes

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -151,7 +151,9 @@
     ;; The official Guix package should use `sbcl-*' inputs though.
     (native-inputs
      `(("prove" ,cl-prove)
-       ("sbcl" ,sbcl)))
+       ("sbcl" ,sbcl)
+       ;; Only for development, unneeded for the upstream Guix package:
+       ("cl-trivial-benchmark" ,cl-trivial-benchmark)))
     (inputs
      `(("alexandria" ,cl-alexandria)
        ("bordeaux-threads" ,cl-bordeaux-threads)

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -10,6 +10,11 @@
 ;; they may be defined globally.  Conversely, `prompter' is mostly used
 ;; locally.
 
+;; TODO: Performance: plists are faster, especially when it comes to modifying
+;; existing attributes.
+;; TODO: Performance: Consider computing the attribute values only when active.
+;; Lazy evaluation would make it easy.
+
 (deftype must-match-choices ()
   `(member :always :ignore :confirm))
 

--- a/libraries/prompter/readme.org
+++ b/libraries/prompter/readme.org
@@ -8,7 +8,7 @@ Non-exhaustive list of features:
 - Multiple sources.
 - Multiple actions.
 - Customizable matching and sorting.
-- Multiple properties to match and display (also known as "multiple column
+- Multiple attributes to match and display (also known as "multiple column
   display" like =helm-find-files=).
 - Customizable initialization and cleanup functions.
 - Notifications sent when suggestion list is updated.

--- a/libraries/prompter/tests/tests.lisp
+++ b/libraries/prompter/tests/tests.lisp
@@ -52,8 +52,8 @@
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
 (defmethod prompter:object-attributes ((url url))
-  `(:uri ,(uri url)
-    :title ,(title url)))
+  `(("URI" ,(uri url))
+    ("Title" ,(title url))))
 
 (prove:subtest "Multi-attribute matching"
   (let* ((url1 (make-instance 'url :uri "http://example.org" :title "Example"))
@@ -67,7 +67,15 @@
       (let ((filtered-suggestions (prompter:suggestions
                                    (first (prompter:sources prompter)))))
         (prove:is (mapcar #'prompter:value filtered-suggestions)
-                  (list url2))))))
+                  (list url2))))
+    (setf (prompter:active-attributes-keys (prompter:selected-source prompter))
+          '("URI"))
+    (prove:is (prompter:active-attributes-keys (prompter:selected-source prompter))
+               '("URI"))
+    (prove:is (prompter:active-attributes
+                (prompter:selected-suggestion prompter)
+                :source (prompter:selected-source prompter))
+              `(("URI" ,(uri url2) )))))
 
 (defvar *prompter-suggestion-update-interval* 1.5)
 
@@ -126,7 +134,8 @@
                 :test #'<
                 "Consecutive inputs happened fast enough"))))
 
-(prove:subtest "Yes-No prompt"
+(prove:subtest "Yes-No prompt"          ; TODO: This test randomly throws an error:
+  ;; Raised an error Interrupt thread failed: thread #<THREAD "Anonymous thread" FINISHED values: T {1013B856B3}> has exited. (expected: :NON-ERROR)
   (let* ((source (make-instance 'prompter:yes-no-source
                                 :constructor '("no" "yes")))
          (prompter (prompter:make

--- a/libraries/prompter/tests/tests.lisp
+++ b/libraries/prompter/tests/tests.lisp
@@ -51,11 +51,11 @@
    (title ""))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(defmethod prompter:object-properties ((url url))
+(defmethod prompter:object-attributes ((url url))
   `(:uri ,(uri url)
     :title ,(title url)))
 
-(prove:subtest "Multi-property matching"
+(prove:subtest "Multi-attribute matching"
   (let* ((url1 (make-instance 'url :uri "http://example.org" :title "Example"))
          (url2 (make-instance 'url :uri "http://nyxt.atlas.engineer" :title "Nyxt homepage"))
          (prompter (prompter:make

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -488,4 +488,4 @@
   :depends-on (nyxt/prompter prove)
   :components ((:file "libraries/prompter/test-package"))
   :perform (test-op (op c)
-                         (nyxt-run-test c "libraries/prompter/tests/")))
+                    (nyxt-run-test c "libraries/prompter/tests/")))

--- a/source/autofill.lisp
+++ b/source/autofill.lisp
@@ -32,10 +32,10 @@ Can be:
 (defmethod object-string ((autofill autofill))
   (autofill-key autofill))
 
-(defmethod prompter:object-properties ((autofill autofill))
-  (list :key (autofill-key autofill)
-        :name (autofill-name autofill)
-        :fill (autofill-fill autofill)))
+(defmethod prompter:object-attributes ((autofill autofill))
+  `(("Key" ,(autofill-key autofill))
+    ("Name" ,(autofill-name autofill))
+    ("Fill" ,(autofill-fill autofill))))
 
 (defmethod object-display ((autofill autofill))
   (format nil "~a:  ~a" (autofill-key autofill)

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -38,14 +38,14 @@ appended to the URL."))
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(defmethod prompter:object-properties ((entry bookmark-entry))
+(defmethod prompter:object-attributes ((entry bookmark-entry))
   ;; TODO: Add annocation slots?
-  `(:url ,(quri:render-uri (url entry))
-    :title ,(title entry)
-    :tags ,(format nil "~{~a ~}" (tags entry))
-    :date ,(date entry)
-    :shortcut ,(shortcut entry)
-    :search-url ,(search-url entry)))
+  `(("URL" ,(quri:render-uri (url entry)))
+    ("Title" ,(title entry))
+    ("Tags" ,(format nil "~{~a ~}" (tags entry)))
+    ("Date" ,(date entry))
+    ("Shortcut" ,(shortcut entry))
+    ("Search URL" ,(search-url entry))))
 
 (defmethod object-string ((entry bookmark-entry)) ; TODO: Delete?
   (object-string (url entry)))
@@ -108,7 +108,7 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
 (define-class bookmark-source (prompter:source)
   ((prompter:name "Bookmarks")
    (prompter:constructor (get-data (bookmarks-path (current-buffer))))
-   (prompter:active-properties '(:url :title :tags))))
+   (prompter:active-attributes-keys '("URL" "Title" "Tags"))))
 
 (defun tag-suggestions ()
   (with-data-unsafe (bookmarks (bookmarks-path (current-buffer)))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -534,9 +534,9 @@ BUFFER's modes."
 (defmethod object-display ((buffer buffer))
   (format nil "~a  ~a" (title buffer) (object-display (url buffer))))
 
-(defmethod prompter:object-properties ((buffer buffer))
-  (list :default (url buffer)
-        :title (title buffer)))
+(defmethod prompter:object-attributes ((buffer buffer))
+  `(("URL" ,(url buffer))
+    ("Title" ,(title buffer))))
 
 (define-command make-buffer (&key (title "") modes (url "") parent-buffer (load-url-p t))
   "Create a new buffer.

--- a/source/command-commands.lisp
+++ b/source/command-commands.lisp
@@ -11,12 +11,12 @@
           :documentation "The hook value."))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(defmethod prompter:object-properties ((hook-description hook-description))
-  (list :name (name hook-description)
-        :value (value hook-description)))
+(defmethod prompter:object-attributes ((hook-description hook-description))
+  `(("Name" ,(name hook-description))
+    ("Value" ,(value hook-description))))
 
-(defmethod prompter:object-properties ((handler hooks:handler))
-  (list :name (str:downcase (hooks:name handler))))
+(defmethod prompter:object-attributes ((handler hooks:handler))
+  `(("Name" ,(str:downcase (hooks:name handler)))))
 
 (defun get-commands (&optional (buffer (current-buffer)))
   (sort (apply #'list-commands
@@ -34,15 +34,15 @@
             return bindings)
     (flet ((first-line (string)
              (first (str:split +newline+ string))))
-      (list :name (string-downcase (name command))
-            :bindings (format nil "~{~a~^, ~}" bindings)
-            :docstring (first-line (nyxt::docstring command))
-            :mode (let ((package-name (str:downcase (uiop:symbol-package-name (name command)))))
-                    (if (sera:in package-name "nyxt" "nyxt-user")
-                        ""
-                        (str:replace-first "nyxt/" "" package-name)))))))
+      `(("Name" ,(string-downcase (name command)))
+        ("Bindings" ,(format nil "~{~a~^, ~}" bindings))
+        ("Docstring" ,(first-line (nyxt::docstring command)))
+        ("Mode" ,(let ((package-name (str:downcase (uiop:symbol-package-name (name command)))))
+                   (if (sera:in package-name "nyxt" "nyxt-user")
+                       ""
+                       (str:replace-first "nyxt/" "" package-name))))))))
 
-(defmethod prompter:object-properties ((command command))
+(defmethod prompter:object-attributes ((command command))
   (command-properties command))
 
 (define-class command-source (prompter:source)

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -256,9 +256,9 @@ and all (possibly unexported) symbols in USER-PACKAGE-DESIGNATORS."
                            (name slot)
                            (class-sym slot))))
 
-(defmethod prompter:object-properties ((slot slot))
-  `(:name ,(name slot)
-    :class ,(class-sym slot)))
+(defmethod prompter:object-attributes ((slot slot))
+  `(("Name" ,(name slot))
+    ("Class" ,(class-sym slot))))
 
 (defun exported-p (sym)
   (eq :external

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -385,9 +385,9 @@ you use this macro! For a modification-safe macro, see `with-data-access'."
    (prompter:must-match-p nil)
    (prompter:constructor (gpg-private-keys))))
 
-(defmethod prompter:object-properties ((gpg-key gpg-key))
-  (list :id (gpg-key-key-id gpg-key)
-        :additional (str:join ", " (mapcar #'gpg-uid-user-id (gpg-key-uids gpg-key)))))
+(defmethod prompter:object-attributes ((gpg-key gpg-key))
+  `(("ID" ,(gpg-key-key-id gpg-key))
+    ("Additional" ,(str:join ", " (mapcar #'gpg-uid-user-id (gpg-key-uids gpg-key))))))
 
 (defmethod object-string ((gpg-key gpg-key))
   (gpg-key-key-id gpg-key))

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -243,10 +243,10 @@ identifier for every hinted element."
          :documentation "The body of the anchor tag."))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(defmethod prompter:object-properties ((hint hint))
-  (list :hint (hint hint)
-        :body (body hint)
-        :url (when (slot-exists-p hint 'url) (url hint))))
+(defmethod prompter:object-attributes ((hint hint))
+  `(("Hint" ,(hint hint))
+    ("Body" ,(body hint))
+    ("URL" ,(when (slot-exists-p hint 'url) (url hint)))))
 
 (define-class clickable-hint (hint) ())
 

--- a/source/file-manager.lisp
+++ b/source/file-manager.lisp
@@ -16,7 +16,7 @@
               (make-instance 'prompter:suggestion
                              :value file
                              :match-data (namestring file)
-                             :properties (prompter:object-properties file)
+                             :attributes (prompter:object-attributes file)
                              :source source
                              :input input))
             (directory-elements (if (uiop:directory-pathname-p pathname)

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -37,9 +37,9 @@ The total number of visit for a given URL is (+ explicit-visits implicit-visits)
 (defmethod object-display ((entry history-entry))
   (format nil "~a  ~a" (object-display (url entry)) (title entry)))
 
-(defmethod prompter:object-properties ((entry history-entry))
-  (list :default (object-string (url entry)) ; TODO: Use object-properties instead?
-        :title (title entry)))
+(defmethod prompter:object-attributes ((entry history-entry))
+  `(("URL" ,(object-string (url entry))) ; TODO: Use object-properties instead?
+    ("Title" ,(title entry))))
 
 (export-always 'equals)
 (defmethod equals ((e1 history-entry) (e2 history-entry))

--- a/source/jump-heading.lisp
+++ b/source/jump-heading.lisp
@@ -13,8 +13,8 @@
 (defmethod title ((heading heading))
   (subseq (inner-text heading) 0 (position #\[ (inner-text heading))))
 
-(defmethod prompter:object-properties ((heading heading))
-  (list :title (title heading)))
+(defmethod prompter:object-attributes ((heading heading))
+  `(("Title" ,(title heading))))
 
 (defun get-headings (&key (buffer (current-buffer)))
   (pflet ((get-headings ()

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -134,8 +134,8 @@ It is run before the destructor.")
    (keymap-scheme (make-hash-table :size 0)
                   :type keymap:scheme)))
 
-(defmethod prompter:object-properties ((mode root-mode))
-  (list :name (mode-name mode)))
+(defmethod prompter:object-attributes ((mode root-mode))
+  `(("Name" ,(mode-name mode))))
 
 (export-always 'glyph)
 (defmethod glyph ((mode root-mode))

--- a/source/os-package-manager-mode.lisp
+++ b/source/os-package-manager-mode.lisp
@@ -85,14 +85,14 @@
               " (current)"
               "")))
 
-(defmethod prompter:object-attributes ((pkg ospm:guix-package)) ; TODO: This is much too slow.
+(defmethod prompter:object-attributes ((pkg ospm:guix-package))
   (let ((result (call-next-method pkg))
         (map `(("Dependencies" nil)
-               ("Outputs" ,(str:join " " (mapcar #'ospm:name (ospm:outputs pkg))))
-               ("Supported systems" ,(str:join " " (ospm:supported-systems pkg)))
-               ("Inputs" ,(str:join " " (ospm:inputs pkg)))
-               ("Native inputs" ,(str:join " " (ospm:native-inputs pkg)))
-               ("Propagated inputs" ,(str:join " " (ospm:propagated-inputs pkg)))
+               ("Outputs" ,(sera:string-join (mapcar #'ospm:name (ospm:outputs pkg)) " "))
+               ("Supported systems" ,(sera:string-join (ospm:supported-systems pkg) " "))
+               ("Inputs" ,(sera:string-join (ospm:inputs pkg) " "))
+               ("Native inputs" ,(sera:string-join (ospm:native-inputs pkg) " "))
+               ("Propagated inputs" ,(sera:string-join (ospm:propagated-inputs pkg) " "))
                ("Licenses" ,(format nil "~{~a~^, ~}" (ospm:licenses pkg))))))
     (delete nil
             (mapcar (lambda (key-value)

--- a/source/os-package-manager-mode.lisp
+++ b/source/os-package-manager-mode.lisp
@@ -86,22 +86,20 @@
               "")))
 
 (defmethod prompter:object-attributes ((pkg ospm:guix-package))
-  (let ((result (call-next-method pkg))
-        (map `(("Dependencies" nil)
-               ("Outputs" ,(sera:string-join (mapcar #'ospm:name (ospm:outputs pkg)) " "))
-               ("Supported systems" ,(sera:string-join (ospm:supported-systems pkg) " "))
-               ("Inputs" ,(sera:string-join (ospm:inputs pkg) " "))
-               ("Native inputs" ,(sera:string-join (ospm:native-inputs pkg) " "))
-               ("Propagated inputs" ,(sera:string-join (ospm:propagated-inputs pkg) " "))
-               ("Licenses" ,(format nil "~{~a~^, ~}" (ospm:licenses pkg))))))
-    (delete nil
-            (mapcar (lambda (key-value)
-                      (alex:if-let ((new-key-value (first (member (first key-value) map :test #'string= :key #'first))))
-                        (if (second new-key-value)
-                            new-key-value
-                            nil)
-                        key-value))
-                    result))))
+  ;; We could have called `call-next-method', then modify the result, but it's
+  ;; too costly for thousands of packages.
+  `(("Name" ,(ospm:name pkg))
+    ("Version" ,(ospm:version pkg))
+    ("Synopsis" ,(ospm:synopsis pkg))
+    ("Description" ,(ospm:description pkg))
+    ("Home page" ,(ospm:home-page pkg))
+    ("Location" ,(ospm:location pkg))
+    ("Outputs" ,(sera:string-join (mapcar #'ospm:name (ospm:outputs pkg)) " "))
+    ("Supported systems" ,(sera:string-join (ospm:supported-systems pkg) " "))
+    ("Inputs" ,(sera:string-join (ospm:inputs pkg) " "))
+    ("Native inputs" ,(sera:string-join (ospm:native-inputs pkg) " "))
+    ("Propagated inputs" ,(sera:string-join (ospm:propagated-inputs pkg) " "))
+    ("Licenses" ,(format nil "~{~a~^, ~}" (ospm:licenses pkg)))))
 
 (define-class os-package-source (prompter:source)
   ((prompter:name "Packages")

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -229,7 +229,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
   (let* ((sources (prompter:sources prompt-buffer))
          (current-source-index (position (current-source prompt-buffer) sources))
          (last-source-index (1- (length sources))))
-    ;; TODO: Factor out property printing.
+    ;; TODO: Factor out attribute printing.
     (flet ((source->html (source)
              (markup:markup
               (:div :class "source"
@@ -246,11 +246,10 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                              (markup:markup*
                               `(:tr
                                 ,@(when (and (compact-display-p prompt-buffer)
-                                             (sera:single (prompter:active-properties source)))
+                                             (sera:single (prompter:active-attributes-keys source)))
                                     '(:hidden "true"))
-                                ,@(loop for property in (prompter:active-properties source)
-                                        ;; TODO: If we turn properties to strings, no need to capitalize.
-                                        collect `(:th ,(str:capitalize property))))))
+                                ,@(loop for attribute-key in (prompter:active-attributes-keys source)
+                                        collect `(:th ,attribute-key)))))
                             (loop ;; TODO: Only print as many lines as fit the height.  But how can we know in advance?
                                   ;; Maybe first make the table, then add the element one by one _if_ there are into view.
                                   with max-suggestion-count = 10
@@ -264,8 +263,8 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                                       "selection")
                                                 :class (when (prompter:marked-p source (prompter:value suggestion))
                                                          "marked")
-                                                (loop for (nil property) on (prompter:active-properties suggestion :source source) by #'cddr
-                                                      collect (markup:markup (:td property)))))))))))
+                                                (loop for (nil attribute) in (prompter:active-attributes suggestion :source source)
+                                                      collect (markup:markup (:td attribute)))))))))))
       (ffi-prompt-buffer-evaluate-javascript-async
        (window prompt-buffer)
        (ps:ps
@@ -384,9 +383,9 @@ See the documentation of `prompt-buffer' to know more about the options."
         ((calispel:? interrupt-channel)
          (error 'nyxt-prompt-buffer-canceled))))))
 
-(defmethod prompter:object-properties ((prompt-buffer prompt-buffer))
-  (list :prompt (prompter:prompt prompt-buffer)
-        :input (prompter:input prompt-buffer)))
+(defmethod prompter:object-attributes ((prompt-buffer prompt-buffer))
+  `(("Prompt" ,(prompter:prompt prompt-buffer))
+    ("Input" ,(prompter:input prompt-buffer))))
 
 (define-class resume-prompt-source (prompter:source)
   ((prompter:name "Resume prompters")

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -270,10 +270,10 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
        (ps:ps
         (setf (ps:chain document (get-element-by-id "suggestions") |innerHTML|)
               (ps:lisp
-               (str:join +newline+
-                         (loop for i from current-source-index to last-source-index
-                               for source = (nth i sources)
-                               collect (source->html source))))))))
+               (sera:string-join (loop for i from current-source-index to last-source-index
+                                       for source = (nth i sources)
+                                       collect (source->html source))
+                                 +newline+))))))
     (prompt-render-prompt prompt-buffer)))
 
 (defun erase-document (prompt-buffer)

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -116,11 +116,11 @@
    (buffer))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(defmethod prompter:object-properties ((match search-match))
-  (list :default (body match)
-        :id (identifier match)
-        :buffer-id (id (buffer match))
-        :buffer-title (title (buffer match))))
+(defmethod prompter:object-attributes ((match search-match))
+  `(("Default" ,(body match))
+    ("ID" ,(identifier match))
+    ("Buffer ID" ,(id (buffer match)))
+    ("Buffer title" ,(title (buffer match)))))
 
 (defun matches-from-json (matches-json &optional (buffer (current-buffer)))
   (loop for element in (handler-case (cl-json:decode-json-from-string matches-json)

--- a/source/visual-mode.lisp
+++ b/source/visual-mode.lisp
@@ -201,9 +201,9 @@ identifier for every hinted element."
 
 (defclass paragraph-hint (nyxt/web-mode::hint) ())
 
-(defmethod prompter:object-properties ((hint paragraph-hint))
-  (list :hint (nyxt/web-mode::hint hint)
-        :body (nyxt/web-mode::body hint)))
+(defmethod prompter:object-attributes ((hint paragraph-hint))
+  `(("Hint" ,(nyxt/web-mode::hint hint))
+    ("Body" ,(nyxt/web-mode::body hint))))
 
 (define-parenscript set-caret-on-start (&key nyxt-identifier)
   (defun qs (context selector)

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -267,10 +267,10 @@ and to index the top of the page.")
                  history)))))
   (:export-class-name-p t))
 
-(defmethod prompter:object-properties ((node history-tree:node))
+(defmethod prompter:object-attributes ((node history-tree:node))
   (let ((entry (htree:data (history-tree:entry node))))
-    (list :url (object-display (url entry))
-          :title (title entry))))
+    `(("URL" ,(object-display (url entry)))
+      ("Title" ,(title entry)))))
 
 (define-command history-backwards-query (&optional (buffer (current-buffer)))
   "Query parent URL to navigate back to."

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -123,9 +123,9 @@ The handlers take the window as argument."))
   (when (zerop (hash-table-count (windows *browser*)))
     (quit)))
 
-(defmethod prompter:object-properties ((window window))
-  (list :id (id window)
-        :active-buffer (title (active-buffer window))))
+(defmethod prompter:object-attributes ((window window))
+  `(("ID" ,(id window))
+    ("Active buffer" ,(title (active-buffer window)))))
 
 (define-class window-source (prompter:source)
   ((prompter:name "Windows")

--- a/tests/benchmark-package.lisp
+++ b/tests/benchmark-package.lisp
@@ -1,0 +1,6 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(benchmark:define-benchmark-package nyxt/benchmark
+  (:use #:common-lisp)
+  (:import-from #:nyxt))

--- a/tests/benchmarks/prompter.lisp
+++ b/tests/benchmarks/prompter.lisp
@@ -1,0 +1,13 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package nyxt/benchmark)
+
+(define-benchmark measure-guix-package-source ()
+  "Measure the time needed to create a prompter source for Guix packages.
+The build time for the Guix package database is not taken into account."
+  (declare (optimize speed))
+  (ospm:list-packages)
+  (loop repeat 10
+        do (with-benchmark-sampling
+             (make-instance 'nyxt/os-package-manager-mode::os-package-source))))


### PR DESCRIPTION
Two major changes:

- Rename "properties" to "attributes" in prompter library.  This is to avoid ambiguity with CL symbol properties or plists.

- Turn the attributes into a string-keyed alist.
  This has the benefit that we can now customize how we want to display they attributes keys in the attribute HTML header.  For instance, we now display "URL" instead of "Url".

Please have a a quick test! :)