### PR TITLE
Remove suggestion maker? Maybe not.

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -223,7 +223,7 @@ It's called when `destroy' is called over `prompter'.")
                         "Suggestions used on initialization, before any
 user input is processed.
 On initialization this list is transformed to a list of `suggestion's
-where attributes are set from `suggestion-attribute-function'.
+with `suggestion-maker'.
 This list is never modified after initialization.")
 
    (initial-suggestions-lock (bt:make-lock)
@@ -530,7 +530,9 @@ If you are looking for a source that just returns its plain suggestions, use `so
   (second (first (attributes suggestion))))
 
 (defmethod attributes-default ((object t))
-  "Return OBJECT default attribute value."
+  "Return OBJECT default attribute value.
+Since the OBJECT is taken outside of a source context, attributes are derived
+from `object-attributes'."
   (second (first (object-attributes object))))
 
 (export-always 'attributes-non-default)

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -344,31 +344,30 @@ rest in background buffers."
 
 (define-command import-bookmarks-from-html (&key (html-file nil))
   "Import bookmarks from an HTML file."
-  (flet ((directory-or-html-file (suggestions source input)
-           (remove-if-not #'(lambda (suggestion)
-                              (or (string-equal (pathname-type (prompter:value suggestion)) "html")
-                                  (uiop:directory-pathname-p (prompter:value suggestion))))
-                          (make-file-suggestions suggestions source input))))
-    (let ((html-file (or html-file
-                         (first (prompt
-                                 ;; TODO: Is there a more intuitive directory for bookmarks?
-                                 :input (namestring (uiop:getcwd))
-                                 :sources (make-instance 'file-source
-                                           :filter-preprocessor #'directory-or-html-file))))))
-      (if (and (uiop:file-exists-p html-file)
-               (equal (pathname-type html-file) "html"))
-          (with-open-file (in-html html-file :external-format :utf-8)
-            (let ((a-tags (plump:get-elements-by-tag-name (plump:parse in-html) "a")))
-              (dolist (a-tag a-tags)
-                (let* ((url (plump:attribute a-tag "href"))
-                       (title (plump:render-text a-tag))
-                       (date (plump:attribute a-tag "add_date"))
-                       (tags (plump:attribute a-tag "tags"))
-                       (url-uri (quri:uri url)))
-                  (when (str:starts-with? "http" (quri:uri-scheme url-uri))
-                    (bookmark-add url-uri
-                                  :title title
-                                  :date (ignore-errors (local-time:unix-to-timestamp (parse-integer date)))
-                                  :tags (when tags
-                                          (str:split "," tags))))))))
-          (echo "The file doesn't exist or is not an HTML file.")))))
+  (let ((html-file (or html-file
+                       (first (prompt
+                               ;; TODO: Is there a more intuitive directory for bookmarks?
+                               :input (namestring (uiop:getcwd))
+                               :sources (make-instance
+                                         'file-source
+                                         :filter-preprocessor
+                                         (make-file-source-preprocessor
+                                          (alex:disjoin (match-externsion "html")
+                                                        #'uiop:directory-pathname-p))))))))
+    (if (and (uiop:file-exists-p html-file)
+             (equal (pathname-type html-file) "html"))
+        (with-open-file (in-html html-file :external-format :utf-8)
+          (let ((a-tags (plump:get-elements-by-tag-name (plump:parse in-html) "a")))
+            (dolist (a-tag a-tags)
+              (let* ((url (plump:attribute a-tag "href"))
+                     (title (plump:render-text a-tag))
+                     (date (plump:attribute a-tag "add_date"))
+                     (tags (plump:attribute a-tag "tags"))
+                     (url-uri (quri:uri url)))
+                (when (str:starts-with? "http" (quri:uri-scheme url-uri))
+                  (bookmark-add url-uri
+                                :title title
+                                :date (ignore-errors (local-time:unix-to-timestamp (parse-integer date)))
+                                :tags (when tags
+                                        (str:split "," tags))))))))
+        (echo "The file doesn't exist or is not an HTML file."))))

--- a/source/command-commands.lisp
+++ b/source/command-commands.lisp
@@ -23,7 +23,7 @@
                (mapcar #'mode-name (modes buffer)))
         #'local-time:timestamp> :key #'last-access))
 
-(defun command-properties (command &optional (buffer (active-buffer (current-window :no-rescan))))
+(defun command-attributes (command &optional (buffer (active-buffer (current-window :no-rescan))))
   (let ((scheme-name (keymap-scheme-name buffer))
         (bindings '()))
     (loop for mode in (modes buffer)
@@ -41,7 +41,7 @@
                      (str:replace-first "nyxt/" "" package-name)))))))
 
 (defmethod prompter:object-attributes ((command command))
-  (command-properties command))
+  (command-attributes command))
 
 (define-class command-source (prompter:source)
   ((prompter:name "Commands")

--- a/source/editor-mode.lisp
+++ b/source/editor-mode.lisp
@@ -67,9 +67,10 @@ get/set-content (which is necessary for operation)."
                       :prompt "Open file"
                       :input (namestring (uiop:getcwd))
                       :sources
-                      (list (make-instance 'prompter:raw-source)
-                            (make-instance 'file-source
-                                           :name "Absolute file path"))))))
+                      (list (make-instance 'file-source
+                                           :name "Absolute file path")
+                            (make-instance 'prompter:raw-source
+                                           :name "New file"))))))
     (open-file buffer file)
     ;; TODO: Maybe make `editor-mode' and `editor-buffer' pathname-friendly?
     (setf (file buffer) (namestring file))

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -227,7 +227,7 @@ If STEPS is negative, go to next pages instead."
   (make-instance
    'prompter:suggestion
    :value command
-   :attributes (nyxt::command-properties command (parent-prompt-buffer source))))
+   :attributes (nyxt::command-attributes command (parent-prompt-buffer source))))
 
 (define-command run-prompt-buffer-command (&optional (prompt-buffer (current-prompt-buffer)))
   "Prompt for a command to call in PROMPT-BUFFER."


### PR DESCRIPTION
@aartaka This update file-manager to leverage the preprocessor and object-attributes instead of making suggestions manually.

How does it look to you?  Can you test and see if it didn't remove any functionality?

@jmercouris In the end, I kept `suggestion-maker`.  This is because `prompt-buffer-command-source` can only create suggestions if it knows the parent source.
Can you think of an alternative?  I'll think a bit more about it.