### PR TITLE
libraries/prompter: Remove unused keymap support from the prompter li…

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -380,11 +380,6 @@ Also see `follow-delay'.")
                  "Execute `persistent-action' after this delay when `follow-p' is
 non-nil.")
 
-   (keymap nil
-           :type (or null keymap:keymap)
-           :documentation
-           "Keymap specific to this source.")
-
    (help-message ""                   ; TODO: Use.
                  :type (or string function)
                  :documentation

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -82,13 +82,6 @@ Note that the function is executed *before* performing an action.")
               "History of inputs for the prompter.
 If nil, no history is used.")
 
-     (keymap nil
-             :type (or null keymap:keymap)
-             :documentation
-             "Keymap for the prompter.
-Useful, say, to switch source.
-It takes precedence over individual source keymaps.")
-
      (help-message ""                   ; TODO: Use.
                    :type (or string function)
                    :documentation

--- a/libraries/prompter/readme.org
+++ b/libraries/prompter/readme.org
@@ -13,7 +13,6 @@ Non-exhaustive list of features:
 - Customizable initialization and cleanup functions.
 - Notifications sent when suggestion list is updated.
 - Per-source history.
-- Per-source keymaps.
 - Resumable prompters.
 - Persistent action (executed without closing the prompter).
 - Follow-mode (automatically run the persistent action on selection change).

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -514,7 +514,6 @@
                serapeum
                str
                trivial-package-local-nicknames
-               nyxt/keymap
                nyxt/class-star)
   :pathname "libraries/prompter/"
   :components ((:file "package")


### PR DESCRIPTION
…brary.

Nyxt uses its own mode-associated keymaps.

This is a trivial pull request but I'm opening it to start a discussion: should prompters support keymaps?
Can anyone see some use to it?