### PR TITLE
Make modes rememberable.

### DIFF
--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -7,6 +7,7 @@
   "Bind general-purpose commands defined by `define-command'.
 This mode is a good candidate to be passed to `make-buffer'."
   ((visible-in-status-p nil)
+   (rememberable-p nil)
    (keymap-scheme (define-scheme "base"
                     scheme:cua
                     (list

--- a/source/buffer-listing-mode.lisp
+++ b/source/buffer-listing-mode.lisp
@@ -8,7 +8,7 @@
 
 (define-mode buffer-listing-mode ()
   "Mode for buffer-listing."
-  ())
+  ((rememberable-p nil)))
 
 (define-command nyxt::list-buffers (&key (cluster nil))
   "Show the *Buffers* buffer."

--- a/source/diff-mode.lisp
+++ b/source/diff-mode.lisp
@@ -5,7 +5,8 @@
 
 (define-mode diff-mode ()
   "Diff mode is used to view the diffs between two buffers."
-  ((buffer (error "Please supply a buffer.")
+  ((rememberable-p nil)
+   (buffer (error "Please supply a buffer.")
            :documentation "The buffer where the diff will be displayed.")
    (old-html :documentation "String html representation.")
    (new-html :documentation "String html representation.")

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -92,7 +92,8 @@ appearance in the buffer when they are setf'd."
 ;; TODO: Move to separate package
 (define-mode download-mode ()
   "Display list of downloads."
-  ((open-file-function #'default-open-file-function)
+  ((rememberable-p nil)
+   (open-file-function #'default-open-file-function)
    (style
     (cl-css:css
      '((".download"

--- a/source/help-mode.lisp
+++ b/source/help-mode.lisp
@@ -9,4 +9,4 @@
 
 (define-mode help-mode ()
   "Mode for displaying documentation."
-  ())
+  ((rememberable-p nil)))

--- a/source/history-tree-mode.lisp
+++ b/source/history-tree-mode.lisp
@@ -8,7 +8,8 @@
 
 (define-mode history-tree-mode ()
   "Mode for history-tree listing."
-  ((display-buffer-id-glyphs-p t
+  ((rememberable-p nil)
+   (display-buffer-id-glyphs-p t
                                :documentation "Whether to show unique glyphs
 matching buffer `id's along with buffer history entries.")
    (style

--- a/source/list-history-mode.lisp
+++ b/source/list-history-mode.lisp
@@ -8,4 +8,4 @@
 
 (define-mode list-history-mode ()
   "Mode for listing history."
-  ())
+  ((rememberable-p nil)))

--- a/source/message-mode.lisp
+++ b/source/message-mode.lisp
@@ -8,7 +8,7 @@
 
 (define-mode message-mode ()
   "Mode for log and message listing."
-  ())
+  ((rememberable-p nil)))
 
 (define-command clear-messages ()
   "Clear the *Messages* buffer."

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -108,6 +108,8 @@ Example:
    (visible-in-status-p
     t
     :documentation "Whether the mode is visible in the status line.")
+   (rememberable-p t
+                   :documentation "Whether this mode is visible to `auto-mode'.")
    (activate :accessor activate :initarg :activate) ; TODO: This can be used in the future to temporarily turn off modes without destroying the object.
    (constructor nil ; TODO: Make constructor / destructor methods?  Then we can use initialize-instance, etc.
                 :type (or function null)

--- a/source/plaintext-editor-mode.lisp
+++ b/source/plaintext-editor-mode.lisp
@@ -5,7 +5,8 @@
 
 (define-mode plaintext-editor-mode (editor-mode)
   "Mode for basic plaintext editing."
-  ((style (cl-css:css
+  ((rememberable-p nil)
+   (style (cl-css:css
            '(("body"
               :margin 0)
              ("#editor"

--- a/source/repl-mode.lisp
+++ b/source/repl-mode.lisp
@@ -5,7 +5,8 @@
 
 (define-mode repl-mode ()
   "Mode for interacting with the REPL."
-  ((keymap-scheme
+  ((rememberable-p nil)
+   (keymap-scheme
     (define-scheme "repl"
       scheme:cua
       (list

--- a/source/visual-mode.lisp
+++ b/source/visual-mode.lisp
@@ -9,7 +9,8 @@
 
 (define-mode visual-mode ()
   "Visual mode. For documentation on commands and keybindings, see the manual."
-  ((keymap-scheme
+  ((rememberable-p nil)
+   (keymap-scheme
     (define-scheme "visual"
       scheme:cua
       (list

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -19,7 +19,8 @@
 
 (define-mode web-mode ()
   "Base mode for interacting with documents."
-  ((history-blocklist '("https://duckduckgo.com/l/")
+  ((rememberable-p nil)
+   (history-blocklist '("https://duckduckgo.com/l/")
                       ;; TODO: Find a more automated way to do it.  WebKitGTK
                       ;; automatically removes such redirections from its
                       ;; history.  How?


### PR DESCRIPTION
This adds `rememberable-p` slot to `root-mode` and (all) the inheriting
modes. It's set to nil for those modes that we don't want to be
remembered by `auto-mode`, like `internal-buffer`-styling modes or
one-shot modes, like `visual-mode` or `expedition-mode`.

# Things To Discuss
This, however, shifts some of the responsibilities of `auto-mode` back
to modes, instead of universal `mode-invocation`s. Should it be that
way? I'm not sure.

# How Has This Been Tested
- Nyxt compiles and runs with this. Haven't tested all the non-rememberable modes, though.

How does that look?