### PR TITLE
Remove must-match-p

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -15,9 +15,6 @@
 ;; TODO: Performance: Consider computing the attribute values only when active.
 ;; Lazy evaluation would make it easy.
 
-(deftype must-match-choices ()
-  `(member :always :ignore :confirm))
-
 (deftype function-symbol ()
   `(and symbol (satisfies fboundp)))
 
@@ -350,14 +347,6 @@ Also see `follow-delay'.")
                  "Execute `persistent-action' after this delay when `follow-p' is
 non-nil.")
 
-   (must-match-p :always ; TODO: Remove and use dedicated source instead?  Then remove `return-input'.
-                 :type (or must-match-choices boolean) ; TODO: Should not allow T, should we?  Anyways, we can probably remove this slot.
-                 :documentation
-                 "Control what to do when input does not match anything.
-- `:always': Reject input.
-- `:confirm': Prompt before accepting the input.
-- `:ignore': Exit and do nothing.")
-
    (keymap nil
            :type (or null keymap:keymap)
            :documentation
@@ -456,10 +445,6 @@ call."))
          (calispel:! wait-channel t))))
     ;; Wait until above thread has acquired the `initial-suggestions-lock'.
     (calispel:? wait-channel))
-  (unless (filter source)
-    ;; If we have no filter, then we have no suggestions beside
-    ;; immediate input, so we must allow them as valid suggestion.
-    (setf (must-match-p source) nil))
   source)
 
 (export-always 'attributes-keys-non-default)

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -351,9 +351,7 @@ If there is no marks, the current selection value is returned as a list of one e
 For instance, if the selected element value is NIL, this returns '(NIL).
 If there is no element, NIL is returned."
   (or (all-marks prompter)
-      (mapcar #'value (uiop:ensure-list (selected-suggestion prompter)))
-      (and (not (must-match-p (selected-source prompter))) ; TODO: Remove when we remove `must-match-p'.
-           (slot-value prompter 'input))))
+      (mapcar #'value (uiop:ensure-list (selected-suggestion prompter)))))
 
 (export-always 'actions)
 (defun actions (prompter)

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -388,13 +388,6 @@ instead."
       (calispel:! (result-channel prompter) action-result))
     (calispel:! (interrupt-channel prompter) t)))
 
-(export-always 'return-input)
-(defun return-input (prompter)
-  "Send input to PROMPTER's `result-channel'."
-  (setf (returned-p prompter) t)
-  (add-input-to-history prompter)
-  (calispel:! (result-channel prompter) (input prompter)))
-
 (export-always 'toggle-follow)
 (defun toggle-follow (prompter &optional (source (selected-source prompter)))
   "Toggle `follow-p' in SOURCE."

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -952,7 +952,6 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
                            (history-initial-suggestions)))
    (prompter:filter-preprocessor nil)   ; Don't remove non-exact results.
    (prompter:multi-selection-p t)       ; TODO: Disable once tested OK.
-   (prompter:must-match-p nil)
    (prompter:actions '(buffer-load)))
   (:export-class-name-p t))
 

--- a/source/command-commands.lisp
+++ b/source/command-commands.lisp
@@ -47,7 +47,6 @@
 
 (define-class command-source (prompter:source)
   ((prompter:name "Commands")
-   (prompter:must-match-p t)
    (prompter:constructor (get-commands)))
   (:export-class-name-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))
@@ -122,12 +121,10 @@ keyword parameters."
 
 (define-class hook-source (prompter:source)
   ((prompter:name "Hooks")
-   (prompter:must-match-p t)
    (prompter:constructor (get-hooks))))
 
 (define-class handler-source (prompter:source)
   ((prompter:name "Handlers")
-   (prompter:must-match-p t)
    (hook :accessor hook
          :initarg :hook
          :documentation "The hook for which to retrieve handlers for.")

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -382,7 +382,6 @@ you use this macro! For a modification-safe macro, see `with-data-access'."
 
 (define-class gpg-key-source (prompter:source)
   ((prompter:name "GPG Private Keys")
-   (prompter:must-match-p nil)
    (prompter:constructor (gpg-private-keys))))
 
 (defmethod prompter:object-attributes ((gpg-key gpg-key))

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -171,8 +171,7 @@ download."
   (download (current-buffer) (url (current-buffer))))
 
 (define-class downloaded-files-source (file-source)
-  ((prompter:must-match-p t)
-   (prompter:constructor (mapcar #'destination-path (downloads *browser*)))
+  ((prompter:constructor (mapcar #'destination-path (downloads *browser*)))
    ;; TODO: Extract to `file-source'?
    ;; TODO: Maybe extract `open-file-function' to `browser'?
    (prompter:actions

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -172,7 +172,6 @@ identifier for every hinted element."
 
 (define-class hint-source (prompter:source)
   ((prompter:name "Hints")
-   (prompter:must-match-p t)
    (prompter:follow-p t)
    (prompter:persistent-action (lambda (suggestion)
                                  (highlight-selected-hint :link-hint suggestion)))))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -5,25 +5,21 @@
 
 (define-class function-source (prompter:source)
   ((prompter:name "Functions")
-   (prompter:must-match-p t)
    (prompter:constructor (package-functions))
    (prompter:actions (list (make-unmapped-command describe-function)))))
 
 (define-class class-source (prompter:source)
   ((prompter:name "Classes")
-   (prompter:must-match-p t)
    (prompter:constructor (package-classes))
    (prompter:actions (list (make-unmapped-command describe-class)))))
 
 (define-class slot-source (prompter:source)
   ((prompter:name "Slots")
-   (prompter:must-match-p t)
    (prompter:constructor (package-slots))
    (prompter:actions (list (make-unmapped-command describe-slot)))))
 
 (define-class variable-source (prompter:source)
   ((prompter:name "Variables")
-   (prompter:must-match-p t)
    (prompter:constructor (package-variables))
    (prompter:actions (list (make-unmapped-command describe-variable)))))
 

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -163,7 +163,6 @@ lot."
 (define-class history-disowned-source (prompter:source)
   ((prompter:name "Disowned History")
    (buffer :accessor buffer :initarg :buffer)
-   (prompter:must-match-p t)
    (prompter:multi-selection-p t)
    (prompter:constructor
     (lambda (source)
@@ -430,7 +429,6 @@ We keep this variable as a means to import the old format to the new one.")
 
 (define-class history-name-source (prompter:source)
   ((prompter:name "Histories")
-   (prompter:must-match-p t)
    (prompter:constructor (histories-list))))
 
 (define-command store-history-by-name ()

--- a/source/jump-heading.lisp
+++ b/source/jump-heading.lisp
@@ -46,7 +46,6 @@
 (define-class heading-source (prompter:source)
   ((prompter:name "Headings")
    (buffer :accessor buffer :initarg :buffer)
-   (prompter:must-match-p t)
    (prompter:follow-p t)
    (prompter:persistent-action #'scroll-page-to-heading)
    (prompter:constructor (lambda (source)

--- a/source/lisp-system.lisp
+++ b/source/lisp-system.lisp
@@ -26,7 +26,6 @@
 
 (define-class quicklisp-source (prompter:source)
   ((prompter:name "Quicklisp systems")
-   (prompter:must-match-p t)
    (prompter:constructor (mapcar #'ql-dist:short-description (ql:system-list)))
    (prompter:actions (list (make-command quickload* (systems)
                              (ql:quickload (first systems)))))))

--- a/source/os-package-manager-mode.lisp
+++ b/source/os-package-manager-mode.lisp
@@ -103,24 +103,20 @@
 
 (define-class os-package-source (prompter:source)
   ((prompter:name "Packages")
-   (prompter:must-match-p t)
    (prompter:multi-selection-p t)
    (prompter:constructor (ospm:list-packages))
    (prompter:active-attributes-keys '("Name" "Version" "Synopsis"))))
 
 (define-class os-manifest-source (prompter:source)
   ((prompter:name "Manifests")
-   (prompter:must-match-p t)
    (prompter:constructor (mapcar #'namestring (ospm:list-manifests)))))
 
 (define-class os-package-output-source (prompter:source)
   ((prompter:name "Package Outputs")
-   (prompter:must-match-p t)
    (prompter:constructor (ospm:list-package-outputs))))
 
 (define-class os-installed-package-source (prompter:source)
   ((prompter:name "Installed Packages")
-   (prompter:must-match-p t)
    (profile)
    (prompter:constructor
     (lambda (source)
@@ -129,7 +125,6 @@
 
 (define-class os-profile-source (prompter:source)
   ((prompter:name "Profiles")
-   (prompter:must-match-p t)
    (include-manager-p)
    (prompter:constructor
     (lambda (source) (ospm:list-profiles
@@ -138,7 +133,6 @@
 
 (define-class os-generation-source (prompter:source)
   ((prompter:name "Packages")
-   (prompter:must-match-p t)
    (profile)
    (prompter:constructor
     (lambda (source) 

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -25,7 +25,6 @@ for which the `executable' slot is non-nil."
   ((prompter:name "Passwords")
    (buffer :accessor buffer :initarg :buffer)
    (password-instance :accessor password-instance :initarg :password-instance)
-   (prompter:must-match-p t)
    (prompter:constructor
     (lambda (source)
       (password:list-passwords (password-instance source))))))

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -37,10 +37,10 @@ Actions can be listed and run with `return-selection-over-action' (bound to
        "M-[" 'select-previous-source
        "tab" 'prompt-buffer-insert-selection
        "return" 'return-selection
-       "C-return" 'return-input         ; TODO: Bind to shift-return instead?
-       "M-return" 'return-selection-over-action       ; TODO: Also bind to C-return?
-       "C-j" 'run-persistent-action
-       "C-g" 'cancel-input
+       "M-return" 'return-selection-over-action
+       "C-return" 'run-persistent-action
+       "C-j" 'run-persistent-action     ; Emacs binding.
+       "C-g" 'cancel-input              ; Emacs binding.
        "f1 b" 'run-prompt-buffer-command
        "f1 m" 'describe-prompt-buffer
        "C-h b" 'run-prompt-buffer-command ; TODO: Move to Emacs bindings.
@@ -146,11 +146,6 @@ If STEPS is negative, go to next pages instead."
   (hide-prompt-buffer prompt-buffer
                       (lambda ()
                         (prompter:return-selection prompt-buffer))))
-
-(define-command return-input (&optional (prompt-buffer (current-prompt-buffer))) ; TODO: Remove if we remove `must-match-p'?
-  "Have the PROMT-BUFFER return the selection, then quit."
-  (hide-prompt-buffer prompt-buffer
-                      (lambda () (prompter:return-input prompt-buffer))))
 
 (defun make-attribute-suggestion (attribute source &optional input)
   "Return a `suggestion' wrapping around ATTRIBUTE. "

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -185,7 +185,6 @@ If STEPS is negative, go to next pages instead."
 (define-class prompt-buffer-command-source (prompter:source)
   ((prompter:name "List of prompt buffer commands")
    (parent-prompt-buffer (error "Parent prompt buffer required"))
-   (prompter:must-match-p t)
    (prompter:suggestion-maker 'make-prompt-buffer-command-suggestion)
    (prompter:constructor (nyxt::get-commands (current-prompt-buffer))))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -136,11 +136,6 @@ See `prompt' for how to invoke prompts.")))
 
 (defmethod initialize-instance :after ((prompt-buffer prompt-buffer) &key)
   (hooks:run-hook (prompt-buffer-make-hook *browser*) prompt-buffer)
-  ;; We don't want to show the input in the suggestion list when invisible.
-  (when (invisible-input-p prompt-buffer)
-    (dolist (source (prompter:sources prompt-buffer))
-      ;; This way the prompt-buffer won't display the input as a suggestion.
-      (setf (prompter:must-match-p source) t)))
   (initialize-modes prompt-buffer))
 
 (export-always 'current-source)

--- a/source/recent-buffers.lisp
+++ b/source/recent-buffers.lisp
@@ -12,7 +12,6 @@
 
 (define-class recent-buffer-source (prompter:source)
   ((prompter:name "Deleted buffers")
-   (prompter:must-match-p t)
    (prompter:multi-selection-p t)
    (prompter:constructor
     (containers:container->list (recent-buffers *browser*)))))

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -148,7 +148,6 @@
    (buffer (current-buffer))
    (minimum-search-length 3)
    (prompter:name "Search buffer")
-   (prompter:must-match-p nil)
    (prompter:follow-p t)
    (prompter:filter nil)
    (prompter:filter-preprocessor

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -65,7 +65,6 @@ bookmarks."
 
 (define-class search-engine-source (prompter:source)
   ((prompter:name "Search Engines")
-   (prompter:must-match-p t)
    (prompter:constructor (search-engines (current-buffer)))))
 
 (define-command search-selection ()

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -63,9 +63,9 @@ matching your input as you type.")
                           :modes (list (make-instance 'nyxt/prompt-buffer-mode:prompt-buffer-mode)))
           ": Validate the selected suggestion(s) or the current input if there is
 no suggestion.")
-    (:li  (command-markup 'nyxt/prompt-buffer-mode:return-input
+    (:li  (command-markup 'nyxt/prompt-buffer-mode:return-selection-over-action
                           :modes (list (make-instance 'nyxt/prompt-buffer-mode:prompt-buffer-mode)))
-          ": Validate the current input, ignoring any suggestion."))
+          ": Query the user for an action to run over the selected suggestion(s)."))
    (:p " Some commands support multiple selections, for
 instance " (:code "delete-buffer") " can delete all selected buffers at once.
 When the input is changed and the suggestions are re-filtered, the selection is

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -257,7 +257,6 @@ and to index the top of the page.")
 (define-class history-backwards-source (prompter:source)
   ((prompter:name "Parent URLs")
    (buffer :initarg :buffer :accessor buffer :initform nil)
-   (prompter:must-match-p t)
    (prompter:constructor
     (lambda (source)
       (with-data-unsafe (history (history-path (buffer source)))
@@ -287,7 +286,6 @@ and to index the top of the page.")
 (define-class direct-history-forwards-source (prompter:source)
   ((prompter:name "Direct child URLs")
    (buffer :initarg :buffer :accessor buffer :initform nil)
-   (prompter:must-match-p t)
    (prompter:constructor
     (lambda (source)
       (with-data-unsafe (history (history-path (buffer source)))
@@ -323,7 +321,6 @@ Otherwise go forward to the only child."
 (define-class history-forwards-source (prompter:source)
   ((prompter:name "Child URLs")
    (buffer :initarg :buffer :accessor buffer :initform nil)
-   (prompter:must-match-p t)
    (prompter:constructor
     (lambda (source)
       (with-data-unsafe (history (history-path (buffer source)))
@@ -348,7 +345,6 @@ Otherwise go forward to the only child."
 (define-class all-history-forwards-source (prompter:source)
   ((prompter:name "Child URLs")
    (buffer :initarg :buffer :accessor buffer :initform nil)
-   (prompter:must-match-p t)
    (prompter:constructor
     (lambda (source)
       (with-data-unsafe (history (history-path (buffer source)))
@@ -372,7 +368,6 @@ Otherwise go forward to the only child."
 (define-class history-all-source (prompter:source)
   ((prompter:name "History URLs")
    (buffer :initarg :buffer :accessor buffer :initform nil)
-   (prompter:must-match-p t)
    (prompter:constructor
     (lambda (source)
       (with-data-unsafe (history (history-path (buffer source)))
@@ -486,7 +481,6 @@ Otherwise go forward to the only child."
 (define-class ring-source (prompter:source)
   ((prompter:name "Clipboard ring")
    (ring :initarg :ring :accessor ring :initform nil)
-   (prompter:must-match-p t)
    (prompter:constructor
     (lambda (source)
       (containers:container->list (ring source))))
@@ -510,7 +504,6 @@ Otherwise go forward to the only child."
 
 (define-class autofill-source (prompter:source)
   ((prompter:name "Autofills")
-   (prompter:must-match-p t)
    (prompter:constructor (autofills *browser*))
    (prompter:actions
     (list (make-command autofill* (autofills)

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -129,7 +129,6 @@ The handlers take the window as argument."))
 
 (define-class window-source (prompter:source)
   ((prompter:name "Windows")
-   (prompter:must-match-p t)
    (prompter:multi-selection-p t)
    (prompter:constructor (window-list))
    (prompter:actions (list (make-mapped-command window-delete)))))


### PR DESCRIPTION
must-match-p was never used and it seems that raw sources do a better job.

With sources like yes/no that must match, there are only two options: either "yes" or "no" is selected, or the prompt is canceled.

In the future, I'd also like to add a prompt-buffer option that displays a message instead of the prompt buffer when there are no suggestions.  This implies that the prompt buffer suggestions are determined synchronously at creation time, so we must add an option for that.  But this is a feature different from "must-match-p".