### PR TITLE
Remove trailing slash from cl-cffi-gtk submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/quicklisp/quicklisp-client
 [submodule "quicklisp-libraries/cl-cffi-gtk"]
 	path = _build/submodules/cl-cffi-gtk
-	url = https://github.com/Ferada/cl-cffi-gtk/
+	url = https://github.com/Ferada/cl-cffi-gtk
 [submodule "quicklisp-libraries/quri"]
 	path = _build/submodules/quri
 	url = https://github.com/fukamachi/quri


### PR DESCRIPTION
Fixes an issue I ran into on a fresh clone of nyxt where the cl-cffi-gtk submodule fails to clone. This is caused by a url rewrite I have in my gitconfig:
```
[url "git@github.com:"]
    insteadOf = https://github.com/
```

When attempting to run `git submodule update --init` with this gitconfig change, I got the following output (removed some irrelevant lines from the other submodules):
```
<snip>
Cloning into '/home/sean/Code/github.com/atlas-engineer/nyxt/_build/submodules/cl-cffi-gtk'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https://github.com/Ferada/cl-cffi-gtk/' into submodule path '/home/sean/Code/github.com/atlas-engineer/nyxt/_build/submodules/cl-cffi-gtk' failed
Failed to clone '_build/submodules/cl-cffi-gtk'. Retry scheduled
<snip>
Cloning into '/home/sean/Code/github.com/atlas-engineer/nyxt/_build/submodules/cl-cffi-gtk'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https://github.com/Ferada/cl-cffi-gtk/' into submodule path '/home/sean/Code/github.com/atlas-engineer/nyxt/_build/submodules/cl-cffi-gtk' failed
Failed to clone '_build/submodules/cl-cffi-gtk' a second time, aborting
```

Removing the trailing slash for cl-cffi-gtk allows for the submodule init to succeed both with and without url rewrite in my gitconfig.

I don't know how common this particular rewrite is, and it's mostly a convenience for me when cloning private repos, so I would understand not accepting this change.