### PR TITLE
Add element-hint-mode package.

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -142,6 +142,7 @@
                (:file "bookmarklets")
                (:file "input-edit")
                (:file "element-hint")
+               (:file "element-hint-mode")
                (:file "jump-heading")
                (:file "scroll")
                (:file "search-buffer")

--- a/source/element-hint-mode.lisp
+++ b/source/element-hint-mode.lisp
@@ -1,0 +1,30 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package :nyxt/element-hint-mode
+  (:use :common-lisp :nyxt)
+  (:import-from #:keymap #:define-key #:define-scheme)
+  (:documentation "Mode for element hint prompt buffer"))
+(in-package :nyxt/element-hint-mode)
+
+(define-command toggle-hints-transparency (&key (buffer (current-buffer)))
+  "Toggle the on-screen element hints transparency."
+  (pflet ((toggle-transparent ()
+            (defun qsa (context selector)
+              "Alias of document.querySelectorAll"
+              (ps:chain context (query-selector-all selector)))
+            (ps:dolist (element (qsa document ".nyxt-hint"))
+              (if (or (= (ps:chain element style opacity) "1")
+                      (= (ps:chain element style opacity) ""))
+                  (setf (ps:chain element style opacity) "0.2")
+                  (setf (ps:chain element style opacity) "1.0")))))
+    (with-current-buffer buffer
+      (toggle-transparent))))
+
+(define-mode element-hint-mode (nyxt/prompt-buffer-mode:prompt-buffer-mode)
+  "Prompt buffer mode for element hinting."
+  ((keymap-scheme
+    (define-scheme "element-hint"
+      scheme:cua
+      (list
+       "M-i" 'toggle-hints-transparency)))))

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -176,14 +176,6 @@ identifier for every hinted element."
    (prompter:persistent-action (lambda (suggestion)
                                  (highlight-selected-hint :link-hint suggestion)))))
 
-(define-mode nyxt/prompt-buffer-mode::element-hint-mode (nyxt/prompt-buffer-mode:prompt-buffer-mode)
-  "Prompt buffer mode for element hinting."
-  ((keymap-scheme
-    (define-scheme "element-hint"
-      scheme:cua
-      (list
-       "M-i" 'toggle-hints-transparency)))))
-
 (serapeum:export-always 'query-hints)
 (defun query-hints (prompt function &key multi-selection-p annotate-visible-only-p)
   (let* ((buffer (current-buffer)))
@@ -423,17 +415,3 @@ visible nosave active buffer."
                             (sleep 0.25)))
                  :multi-selection-p t
                  :annotate-visible-only-p annotate-visible-only-p)))
-
-(define-command toggle-hints-transparency (&key (buffer (current-buffer)))
-  "Toggle the on-screen element hints transparency."
-  (pflet ((toggle-transparent ()
-            (defun qsa (context selector)
-              "Alias of document.querySelectorAll"
-              (ps:chain context (query-selector-all selector)))
-            (ps:dolist (element (qsa document ".nyxt-hint"))
-              (if (or (= (ps:chain element style opacity) "1")
-                      (= (ps:chain element style opacity) ""))
-                  (setf (ps:chain element style opacity) "0.2")
-                  (setf (ps:chain element style opacity) "1.0")))))
-    (with-current-buffer buffer
-      (toggle-transparent))))


### PR DESCRIPTION
Indeed, toggle-hints-transparency belongs to this mode and thus the package.
Without this, "f1 b" in the prompt buffer would fail to list toggle-hints-transparency.