### PR TITLE
Prompter keymaps (emacs, VI!)

### DIFF
--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -58,7 +58,6 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-/" 'reopen-buffer
                      "C-shift-t" 'reopen-buffer
                      "C-T" 'reopen-buffer
-                     "M-i" 'focus-first-input-field
                      "C-p" 'print-buffer)
 
                     scheme:emacs

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -58,7 +58,7 @@ Example:
          ,(unless (eq name 'root-mode)
             `(define-command ,name (&rest args
                                     &key
-                                    (buffer (current-buffer))
+                                    (buffer (or (current-prompt-buffer) (current-buffer)))
                                     (activate t explicit?)
                                     &allow-other-keys)
                ,docstring
@@ -80,7 +80,9 @@ Example:
                          (push ,new-mode (modes buffer))
                          (hooks:run-hook (enable-hook ,new-mode) ,new-mode)
                          (hooks:run-hook (enable-mode-hook buffer) ,new-mode))
-                       (print-status)
+                       (if (prompt-buffer-p buffer)
+                           (prompt-render-prompt buffer)
+                           (print-status))
                        (log:debug "~a enabled." ',name))
                      (when ,existing-instance
                        (hooks:run-hook (disable-hook ,existing-instance) ,existing-instance)
@@ -88,7 +90,9 @@ Example:
                        (funcall* (destructor ,existing-instance) ,existing-instance)
                        (setf (modes buffer) (delete ,existing-instance
                                                     (modes buffer)))
-                       (print-status)
+                       (if (prompt-buffer-p buffer)
+                           (prompt-render-prompt buffer)
+                           (print-status))
                        (log:debug "~a disabled." ',name))))
                buffer))))))
 

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -25,6 +25,7 @@ Actions can be listed and run with `return-selection-over-action' (bound to
     (define-scheme "prompt-buffer"
       scheme:cua
       (list
+       "escape" 'cancel-input
        "down" 'select-next
        "up" 'select-previous
        "C-n" 'select-next

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -39,11 +39,8 @@ Actions can be listed and run with `return-selection-over-action' (bound to
        "return" 'return-selection
        "M-return" 'return-selection-over-action
        "C-return" 'run-persistent-action
-       "C-j" 'run-persistent-action     ; Emacs binding.
-       "C-g" 'cancel-input              ; Emacs binding.
        "f1 b" 'run-prompt-buffer-command
        "f1 m" 'describe-prompt-buffer
-       "C-h b" 'run-prompt-buffer-command ; TODO: Move to Emacs bindings.
        "C-c C-f" 'toggle-follow
        "C-]" 'toggle-attributes-display ; "C-]" is Emacs Helm binding.
        "C-space" 'prompt-buffer-toggle-mark
@@ -54,7 +51,12 @@ Actions can be listed and run with `return-selection-over-action' (bound to
        "M-m" 'prompt-buffer-toggle-mark-all
        "C-w" 'copy-selection
        "C-v" 'prompt-buffer-paste
-       "M-h" 'prompt-buffer-history))
+       "M-h" 'prompt-buffer-history)
+      scheme:emacs
+      (list
+       "C-j" 'run-persistent-action     ; Emacs binding.
+       "C-g" 'cancel-input              ; Emacs binding.
+       "C-h b" 'run-prompt-buffer-command))
     ;; TODO: We could have VI bindings for the prompt-buffer too.
     ;; But we need to make sure it's optional + to have an indicator
     ;; for the mode.

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -53,15 +53,38 @@ Actions can be listed and run with `return-selection-over-action' (bound to
        "C-w" 'copy-selection
        "C-v" 'prompt-buffer-paste
        "M-h" 'prompt-buffer-history)
+
       scheme:emacs
       (list
        "C-j" 'run-persistent-action     ; Emacs binding.
        "C-g" 'cancel-input              ; Emacs binding.
-       "C-h b" 'run-prompt-buffer-command))
-    ;; TODO: We could have VI bindings for the prompt-buffer too.
-    ;; But we need to make sure it's optional + to have an indicator
-    ;; for the mode.
-    )))
+       "C-h b" 'run-prompt-buffer-command)
+
+      scheme:vi-normal
+      (list
+       "j" 'select-next
+       "k" 'select-previous
+       ;; C-j and C-k are useful in insert mode since "j", "k" are taken.
+       ;; We bind C-j and C-k in normal mode for consistency between the two modes.
+       "C-j" 'select-next
+       "C-k" 'select-previous
+       "C-f" 'select-next-page
+       "C-b" 'select-previous-page
+       "G" 'select-last
+       "g g" 'select-first
+       "J" 'select-next-source
+       "K" 'select-previous-source
+       "z f" 'toggle-follow
+       "z a" 'toggle-attributes-display
+       "y" 'copy-selection
+       "p" 'prompt-buffer-paste)
+
+      scheme:vi-insert
+      (list
+       "C-j" 'select-next
+       "C-k" 'select-previous
+       "C-f" 'select-next-page
+       "C-b" 'select-previous-page)))))
 
 (define-command select-next (&optional (prompt-buffer (current-prompt-buffer)))
   "Select next entry in prompt buffer."
@@ -250,6 +273,7 @@ If STEPS is negative, go to next pages instead."
   "Close the prompt-buffer without further action."
   (prompter:toggle-follow prompt-buffer))
 
+; TODO: Remove the "prompt-buffer-" prefix of all prompt-buffer-mode commands.
 (define-command prompt-buffer-toggle-mark (&key
                                            (prompt-buffer (current-prompt-buffer))
                                            (direction :forward))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -59,7 +59,7 @@ new history for each new prompt buffer.  Here we set the history to be shared gl
                  ("#prompt-area"
                   :background-color "dimgray"
                   :display "grid"
-                  :grid-template-columns "auto auto 1fr"
+                  :grid-template-columns "auto auto 1fr auto"
                   :width "100%"
                   :color "white")
                  ("#prompt"
@@ -68,6 +68,9 @@ new history for each new prompt buffer.  Here we set the history to be shared gl
                  ("#prompt-extra"
                   :line-height "26px"
                   :padding-right "7px")
+                 ("#prompt-modes"
+                  :line-height "26px"
+                  :padding-left "7px")
                  ("#input"
                   :border "none"
                   :outline "none"
@@ -216,7 +219,13 @@ To access the suggestion instead, see `prompter:selected-suggestion'."
                          (length suggestions)))
                 ((not marks)
                  (format nil "[~a]"
-                         (length suggestions))))))))))
+                         (length suggestions))))))
+       (setf (ps:chain document (get-element-by-id "prompt-modes") |innerHTML|)
+             (ps:lisp
+              (format nil "~{~a~^ ~}" (delete "prompt-buffer"
+                                              (mapcar #'format-mode
+                                                      (modes prompt-buffer))
+                                              :test #'string=))))))))
 
 (export 'prompt-render-suggestions)
 (defmethod prompt-render-suggestions ((prompt-buffer prompt-buffer))
@@ -295,7 +304,8 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                                               "password"
                                                               "text")
                                                     :id "input"
-                                                    :value (prompter:input prompt-buffer))))
+                                                    :value (prompter:input prompt-buffer)))
+                                      (:div :id "prompt-modes" ""))
                                 (markup:raw
                                  (markup:markup*
                                   `(:div :id "suggestions"

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -118,14 +118,7 @@ new history for each new prompt buffer.  Here we set the history to be shared gl
                  (.selected :background-color "gray"
                             :color "white")))
             :documentation "The CSS applied to a prompt-buffer when it is set-up.")
-     (override-map (let ((map (make-keymap "override-map")))
-                     (define-key map
-                       "escape"
-                       ;; We compute symbol at runtime because
-                       ;; nyxt/prompt-buffer-mode does not exist at
-                       ;; compile-time since it's loaded afterwards.
-                       (find-symbol (string 'cancel-input)
-                                    (find-package 'nyxt/prompt-buffer-mode))))
+     (override-map (make-keymap "override-map")
                    :type keymap:keymap
                    :documentation "Keymap that takes precedence over all modes' keymaps."))
     (:export-class-name-p t)

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -46,12 +46,13 @@ vi-normal-mode.")
         (setf (keymap-scheme-name buffer) scheme:vi-normal)
         (setf (forward-input-events-p buffer) nil))))))
 
-(define-command switch-to-vi-normal-mode (&optional (mode (find-submode (current-buffer)
+(define-command switch-to-vi-normal-mode (&optional (mode (find-submode (or (current-prompt-buffer) (current-buffer))
                                                                         'vi-insert-mode)))
   "Switch to the mode remembered to be the matching VI-normal one for this MODE."
   (when mode
     (enable-modes (list (and (previous-vi-normal-mode mode)
-                             (mode-name (previous-vi-normal-mode mode)))))))
+                             (mode-name (previous-vi-normal-mode mode))))
+                  (buffer mode))))
 
 ;; TODO: Move ESCAPE binding to the override map?
 (define-mode vi-insert-mode ()

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -65,6 +65,7 @@ and to index the top of the page.")
        "M-left" 'history-backwards
        "M-]" 'history-forwards
        "M-[" 'history-backwards
+       "M-i" 'focus-first-input-field
        "C-j" 'follow-hint
        "C-u C-j" 'follow-hint-new-buffer-focus
        "C-J" 'follow-hint-new-buffer


### PR DESCRIPTION
The long awaited VI bindings for the prompt buffer!

This induces some significant changes:

- The prompt buffer mode list is now displayed to the right of the input.  It's empty by default.
- I've emptied the prompt-buffer override map because `escape` would conflict with vi-insert-mode `escape`.  Can you think of a better way?
- Mode togglers now apply to `current-prompt-buffer`, if any, with higher priority than `current-buffer`.  This may be quite a disruptive change.

To do: test with the `enable-mode-*` and `disable-mode-*` commands still behave as expected.

Thoughts?

Tests are welcome! :)