### PR TITLE
Toggle modes

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1200,15 +1200,6 @@ ARGS are passed to the mode command."
                              (set-difference (mode-list) common-modes)))))
   (:export-class-name-p t))
 
-(define-command disable-mode-for-current-buffer (&key (buffer (current-buffer)))
-  "Disable queried mode(s)."
-  (let ((modes (prompt
-                :prompt "Disable mode(s)"
-                :sources (make-instance 'active-mode-source
-                                        :buffers buffer))))
-    (disable-modes (mapcar #'mode-name modes) buffer)))
-
-
 (define-command disable-mode-for-buffer ()
   "Disable queried mode(s) for select buffer(s)."
   (let* ((buffers (prompt
@@ -1222,14 +1213,6 @@ ARGS are passed to the mode command."
                                          :buffers buffers))))
     (loop for buffer in buffers
           do (disable-modes (mapcar #'mode-name modes) buffer))))
-
-(define-command enable-mode-for-current-buffer (&key (buffer (current-buffer)))
-  "Enable queried mode(s)."
-  (let ((modes (prompt
-                :prompt "Enable mode(s)"
-                :sources (make-instance 'inactive-mode-source
-                                        :buffers buffer))))
-    (enable-modes (uiop:ensure-list modes) buffer)))
 
 (define-command enable-mode-for-buffer ()
   "Enable queried mode(s) for select buffer(s)."

--- a/source/style-mode.lisp
+++ b/source/style-mode.lisp
@@ -12,8 +12,7 @@
 
 (define-mode style-mode ()
   "Mode for styling documents."
-  ((rememberable-p nil)
-   (css-cache-path (make-instance 'css-cache-data-path
+  ((css-cache-path (make-instance 'css-cache-data-path
                                   :dirname (uiop:xdg-data-home
                                             nyxt::+data-root+
                                             "style-mode-css-cache")))


### PR DESCRIPTION
This answers one of my primary itches with auto-mode: when one wants to override the behaviour of auto-mode _for the current buffer_, and _permanently_, we had to toggle the desired modes _and_ disable auto-mode, which was cumbersome.

With `toggle-modes`, it's now easier to select the desired modes and run the secondary action which disables auto-mode in the process.

I've seized this opportunity to remove `enable-modes-for-current-buffer`, etc. since they are superseded by `toggle-modes`.

Thoughts?