### PR TITLE
urls.lisp: Add utils to compare urls.

### DIFF
--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -47,23 +47,11 @@ appended to the URL."))
     ("Shortcut" ,(shortcut entry))
     ("Search URL" ,(search-url entry))))
 
-(declaim (ftype (function (quri:uri quri:uri) boolean) equal-url))
-(defun equal-url (url1 url2)
-  "URLs are equal if the URIs are equal, scheme excluded.
-Empty paths are also excluded from the comparison.
-For instance, these are equal:
-- http://example.org
-- https://example.org/"
-  (if (and (quri:uri-http-p url1)
-           (quri:uri-http-p url2))
-      (schemeless-uri= url1 url2)
-      (the (values boolean &optional) (quri:uri= url1 url2))))
-
 (export-always 'equals)
 (defmethod equals ((e1 bookmark-entry) (e2 bookmark-entry))
   "Entries are equal if the hosts and the paths are equal.
 In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
-  (equal-url (url e1) (url e2)))
+  (url-equal (url e1) (url e2)))
 
 (declaim (ftype (function (quri:uri &key (:title string) (:date (or local-time:timestamp null)) (:tags t)) t) bookmark-add))
 (export-always 'bookmark-add)
@@ -72,12 +60,11 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
     (unless (or (url-empty-p url)
                 (string= "about:blank" (render-url url)))
       (multiple-value-bind (entries bookmarks-without-url)
-          (sera:partition (sera:partial #'equal-url url) bookmarks :key #'url)
+          (sera:partition (sera:partial #'url-equal url) bookmarks :key #'url)
         (let ((entry (if entries
                          (first entries)
                          (make-instance 'bookmark-entry
                                         :url url))))
-
           (unless (str:emptyp title)
             (setf (title entry) title))
           (setf tags (delete "" tags :test #'string=))
@@ -150,7 +137,7 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
 (defun url-bookmark-tags (url)
   "Return the list of tags of the bookmark corresponding to URL."
   (with-data-unsafe (bookmarks (bookmarks-path (current-buffer)))
-    (alex:when-let ((existing (find url bookmarks :key #'url :test #'equal-url)))
+    (alex:when-let ((existing (find url bookmarks :key #'url :test #'url-equal)))
       (tags existing))))
 
 (define-command bookmark-current-page (&optional (buffer (current-buffer)))

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -126,6 +126,18 @@ This way, HTTPS and HTTP is ignored when comparing URIs."
   (string< (schemeless-url uri1)
            (schemeless-url uri2)))
 
+(declaim (ftype (function (quri:uri quri:uri) boolean) url-equal))
+(defun url-equal (url1 url2)
+  "URLs are equal if the URIs are equal, scheme excluded.
+Empty paths are also excluded from the comparison.
+For instance, these are equal:
+- http://example.org
+- https://example.org/"
+  (if (and (quri:uri-http-p url1)
+           (quri:uri-http-p url2))
+      (schemeless-uri= url1 url2)
+      (the (values boolean &optional) (quri:uri= url1 url2))))
+
 (declaim (ftype (function (string) (values (or quri:uri null) t &optional)) parse-url))
 (defun parse-url (input-url)
   "From user input, return the full URL to visit.

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -185,3 +185,28 @@ functionality into internal-buffers."
        (apply #'str:concat "lisp://"
               (mapcar (alex:compose #'quri:url-encode #'write-to-string)
                       (cons lisp-form more-lisp-forms)))))
+
+(declaim (ftype (function (quri:uri quri:uri) boolean) path=))
+(defun path= (url1 url2)
+  "Return non-nil when URL1 and URL2 have the same path."
+  ;; See https://github.com/fukamachi/quri/issues/48.
+  (equalp (string-right-trim "/" (or (quri:uri-path url1) ""))
+          (string-right-trim "/" (or (quri:uri-path url2) ""))))
+
+(declaim (ftype (function (quri:uri quri:uri) boolean) scheme=))
+(defun scheme= (url1 url2)
+  "Return non-nil when URL1 and URL2 have the same scheme.
+HTTP and HTTPS belong to the same equivalence class."
+  (or (equalp (quri:uri-scheme url1) (quri:uri-scheme url2))
+      (and (quri:uri-http-p url1) (quri:uri-http-p url2))))
+
+(declaim (ftype (function (quri:uri quri:uri) boolean) domain=))
+(defun domain= (url1 url2)
+  "Return non-nil when URL1 and URL2 have the same domain."
+  (equalp (quri:uri-domain url1) (quri:uri-domain url2)))
+
+(declaim (ftype (function (quri:uri quri:uri) boolean) host=))
+(defun host= (url1 url2)
+  "Return non-nil when URL1 and URL2 have the same host.
+This is a more restrictive requirement than `domain='."
+  (equalp (quri:uri-host url1) (quri:uri-host url2)))

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -128,15 +128,19 @@ This way, HTTPS and HTTP is ignored when comparing URIs."
 
 (declaim (ftype (function (quri:uri quri:uri) boolean) url-equal))
 (defun url-equal (url1 url2)
-  "URLs are equal if the URIs are equal, scheme excluded.
-Empty paths are also excluded from the comparison.
-For instance, these are equal:
-- http://example.org
-- https://example.org/"
-  (if (and (quri:uri-http-p url1)
-           (quri:uri-http-p url2))
-      (schemeless-uri= url1 url2)
-      (the (values boolean &optional) (quri:uri= url1 url2))))
+  "Like `quri:uri=' but ignoring the scheme.
+URLs are equal up to `scheme='."
+  (url-eqs url1
+           url2
+           (list #'scheme= 
+                 (lambda (url1 url2) (equal (or (quri:uri-path url1) "/")
+                                       (or (quri:uri-path url2) "/")))
+                 (lambda (url1 url2) (equal (quri:uri-query url1)
+                                       (quri:uri-query url2)))
+                 (lambda (url1 url2) (equal (quri:uri-fragment url1)
+                                       (quri:uri-fragment url2)))
+                 (lambda (url1 url2) (equalp (quri:uri-authority url1)
+                                        (quri:uri-authority url2))))))
 
 (declaim (ftype (function (string) (values (or quri:uri null) t &optional)) parse-url))
 (defun parse-url (input-url)

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -210,3 +210,14 @@ HTTP and HTTPS belong to the same equivalence class."
   "Return non-nil when URL1 and URL2 have the same host.
 This is a more restrictive requirement than `domain='."
   (equalp (quri:uri-host url1) (quri:uri-host url2)))
+
+(declaim (ftype (function (quri:uri quri:uri list) boolean) url-eqs))
+(defun url-eqs (url1 url2 eq-fn-list)
+  "Return non-nil when URL1 and URL2 are \"equal\" as dictated by EQ-FN-LIST.
+
+EQ-FN-LIST is a list of functions that take URL1 and URL2 as arguments and
+return a boolean.  It defines an equivalence relation induced by EQ-FN-LIST.
+`quri:uri=' and `url-equal' are examples of equivalence relations."
+  ;; (and (fn1 url1 url2) (fn2 url1 url2) ...) stops as soon as any fn returns
+  ;; nil, unlike the solution below.
+  (every #'identity (mapcar (lambda (fn) (funcall fn url1 url2)) eq-fn-list)))

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -98,15 +98,6 @@ If it cannot be derived, return an empty `quri:uri'."
                (quri:uri-fragment url)
                (quri:uri-userinfo url))))
 
-(declaim (ftype (function (quri:uri quri:uri) boolean) schemeless-uri=))
-(defun schemeless-uri= (uri1 uri2)
-  "Like `quri:uri=' but ignore scheme in comparison.
-Authority is compared case-insensitively (RFC 3986)."
- (and (equal  (or (quri:uri-path uri1) "/") (or (quri:uri-path uri2) "/"))
-      (equal  (quri:uri-query uri1)     (quri:uri-query uri2))
-      (equal  (quri:uri-fragment uri1)  (quri:uri-fragment uri2))
-      (equalp (quri:uri-authority uri1) (quri:uri-authority uri2))))
-
 (declaim (ftype (function (quri:uri) string) schemeless-url))
 (defun schemeless-url (uri)             ; Inspired by `quri:render-uri'.
   "Return URL without its scheme (e.g. it removes 'https://')."

--- a/tests/online/urls.lisp
+++ b/tests/online/urls.lisp
@@ -69,12 +69,12 @@
       "Valid IP URL")
   (ok (valid-url-p "http://192.168.1.1/foo")
       "Valid IP URL with path")
-  (is (nyxt::schemeless-uri= (quri:uri "http://example.org")
-                             (quri:uri "https://example.org/"))
+  (is (nyxt::url-equal (quri:uri "http://example.org")
+                       (quri:uri "https://example.org/"))
       t
       "same schemeless URIs")
-  (is (nyxt::schemeless-uri= (quri:uri "https://example.org")
-                             (quri:uri "https://example.org/foo"))
+  (is (nyxt::url-equal (quri:uri "https://example.org")
+                       (quri:uri "https://example.org/foo"))
       nil
       "different schemeless URIs")
   (is (nyxt::schemeless-url (quri:uri "http://example.org/foo/bar?query=baz#qux"))


### PR DESCRIPTION
As discussed with @jmercouris.

This is an abstraction that should be leveraged to avoid `quri:uri=`, `url-equal`, `schemeless-uri=` and others. Equivalence relations are our friends :)