### PR TITLE
libraries/prompter: Fix behaviour with case sensitivity.

### DIFF
--- a/libraries/prompter/filter-preprocessor.lisp
+++ b/libraries/prompter/filter-preprocessor.lisp
@@ -28,11 +28,12 @@ If any input substring matches exactly (but not necessarily a whole word),
 then all suggestions that are not exactly matched by at least one substring are removed.
 
 Suitable as a `source' `filter-preprocessor'."
-  (declare (ignore source))
   (unless (str:empty? input)
     (let ((exactly-matching-substrings (find-exactly-matching-substrings
                                         input
-                                        (mapcar #'match-data suggestions))))
+                                        (mapcar (lambda (suggestion)
+                                                  (ensure-match-data-string suggestion source))
+                                                suggestions))))
       (when exactly-matching-substrings
         (setf suggestions
               (delete-if (lambda (suggestion)
@@ -44,11 +45,10 @@ Suitable as a `source' `filter-preprocessor'."
 (export-always 'filter-exact-matches)
 (defun filter-exact-matches (suggestions source input)
   "Return only SUGGESTIONS that match all the words in INPUT."
-  (declare (ignore source))
   (if (str:empty? input)
       suggestions
       (let ((words (sera:words input)))
         (delete-if (lambda (suggestion)
-                     (notevery (lambda (sub) (search sub (match-data suggestion)))
+                     (notevery (lambda (sub) (search sub (ensure-match-data-string suggestion source)))
                                words))
                    suggestions))))

--- a/libraries/prompter/filter.lisp
+++ b/libraries/prompter/filter.lisp
@@ -36,12 +36,6 @@ Only substrings of SUBSTRING-LENGTH characters or more are considered."
            (length long-substrings))
         0)))
 
-(defun to-unicode (input)
-  "Convert INPUT to (simple-array character) type."
-  (if (typep input 'base-string)
-      (coerce input `(simple-array character (,(length input))))
-      input))
-
 (defun score-suggestion-string (input suggestion-string)
   "Return a SUGGESTION's score for INPUT.
 A higher score means the suggestion-string comes first."
@@ -61,16 +55,14 @@ A higher score means the suggestion-string comes first."
      (score suggestion2)))
 
 (export-always 'fuzzy-match)
-(defun fuzzy-match (input suggestion)
+(defun fuzzy-match (suggestion source input)
   "Score the SUGGESTION according to a fuzzy string distance to the INPUT."
-  (setf input (to-unicode input))
-  (setf (match-data suggestion) (to-unicode (match-data suggestion)))
   (setf (score suggestion)
-        (score-suggestion-string input (match-data suggestion)))
+        (score-suggestion-string input (ensure-match-data-string suggestion source)))
   suggestion)
 
 (export-always 'submatches)
-(defun submatches (input suggestion)      ; TODO: Add tests!
+(defun submatches (suggestion source input)      ; TODO: Add tests!
   "Return SUGGESTION untouched if all INPUT strings are contained in it.
 
 This is suitable as a prompter `filter'.
@@ -84,5 +76,5 @@ It probably makes little sense to use it together with the
                             (lambda (suggestion-match-data)
                               (str:contains? term suggestion-match-data :ignore-case t)))
                           terms))
-           (match-data suggestion))
+           (ensure-match-data-string suggestion source))
       suggestion)))

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -87,9 +87,9 @@ inherited or used across different sources)."
 Both the key and the value are strings.")
    (match-data nil
                :type t
-               :writer t
                :documentation "Arbitrary data that can be used by the `filter'
-function and its preprocessors.")
+function and its preprocessors.  It's the responsibility of the filter to ensure
+the match-data is ready for its own use.")
    (score 0.0
           :documentation "A score the can be set by the `filter' function and
 used by the `sort-predicate'."))
@@ -150,41 +150,49 @@ Suggestions are made with the `suggestion-maker' slot from `source'."))
 suggestions."
   (sera:string-join (attributes-values attributes) " "))
 
-(defmethod initialize-instance :after ((suggestion suggestion) &key source input)
-  "Set SUGGESTION `match-data' if empty and if SOURCE and INPUT initargs are provided.
-`match-data' is set by concatenating all the active attributes into a
-space-separated string.
-The `match-data' is downcased if INPUT is lower-case."
+(defmethod initialize-instance :after ((suggestion suggestion) &key)
+  "Check validity."
   (unless (object-attributes-p (attributes suggestion))
     (warn "Attributes of ~s should be a non-dotted alist instead of ~s" (value suggestion) (attributes suggestion))
-    (setf (attributes suggestion) (default-object-attributes (value suggestion))))
-  ;; Access directly because reader also has a provision for empty values.
-  (when (uiop:emptyp (slot-value suggestion 'match-data))
-    (setf (match-data suggestion)
-          (funcall
-           (if (or (not input) (str:downcasep input))
-               #'string-downcase
-               #'identity)
-           (format-attributes
-            (if source
-                (active-attributes suggestion :source source)
-                (attributes suggestion)))))))
+    (setf (attributes suggestion) (default-object-attributes (value suggestion)))))
 
-(defmethod match-data ((suggestion suggestion))
-  (alex:if-let ((value (slot-value suggestion 'match-data)))
-    value
+(defun ensure-non-base-string (s)
+  "Convert S to (simple-array character) type."
+  (if (typep s 'base-string)
+      ;; REVIEW: Maybe simpler to coerce to 'string?
+      (coerce s `(simple-array character (,(length s))))
+      s))
+
+(defun ensure-match-data-string (suggestion source)
+  "Return SUGGESTION's `match-data' as a string.
+If unset, set it to the return value of `format-attributes'."
+  (flet ((maybe-downcase (s)
+           (if (current-input-downcase-p source)
+               (string-downcase s)
+               s)))
     (setf (match-data suggestion)
-          (string-downcase (format-attributes (attributes suggestion))))))
+          (if (and (match-data suggestion)
+                   (typep (match-data suggestion) 'string)
+                   ;; mk-string-metrics requires the (simple-array character)
+                   ;; type, but 'string should be enough.  See
+                   ;; `mk-string-metrics:damerau-levenshtein'.
+                   (not (typep (match-data suggestion) 'base-string)))
+              (if (not (eq (last-input-downcase-p source)
+                           (current-input-downcase-p source)))
+                  (maybe-downcase (match-data suggestion))
+                  (match-data suggestion))
+              (let ((result (ensure-non-base-string
+                             (format-attributes (attributes suggestion)))))
+                (maybe-downcase result)))))
+  (match-data suggestion))
 
 (export-always 'make-suggestion)
-(defmethod make-suggestion ((value t) source &optional input)
+(defmethod make-suggestion ((value t))
   "Return a `suggestion' wrapping around VALUE.
 Attributes are set with `object-attributes'."
   (make-instance 'suggestion
                  :value value
-                 :attributes (object-attributes value)
-                 :source source
-                 :input input))
+                 :attributes (object-attributes value)))
 
 (define-class source ()
   ((name (error "Source must have a name")
@@ -265,8 +273,8 @@ Called on
    (filter #'fuzzy-match
            :type (or null function function-symbol)
            :documentation
-           "Takes `input' and a `suggestion' and return a new suggestion, or
-nil if the suggestion is discarded.")
+           "Takes a `suggestion', the `source' and the `input' and return a new
+suggestion, or nil if the suggestion is discarded.")
 
    (filter-preprocessor #'delete-inexact-matches
                         :type (or null function function-symbol)
@@ -287,6 +295,18 @@ It is passed the following arguments:
 - the filtered suggestions;
 - the source;
 - the input.")
+
+   (current-input-downcase-p nil
+                             :type boolean
+                             :export nil
+                             :documentation "Whether input is downcased.
+This is useful for filters to avoid recomputing it every time.")
+   (last-input-downcase-p nil
+                             :type boolean
+                             :export nil
+                             :documentation "Whether previous input was
+downcased.  This is useful to know if there is a case difference since last time
+and to know if we have to recompute the match-data for instance.")
 
    (sort-predicate #'score>
                    :type (or null function)
@@ -405,7 +425,7 @@ call."))
 
 (defun make-input-suggestion (suggestions source input)
   (declare (ignore suggestions))
-  (list (funcall (suggestion-maker source) input source)))
+  (list (funcall (suggestion-maker source) input)))
 
 (define-class raw-source (source)
   ((name "Input")
@@ -426,7 +446,7 @@ If you are looking for a source that just returns its plain suggestions, use `so
 (defun make-word-suggestions (suggestions source input)
   (declare (ignore suggestions))
   (mapcar (lambda (word)
-            (funcall (suggestion-maker source) word source))
+            (funcall (suggestion-maker source) word))
           (sera:words input)))
 
 (define-class word-source (source)
@@ -438,15 +458,12 @@ If you are looking for a source that just returns its plain suggestions, use `so
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))
   (:documentation "Prompt source for user input words."))
 
-(defmethod ensure-suggestions-list ((source source) elements
-                                    &key input &allow-other-keys)
+(defmethod ensure-suggestions-list ((source source) elements)
   (mapcar (lambda (suggestion-value)
             (if (suggestion-p suggestion-value)
                 suggestion-value
                 (funcall (suggestion-maker source)
-                         suggestion-value
-                         source
-                         input)))
+                         suggestion-value)))
           (uiop:ensure-list elements)))
 
 (defmethod initialize-instance :after ((source source) &key)
@@ -607,6 +624,7 @@ feedback to the user while the list of suggestions is being computed."
     ;; REVIEW: Is there a cleaner way to do this?
     (ignore-errors (bt:destroy-thread (update-thread source))))
   (setf (ready-channel source) new-ready-channel)
+  (setf input (ensure-non-base-string input))
   (setf (update-thread source)
         (bt:make-thread
          (lambda ()
@@ -622,14 +640,13 @@ feedback to the user while the list of suggestions is being computed."
                         initial-suggestions-copy))
                   (process! (preprocessed-suggestions)
                     (let ((last-notification-time (get-internal-real-time)))
-
                       (setf (slot-value source 'suggestions) '())
                       (if (or (str:empty? input)
                               (not (filter source)))
                           (setf (slot-value source 'suggestions) preprocessed-suggestions)
                           (dolist (suggestion preprocessed-suggestions)
                             (sera:and-let* ((processed-suggestion
-                                             (funcall (filter source) input suggestion)))
+                                             (funcall (filter source) suggestion source input)))
                               (setf (slot-value source 'suggestions)
                                     (insert-item-at suggestion (sort-predicate source)
                                                     (suggestions source)))
@@ -649,9 +666,10 @@ feedback to the user while the list of suggestions is being computed."
                              (maybe-funcall (filter-postprocessor source)
                                             (slot-value source 'suggestions)
                                             source
-                                            input)
-                             :input input)))))
+                                            input))))))
              (wait-for-initial-suggestions)
+             (setf (last-input-downcase-p source) (current-input-downcase-p source))
+             (setf (current-input-downcase-p source) (str:downcasep input))
              (process!
               (preprocess
                ;; We copy the list of initial-suggestions so that the

--- a/libraries/prompter/tests/fuzzy.lisp
+++ b/libraries/prompter/tests/fuzzy.lisp
@@ -37,10 +37,12 @@
 (prove:subtest "Fuzzy match"
   (let ((source (make-instance 'prompter:raw-source)))
     (flet ((match (input list)
+             (setf (prompter::current-input-downcase-p source)
+                   (str:downcasep input))
              (prompter:value
               (first (sort (mapcar (lambda (suggestion)
-                                     (prompter:fuzzy-match input suggestion))
-                                   (prompter::ensure-suggestions-list source list :input input))
+                                     (prompter:fuzzy-match suggestion source input))
+                                   (prompter::ensure-suggestions-list source list))
                            #'prompter:score>)))))
       (prove:is (match "hel" '("help-mode" "help" "foo-help" "help-foo-bar"))
           "help")

--- a/libraries/prompter/tests/tests.lisp
+++ b/libraries/prompter/tests/tests.lisp
@@ -79,8 +79,8 @@
 
 (defvar *prompter-suggestion-update-interval* 1.5)
 
-(defun slow-identity-match (input suggestion)
-  (declare (ignore input))
+(defun slow-identity-match (suggestion source input)
+  (declare (ignore source input))
   (sleep *prompter-suggestion-update-interval*)
   suggestion)
 

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -134,8 +134,8 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
                                     initial-suggestions-copy
                                     source
                                     (last-word input))))
-   (prompter:filter (lambda (input suggestion)
-                      (prompter:fuzzy-match (last-word input) suggestion)))
+   (prompter:filter (lambda (suggestion source input)
+                      (prompter:fuzzy-match suggestion source (last-word input))))
    (prompter:multi-selection-p t)
    (prompter:constructor (tag-suggestions)))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))


### PR DESCRIPTION
Previously, non-downcase input would not update the match-data properly.
This is because match-data was computed just one, on initialization, before any
input is given.

This is wrong, we must obviously recompute the match-data on every `update`.
Most importantly, we must leave full control the match-data to the filter
functions.  Indeed, it does not have to be just strings.

To that add, we introduce ensure-match-data-string which is called from our
default filter functions when they need it.

Instead of calculating if the input is upcased of downcased for each
suggestion (it could be slow since it's a performance bottleneck), we do it only
when `update` is called and store the result in `current-input-downcase-p`.

Finally:

- The automatic match-data initialization is removed from `initialize-instance`
and the dedicated `match-data` reader, since NIL is actually an acceptable
value.

- `filter` functions follow the same argument logic as `filter-preprocessor`
and `filter-postprocessor`, so they now take `(SUGGESTION SOURCE INPUT)`.

- `to-unicode` has been renamed to the more appropriate
`ensure-non-base-string`.  It is called only when needed:
  - Once per `update` for `input`.
  - When setting match-data in `ensure-match-data-string`.