### PR TITLE
Fix crash on history-forwards-query...

### DIFF
--- a/libraries/history-tree/history-tree.lisp
+++ b/libraries/history-tree/history-tree.lisp
@@ -231,7 +231,7 @@ even be NIL)."))
       parent)))
 
 (export-always 'current-binding)
-(declaim (ftype (function (owner &optional node) (or null binding)) current-binding))
+(declaim (ftype (function (owner &optional (or null node)) (or null binding)) current-binding))
 (defun current-binding (owner &optional (node (current owner)))
   (and node
        (gethash owner (bindings node))))


### PR DESCRIPTION
Starting nyxt and hitting M-l causes a crash with the following
error:

Unhandled TYPE-ERROR in thread #<SB-THREAD:THREAD "Anonymous thread" RUNNING
                                  {1009A98563}>:
  The value
    NIL
  is not of type
    HISTORY-TREE:NODE
  when binding HISTORY-TREE:NODE

Backtrace for: #<SB-THREAD:THREAD "Anonymous thread" RUNNING {1009A98563}>
0: (HISTORY-TREE:CURRENT-BINDING #<HISTORY-TREE:OWNER {10065AFB63}> NIL) [external]
1: ((:METHOD HISTORY-TREE:ALL-FORWARD-CHILDREN (HISTORY-TREE:HISTORY-TREE)) #<HISTORY-TREE:HISTORY-TREE {10065AE6B3}> NIL) [fast-method]
2: ((LAMBDA NIL :IN INITIALIZE-INSTANCE))
3: ((LAMBDA NIL :IN BORDEAUX-THREADS::BINDING-DEFAULT-SPECIALS))
4: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
5: ((FLET "WITHOUT-INTERRUPTS-BODY-11" :IN SB-THREAD::RUN))
6: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
7: ((FLET "WITHOUT-INTERRUPTS-BODY-4" :IN SB-THREAD::RUN))
8: (SB-THREAD::RUN)
9: ("foreign function: call_into_lisp")
10: ("foreign function: funcall1")

Apparently, history-tree:all-forward-children would call
history-tree:current-binding with nil for the second argument, and the declaim
type declaration for the second parameter was set to only be a
history-tree:node, hence the error.

Since the definition is already prepared for it, this commit permits the second
parameter to also be nil.