### PR TITLE
buffer.lisp: Add function that returns enabled modes.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1156,6 +1156,13 @@ ARGS are passed to the mode command."
           (apply #'funcall command :buffer buffer :activate t args)
           (log:warn "Mode command ~a not found." mode)))))
 
+(export-always 'active-modes)
+(defun active-modes (&optional (buffer (current-buffer)))
+  "Return the enabled modes of BUFFER.
+The modes are the mode symbols, as returned by `mode-name'."
+  (mapcar (lambda (mode) (mode-name mode))
+          (modes buffer)))
+
 (define-class active-mode-source (prompter:source)
   ((prompter:name "Active modes")
    (buffers :initarg :buffers :accessor buffers :initform nil)


### PR DESCRIPTION
The modes are returned as mode symbols.

This differs from the modes slot of the buffer class, since that returns
the instances of the enabled modes.