### PR TITLE
Open-file

### DIFF
--- a/libraries/keymap/keymap.lisp
+++ b/libraries/keymap/keymap.lisp
@@ -337,7 +337,7 @@ Parents are ordered by priority, the first parent has highest priority.")))
 ;; types that use `satisfies' for non-top-level symbols.
 ;; We can verify this with:
 ;;
-;;   (compile 'foo (lambda () (keymap::define-key keymap "C-x C-f" 'find-file)))
+;;   (compile 'foo (lambda () (keymap::define-key keymap "C-x C-f" 'open-file)))
 (defmacro define-key (keymap keyspecs bound-value &rest more-keyspecs-value-pairs)
   "Bind KEYS to BOUND-VALUE in KEYMAP.
 Return KEYMAP.
@@ -353,19 +353,19 @@ In other words, it remaps OTHER-VALUE to VALUE.
 
 Examples:
 
-  (define-key foo-map \"C-x C-f\" 'find-file)
+  (define-key foo-map \"C-x C-f\" 'open-file)
 
   (define-key foo-map
-              \"C-x C-f\" 'find-file
+              \"C-x C-f\" 'open-file
               \"C-h k\" 'describe-key)
 
 \"C-M-1 x\" on a QWERTY:
 
-  (define-key foo-map '((:code 10 :modifiers (\"C\" \"M\") (:value \"x\"))) 'find-file)
+  (define-key foo-map '((:code 10 :modifiers (\"C\" \"M\") (:value \"x\"))) 'open-file)
 
 or the shorter:
 
-  (define-key foo-map \"C-M-#1\" 'find-file)
+  (define-key foo-map \"C-M-#1\" 'open-file)
 
 Remapping keys:
 

--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -58,7 +58,8 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-/" 'reopen-buffer
                      "C-shift-t" 'reopen-buffer
                      "C-T" 'reopen-buffer
-                     "C-p" 'print-buffer)
+                     "C-p" 'print-buffer
+                     "C-o" 'find-file)
 
                     scheme:emacs
                     (list
@@ -92,7 +93,8 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-x r u" 'bookmark-url
                      "C-x 5 2" 'make-window
                      "C-x 5 0" 'delete-current-window
-                     "C-x 5 1" 'delete-window)
+                     "C-x 5 1" 'delete-window
+                     "C-x C-f" 'find-file)
 
                     scheme:vi-normal
                     (list
@@ -134,5 +136,6 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-w C-w" 'make-window
                      "C-w q" 'delete-current-window
                      "C-w C-q" 'delete-window
-                     "u" 'reopen-buffer))
+                     "u" 'reopen-buffer
+                     "g o" 'find-file))
                   :type keymap:scheme)))

--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -59,7 +59,7 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-shift-t" 'reopen-buffer
                      "C-T" 'reopen-buffer
                      "C-p" 'print-buffer
-                     "C-o" 'find-file)
+                     "C-o" 'open-file)
 
                     scheme:emacs
                     (list
@@ -94,7 +94,7 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-x 5 2" 'make-window
                      "C-x 5 0" 'delete-current-window
                      "C-x 5 1" 'delete-window
-                     "C-x C-f" 'find-file)
+                     "C-x C-f" 'open-file)
 
                     scheme:vi-normal
                     (list
@@ -137,5 +137,5 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-w q" 'delete-current-window
                      "C-w C-q" 'delete-window
                      "u" 'reopen-buffer
-                     "g o" 'find-file))
+                     "g o" 'open-file))
                   :type keymap:scheme)))

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -92,9 +92,7 @@ appearance in the buffer when they are setf'd."
 ;; TODO: Move to separate package
 (define-mode download-mode ()
   "Display list of downloads."
-  ((rememberable-p nil)
-   (open-file-function #'default-open-file-function)
-   (style
+  ((style
     (cl-css:css
      '((".download"
         :margin-top "10px"
@@ -120,18 +118,6 @@ appearance in the buffer when they are setf'd."
         :height "100%"
         :background-color "dimgray"))))))
 
-#+linux
-(defvar *xdg-open-program* "xdg-open")
-
-(defun default-open-file-function (filename)
-  "Open FILENAME.
-
-Can be used as a `open-file-function'."
-  (uiop:launch-program
-   #+linux
-   (list *xdg-open-program* (namestring filename))
-   #+darwin
-   (list "open" (namestring filename))))
 
 (define-command list-downloads ()
   "Display a buffer listing all downloads.
@@ -170,17 +156,6 @@ download."
   "Download the page or file of the current buffer."
   (download (current-buffer) (url (current-buffer))))
 
-(define-class downloaded-files-source (file-source)
-  ((prompter:constructor (mapcar #'destination-path (downloads *browser*)))
-   ;; TODO: Extract to `file-source'?
-   ;; TODO: Maybe extract `open-file-function' to `browser'?
-   (prompter:actions
-    (list (make-command open-file* (files)
-            (let ((download-mode (find-submode (current-buffer) 'download-mode)))
-              (funcall (open-file-function download-mode) (first files))))))))
-
 (define-command download-open-file ()
   "Open a downloaded file."
-  (prompt
-   :prompt "Open file:"
-   :sources (make-instance 'downloaded-files-source)))
+  (find-file :default-directory (expand-path (download-path (current-buffer)))))

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -158,4 +158,4 @@ download."
 
 (define-command download-open-file ()
   "Open a downloaded file."
-  (find-file :default-directory (expand-path (download-path (current-buffer)))))
+  (open-file :default-directory (expand-path (download-path (current-buffer)))))

--- a/source/editor-mode.lisp
+++ b/source/editor-mode.lisp
@@ -67,8 +67,9 @@ get/set-content (which is necessary for operation)."
                       :prompt "Open file"
                       :input (namestring (uiop:getcwd))
                       :sources
-                      (list (make-instance 'file-source
-                                           :name "Absolute file path")
+                      (list (make-instance 'user-file-source
+                                           :name "Absolute file path"
+                                           :actions '(identity))
                             (make-instance 'prompter:raw-source
                                            :name "New file"))))))
     (open-file buffer file)

--- a/source/editor-mode.lisp
+++ b/source/editor-mode.lisp
@@ -47,14 +47,14 @@ get/set-content (which is necessary for operation)."
 (defgeneric set-content (editor content)
   (:documentation "Set the content of the editor."))
 
-(defmethod write-file ((buffer editor-buffer) &key (if-exists :error))
+(defmethod write-file-with-editor ((buffer editor-buffer) &key (if-exists :error))
   (alexandria:if-let ((editor (editor buffer)))
     (alexandria:write-string-into-file (get-content editor)
                                        (file buffer)
                                        :if-exists if-exists)
     (echo "Editor buffer cannot write file without configured editor mode.")))
 
-(defmethod open-file ((buffer editor-buffer) file)
+(defmethod open-file-with-editor ((buffer editor-buffer) file)
   (alexandria:if-let ((editor (editor buffer)))
     (if (uiop:file-exists-p file)
         (set-content editor (uiop:read-file-string file))
@@ -72,7 +72,7 @@ get/set-content (which is necessary for operation)."
                                            :actions '(identity))
                             (make-instance 'prompter:raw-source
                                            :name "New file"))))))
-    (open-file buffer file)
+    (open-file-with-editor buffer file)
     ;; TODO: Maybe make `editor-mode' and `editor-buffer' pathname-friendly?
     (setf (file buffer) (namestring file))
     (setf (title buffer) (namestring file))
@@ -80,7 +80,7 @@ get/set-content (which is necessary for operation)."
 
 (define-command editor-write-file (&key (buffer (current-buffer)) (if-exists :error))
   "Write the FILE of the BUFFER to storage."
-  (write-file buffer :if-exists if-exists)
+  (write-file-with-editor buffer :if-exists if-exists)
   (echo "File ~a written to storage." (file buffer)))
 
 (define-command nyxt::open-new-editor-with-file ()

--- a/source/file-manager.lisp
+++ b/source/file-manager.lisp
@@ -43,3 +43,85 @@ It's suitable for `prompter:filter-preprocessor'."
   (:export-class-name-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))
   (:documentation "Prompt source for file(s) on the disk."))
+
+;; TODO: Separate package?
+(define-mode file-mode (nyxt/prompt-buffer-mode:prompt-buffer-mode)
+  "Prompt-buffer mode forthe Nyxt-openable file filtering."
+  ((find-file-in-new-buffer t :documentation "If nil, don't open files and directories in a new buffer.")
+   (supported-media-types '("mp3" "ogg" "mp4" "flv" "wmv" "webm" "mkv")
+                          :type list-of-strings
+                          :documentation "Supported media types.
+Used for file filtering in `find-file'.")
+   (find-file-function #'default-find-file-function)))
+
+(defun supported-media-or-directory (filename)
+  "Return T if this filename's extension is a media that Nyxt can open (or a directory).
+See `supported-media-types' of `file-mode'."
+  (or (and (uiop:directory-pathname-p filename)
+           (uiop:directory-exists-p filename))
+      (sera:and-let* ((extension (pathname-type filename))
+                      (mode (find-submode (current-prompt-buffer) 'file-mode))
+                      (extensions (supported-media-types mode)))
+        (find extension extensions :test #'string-equal))))
+
+#+linux
+(defvar *xdg-open-program* "xdg-open")
+
+(export-always 'default-find-file-function)
+(defun default-find-file-function (filename &key (new-buffer-p
+                                                  (find-file-in-new-buffer
+                                                   (find-submode (current-prompt-buffer)
+                                                                 'file-mode))))
+  "Open FILENAME in Nyxt if supported, or externally otherwise.
+FILENAME is the full path of the file (or directory).
+
+See `supported-media-types' to customize the file types that are opened in
+Nyxt and those that are opened externally.
+
+NEW-BUFFER-P defines whether the file/directory will be open in a new buffer.
+
+Can be used as an `find-file-function'."
+  (handler-case
+      (if (supported-media-or-directory filename)
+          (if new-buffer-p
+              (make-buffer-focus :url (format nil "file://~a" filename))
+              (buffer-load (format nil "file://~a" filename)))
+          (uiop:launch-program
+           #+linux
+           (list *xdg-open-program* (namestring filename))
+           #+darwin
+           (list "open" (namestring filename))))
+    ;; We can probably signal something and display a notification.
+    (error (c) (log:error "Opening ~a: ~a~&" filename c))))
+
+
+(define-command find-file (&key (default-directory (user-homedir-pathname)))
+  "Open a file from the filesystem.
+
+The user is prompted with the prompt-buffer, files are browsable with
+fuzzy suggestion.
+
+DEFAULT-DIRECTORY specifies which directory to start from. Defaults to user home
+directory.
+
+By default, it uses the `xdg-open' command. The user can override the
+`find-file-function' of `file-mode' which takes the filename (or
+directory name) as parameter."
+  ;; TODO: How do we set the current directory permanently?
+  (flet ((supported-media-or-directory-filter (suggestions source input)
+           (remove-if-not #'supported-media-or-directory
+                          (make-file-suggestions suggestions source input)
+                          :key #'prompter:value)))
+    (prompt
+     :input (namestring default-directory)
+     :prompt "Open file"
+     :sources (list (make-instance
+                     'file-source
+                     :actions (list (make-command open* (files)
+                                      (dolist (file files)
+                                        (funcall
+                                         (find-file-function
+                                          (find-submode
+                                           (first (old-prompt-buffers *browser*)) 'file-mode))
+                                         file))))
+                     :filter-preprocessor #'supported-media-or-directory-filter)))))

--- a/source/file-manager.lisp
+++ b/source/file-manager.lisp
@@ -51,9 +51,12 @@ Others are opened with OS-specific mechanisms.")
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))
   (:documentation "Prompt source for file(s) on the disk."))
 
+;; FIXME: Configuring this in init.lisp requires nyxt:: prefix.
+;; How do we export it? :export-class-name-p doesn't work, it seems.
+(define-user-class file-source)
 
 (defun supported-media-or-directory (filename
-                                     &optional (file-source (make-instance 'file-source)))
+                                     &optional (file-source (make-instance 'user-file-source)))
   "Return T if this filename's extension is a media that Nyxt can open (or a directory).
 See `supported-media-types' of `file-mode'."
   (or (and (uiop:directory-pathname-p filename)
@@ -119,4 +122,4 @@ directory name) as parameter."
   (prompt
    :input (namestring default-directory)
    :prompt "Open file"
-   :sources (list (make-instance 'file-source))))
+   :sources (list (make-instance 'user-file-source))))

--- a/source/file-manager.lisp
+++ b/source/file-manager.lisp
@@ -52,7 +52,12 @@ It's suitable for `prompter:filter-preprocessor'."
                           :type list-of-strings
                           :documentation "Supported media types.
 Used for file filtering in `find-file'.")
-   (find-file-function #'default-find-file-function)))
+   (find-file-function #'default-find-file-function)
+   (keymap-scheme
+    (define-scheme "file-prompt-buffer"
+      scheme:cua
+      (list
+       "return" 'open-found-file)))))
 
 (defun supported-media-or-directory (filename
                                      &optional (file-mode (or (find-submode (current-prompt-buffer)
@@ -78,10 +83,6 @@ See `supported-media-types' of `file-mode'."
                                      :new-buffer-p new-buffer-p
                                      :supported-p (supported-media-or-directory file file-mode))))
                         (prompter:return-selection prompt-buffer))))
-
-(defmethod initialize-instance :after ((mode file-mode) &key)
-  (define-key (scheme-keymap (buffer mode) (nyxt/prompt-buffer-mode:keymap-scheme mode))
-    "return" 'open-found-file))
 
 #+linux
 (defvar *xdg-open-program* "xdg-open")
@@ -130,7 +131,7 @@ directory name) as parameter."
                           :key #'prompter:value)))
     (prompt
      :input (namestring default-directory)
-     :default-modes '(file-mode)
+     :default-modes '(file-mode nyxt/prompt-buffer-mode:prompt-buffer-mode)
      :prompt "Open file"
      :sources (list (make-instance 'file-source
                                    :filter-preprocessor #'supported-media-or-directory-filter)))))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -234,7 +234,7 @@ Return the short error message and the full error message as second value."
                         (uiop:getcwd)))
    :sources
    ;; TODO: Load several files at once? `file-source' allows that.
-   (make-instance 'file-source
+   (make-instance 'user-file-source
                   :actions (list (make-command load-file* (files)
                                    (dolist (file files)
                                      (load-lisp file)))))))


### PR DESCRIPTION
Finally, a `find-file` in Nyxt xD

# What's New
- `download-mode` manages files no more.
- `file-mode` to store all the settings (`find-file-function`, `find-file-in-new-buffer`, `supported-media-types`).
- `find-file` command (and underlying `default-find-file-function`).

# Things to Discuss
- I don't like things being over-entangled with `file-mode`.
  - Consequently, maybe we move mode slots to `*browser*` to make it reliant on global state?
    - Doesn't sound like a solution, though.
- @Ambrevar, how does one get the last `prompt-buffer` in it's own actions? I.e., how do I get the access to the current prompt inside `:actions` of it?
``` lisp
(prompt
     :input (namestring default-directory)
     :prompt "Open file"
     :sources (list (make-instance
                     'file-source
                     :actions (list (make-command open* (files)
                                      (dolist (file files)
                                        (funcall
                                         (find-file-function
                                          (find-submode
                                           ;; This does not work, as the current prompt-buffer is not yet there
                                           ;; Neither it is in active buffers 0_o
                                           (first (old-prompt-buffers *browser*)) 'file-mode))
                                         file))))
                     :filter-preprocessor #'supported-media-or-directory-filter)))
```

DOES NOT YET WORK for the reason above.

How does this look to you?