### PR TITLE
Rename: %slot-default -> %slot-default%

### DIFF
--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -142,7 +142,7 @@ Example:
   ((nyxt/blocker-mode:hostlists (list *my-blocked-hosts* nyxt/blocker-mode:*default-hostlist*))))
 
 \(define-configuration buffer
-  ((default-modes (append '(my-blocker-mode) %slot-default))))"
+  ((default-modes (append '(my-blocker-mode) %slot-default%))))"
   ((hostlists (list *default-hostlist*))
    (destructor
     (lambda (mode)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -486,7 +486,7 @@ The following example does a few things:
                                              (uiop:launch-program
                                               `(\"emacs\" ,(quri:uri-path url)))
                                              nil)))
-                                    :initial-value %slot-default))))"
+                                    :initial-value %slot-default%))))"
   (make-handler-resource
    #'(lambda (request-data)
        (let ((url (url request-data)))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -136,7 +136,7 @@ Example:
   ((request-resource-hook
     (reduce #'hooks:add-hook
             (mapcar #'make-handler-resource (list #'old-reddit-handler #'auto-proxy-handler))
-            :initial-value %slot-default))))")
+            :initial-value %slot-default%))))")
    (default-new-buffer-url (quri:uri "https://nyxt.atlas.engineer/start")
                            :documentation "The URL set to a new blank buffer opened by Nyxt.")
    (scroll-distance 50

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -93,7 +93,7 @@ CLASS-SYM to NEW-SUPERCLASSES.  The class is restored when exiting BODY."
               ,@body)
          (define-user-class ,class-sym ,old-superclasses)))))
 
-(export-always '%slot-default)
+(export-always '%slot-default%)
 (defmacro %define-configuration (name &body slots)
   (let* ((final-name (user-class-name name))
          (temp-name (gentemp (string final-name) (symbol-package name))))
@@ -110,8 +110,8 @@ CLASS-SYM to NEW-SUPERCLASSES.  The class is restored when exiting BODY."
                                           :initform))
                 if known-slot?
                   collect (list (first slot)
-                                :initform `(funcall (lambda (%slot-default)
-                                                      (declare (ignorable %slot-default))
+                                :initform `(funcall (lambda (%slot-default%)
+                                                      (declare (ignorable %slot-default%))
                                                       ,(cadr slot))
                                                     ,initform))
                 else do
@@ -133,20 +133,20 @@ Classes can be modes or a one of the user-configurable classes like `browser',
 `buffer', `prompt-buffer', `window'.  Note that the classes must _not_ be prefixed
 by 'user-'.
 
-The `%slot-default' variable is replaced by the slot initform.
+The `%slot-default%' variable is replaced by the slot initform.
 
 Example that sets some defaults for all buffers:
 
 \(define-configuration (buffer web-buffer)
   ((status-buffer-height 24)
-   (default-modes (append '(vi-normal-mode) %slot-default))))
+   (default-modes (append '(vi-normal-mode) %slot-default%))))
 
 Example to get the `blocker-mode' command to use a new default hostlists:
 
 \(define-configuration nyxt/blocker-mode:blocker-mode
-  ((nyxt/blocker-mode:hostlists (append (list *my-blocked-hosts*) %slot-default))))
+  ((nyxt/blocker-mode:hostlists (append (list *my-blocked-hosts*) %slot-default%))))
 
-In the above, `%slot-default' will be substituted with the default value of
+In the above, `%slot-default%' will be substituted with the default value of
 `default-modes'.
 
 In the last example, `nyxt/blocker-mode:user-blocker-mode' is defined to inherit

--- a/source/emacs-mode.lisp
+++ b/source/emacs-mode.lisp
@@ -15,7 +15,7 @@ in your configuration file.
 Example:
 
 \(define-configuration buffer
-  ((default-modes (append '(emacs-mode) %slot-default))))"
+  ((default-modes (append '(emacs-mode) %slot-default%))))"
   ((glyph "ε")
    (previous-keymap-scheme-name nil
     :type (or keymap:scheme-name null)

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -64,7 +64,7 @@ To permanently bypass the \"Unacceptable TLS Certificate\" error:
 Example:
 
 \(define-configuration buffer
-  ((default-modes (append '(force-https-mode) %slot-default))))"
+  ((default-modes (append '(force-https-mode) %slot-default%))))"
   ((previous-url (quri:uri ""))
    (destructor
     (lambda (mode)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -264,7 +264,7 @@ CLASS can be a class symbol or a list of class symbols, as with
              :href (lisp-url `(nyxt::configure-slot
                                'default-modes
                                '(buffer web-buffer)
-                               :value '%slot-default)
+                               :value '%slot-default%)
                              `(nyxt/emacs-mode:emacs-mode :activate nil)
                              `(nyxt/vi-mode:vi-normal-mode :activate nil))
              "Use default (CUA)"))
@@ -272,7 +272,7 @@ CLASS can be a class symbol or a list of class symbols, as with
              :href (lisp-url `(nyxt::configure-slot
                                'default-modes
                                '(buffer web-buffer)
-                               :value '(append '(emacs-mode) %slot-default))
+                               :value '(append '(emacs-mode) %slot-default%))
                              `(nyxt/emacs-mode:emacs-mode :activate t)
                              `(nyxt/vi-mode:vi-normal-mode :activate nil))
              "Use Emacs"))
@@ -280,7 +280,7 @@ CLASS can be a class symbol or a list of class symbols, as with
              :href (lisp-url `(nyxt::configure-slot
                                'default-modes
                                '(buffer web-buffer)
-                               :value '(append '(vi-normal-mode) %slot-default))
+                               :value '(append '(vi-normal-mode) %slot-default%))
                              `(nyxt/vi-mode:vi-normal-mode :activate t)
                              `(nyxt/emacs-mode:emacs-mode :activate nil))
              "Use vi"))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -38,7 +38,7 @@ necessary).")
     (:p "Example:")
     (:pre (:code "
 \(define-configuration buffer
-  ((default-modes (append '(noscript-mode) %slot-default))))"))
+  ((default-modes (append '(noscript-mode) %slot-default%))))"))
     (:p "The above turns on the 'noscript-mode' (disables JavaScript) by default for
 every buffer.")
     (:p "The " (:code "define-configuration") " macro can be used to customize
@@ -67,11 +67,11 @@ add the following to your configuration:")
      (:li "VI bindings:"
       (:pre (:code "
 \(define-configuration (buffer web-buffer)
-  ((default-modes (append '(vi-normal-mode) %slot-default))))")))
+  ((default-modes (append '(vi-normal-mode) %slot-default%))))")))
      (:li "Emacs bindings:"
       (:pre (:code "
 \(define-configuration (buffer web-buffer)
-  ((default-modes (append '(emacs-mode) %slot-default))))"))))
+  ((default-modes (append '(emacs-mode) %slot-default%))))"))))
     (:p "You can create new scheme names with " (:code "keymap:make-scheme-name")
         ".  See also the " (:code "scheme-name") " class and the "
         (:code "define-scheme") " macro.")
@@ -100,7 +100,7 @@ have priorities over the other modes key bindings.")
                    scheme:vi-normal *my-keymap*))))
 
 \(define-configuration (buffer web-buffer)
-  ((default-modes (append '(my-mode) %slot-default))))"))
+  ((default-modes (append '(my-mode) %slot-default%))))"))
 
     (:h3 "Search engines")
     (:p "See the " (:code "search-engines") " buffer slot documentation.
@@ -169,7 +169,7 @@ can set a hook like the following in your configuration file:")
 
 \(define-configuration web-buffer
   ((request-resource-hook
-    (add-hook %slot-default (make-handler-resource #'old-reddit-handler)))))"))
+    (add-hook %slot-default% (make-handler-resource #'old-reddit-handler)))))"))
     (:p "(See " (:code "url-dispatching-handler")
         " for a simpler way to achieve the same result.)")
     (:p "Or, if you want to set multiple handlers at once,")
@@ -179,7 +179,7 @@ can set a hook like the following in your configuration file:")
     (reduce #'hooks:add-hook
             (mapcar #'make-handler-resource (list #'old-reddit-handler
                                                   #'my-other-handler))
-            :initial-value %slot-default))))"))
+            :initial-value %slot-default%))))"))
     (:p "Some hooks like the above example expect a return value, so it's
 important to make sure we return " (:code "request-data") " here.  See the
 documentation of the respective hooks for more details.")

--- a/source/proxy-mode.lisp
+++ b/source/proxy-mode.lisp
@@ -20,7 +20,7 @@ Example to use Tor as a proxy both for browsing and downloading:
                                          :proxied-downloads-p t))))
 
 \(define-configuration buffer
-  ((default-modes (append '(proxy-mode) %slot-default))))"
+  ((default-modes (append '(proxy-mode) %slot-default%))))"
   ((proxy (make-instance 'proxy
                  :server-address (quri:uri "socks5://localhost:9050")
                  :allowlist '("localhost" "localhost:8080")

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -15,7 +15,7 @@ in your configuration file.
 Example:
 
 \(define-configuration buffer
-  ((default-modes (append '(vi-normal-mode) %slot-default))))"
+  ((default-modes (append '(vi-normal-mode) %slot-default%))))"
   ((previous-keymap-scheme-name nil
     :type (or keymap:scheme-name null)
     :documentation "The previous keymap scheme that will be used when ending


### PR DESCRIPTION
%xyz% is for special local variables

for some reason, this does not work, I do not believe to have missed any instances. Any idea why?