### PR TITLE
Make qs and qsa Parenscript macros.

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -83,6 +83,7 @@
                (:file "data-storage")
                (:file "configuration")
                (:file "command")
+               (:file "parenscript-macro")
                (:file "renderer-script")
                (:file "buffer")
                (:file "window")

--- a/source/element-hint-mode.lisp
+++ b/source/element-hint-mode.lisp
@@ -10,7 +10,7 @@
 (define-command toggle-hints-transparency (&key (buffer (current-buffer)))
   "Toggle the on-screen element hints transparency."
   (pflet ((toggle-transparent ()
-            (ps:dolist (element (nyxt:qsa document ".nyxt-hint"))
+            (ps:dolist (element (nyxt/ps:qsa document ".nyxt-hint"))
               (if (or (= (ps:chain element style opacity) "1")
                       (= (ps:chain element style opacity) ""))
                   (setf (ps:chain element style opacity) "0.2")

--- a/source/element-hint-mode.lisp
+++ b/source/element-hint-mode.lisp
@@ -10,10 +10,7 @@
 (define-command toggle-hints-transparency (&key (buffer (current-buffer)))
   "Toggle the on-screen element hints transparency."
   (pflet ((toggle-transparent ()
-            (defun qsa (context selector)
-              "Alias of document.querySelectorAll"
-              (ps:chain context (query-selector-all selector)))
-            (ps:dolist (element (qsa document ".nyxt-hint"))
+            (ps:dolist (element (nyxt:qsa document ".nyxt-hint"))
               (if (or (= (ps:chain element style opacity) "1")
                       (= (ps:chain element style opacity) ""))
                   (setf (ps:chain element style opacity) "0.2")

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -4,20 +4,12 @@
 (in-package :nyxt/web-mode)
 
 (define-parenscript add-element-hints (&key annotate-visible-only-p)
-  (defun qs (context selector)
-    "Alias of document.querySelector"
-    (ps:chain context (query-selector selector)))
-
-  (defun qsa (context selector)
-    "Alias of document.querySelectorAll"
-    (ps:chain context (query-selector-all selector)))
-
   (defun code-char (n)
     "Alias of String.fromCharCode"
     (ps:chain -string (from-char-code n)))
 
   (defun add-stylesheet ()
-    (unless (qs document "#nyxt-stylesheet")
+    (unless (nyxt:qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
                  (box-style (ps:lisp (box-style (current-mode 'web))))
@@ -124,38 +116,29 @@ identifier for every hinted element."
              (aref alphabet (rem n alphabet-length))) "")))
 
   (add-stylesheet)
-  (hints-add (qsa document (list "a" "button" "input" "textarea" "img"))))
+  (hints-add (nyxt:qsa document (list "a" "button" "input" "textarea" "img"))))
 
 (define-parenscript remove-element-hints ()
   (defun hints-remove-all ()
     "Removes all the elements"
-    (ps:dolist (element (qsa document ".nyxt-hint"))
+    (ps:dolist (element (nyxt:qsa document ".nyxt-hint"))
       (ps:chain element (remove))))
   (hints-remove-all))
 
 (define-parenscript click-element (&key nyxt-identifier)
-  (defun qs (context selector)
-    "Alias of document.querySelector"
-    (ps:chain context (query-selector selector)))
-  (ps:chain (qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (click)))
+  (ps:chain (nyxt:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (click)))
 
 (define-parenscript focus-element (&key nyxt-identifier)
-  (defun qs (context selector)
-    "Alias of document.querySelector"
-    (ps:chain context (query-selector selector)))
-  (ps:chain (qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (focus))
-  (ps:chain (qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (select)))
+  (ps:chain (nyxt:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (focus))
+  (ps:chain (nyxt:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (select)))
 
 (define-parenscript highlight-selected-hint (&key link-hint scroll)
-  (defun qs (context selector)
-    "Alias of document.querySelector"
-    (ps:chain context (query-selector selector)))
 
   (defun update-hints ()
-    (ps:let* ((new-element (qs document (ps:lisp (format nil "#nyxt-hint-~a" (identifier link-hint))))))
+    (ps:let* ((new-element (nyxt:qs document (ps:lisp (format nil "#nyxt-hint-~a" (identifier link-hint))))))
       (when new-element
         (unless ((ps:@ new-element class-list contains) "nyxt-highlight-hint")
-          (ps:let ((old-elements (qsa document ".nyxt-highlight-hint")))
+          (ps:let ((old-elements (nyxt:qsa document ".nyxt-highlight-hint")))
             (ps:dolist (e old-elements)
               (setf (ps:@ e class-name) "nyxt-hint"))))
         (setf (ps:@ new-element class-name) "nyxt-hint nyxt-highlight-hint")
@@ -166,7 +149,7 @@ identifier for every hinted element."
   (update-hints))
 
 (define-parenscript remove-focus ()
-  (ps:let ((old-elements (qsa document ".nyxt-highlight-hint")))
+  (ps:let ((old-elements (nyxt:qsa document ".nyxt-highlight-hint")))
     (ps:dolist (e old-elements)
       (setf (ps:@ e class-name) "nyxt-hint"))))
 

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -45,20 +45,6 @@ identifier for every hinted element."
     (ps:let ((hint-element (hint-create-element element hint)))
       (ps:chain document body (append-child hint-element))))
 
-  (defun element-drawable-p (element)
-    (if (or (ps:chain element offset-width)
-            (ps:chain element offset-height)
-            (ps:chain element (get-client-rects) length))
-        t nil))
-
-  (defun element-in-view-port-p (element)
-    (ps:let* ((rect (ps:chain element (get-bounding-client-rect))))
-      (if (and (>= (ps:chain rect top) 0)
-               (>= (ps:chain rect left) 0)
-               (<= (ps:chain rect right) (ps:chain window inner-width))
-               (<= (ps:chain rect bottom) (ps:chain window inner-height)))
-          t nil)))
-
   (defun object-create (element hint)
     (cond ((equal "A" (ps:@ element tag-name))
            (ps:create "type" "link" "hint" hint "href" (ps:@ element href) "body" (ps:@ element |innerHTML|)))
@@ -82,13 +68,13 @@ identifier for every hinted element."
       (ps:chain |json|
                 (stringify
                  (loop for i from 0 to (- elements-length 1)
-                       when (and (element-drawable-p (elt elements i))
-                                 (element-in-view-port-p (elt elements i)))
+                       when (and (nyxt/ps:element-drawable-p (elt elements i))
+                                 (nyxt/ps:element-in-view-port-p (elt elements i)))
                        do (hint-add (elt elements i) (elt hints i))
-                       when (or (and (element-drawable-p (elt elements i))
+                       when (or (and (nyxt/ps:element-drawable-p (elt elements i))
                                      (not (ps:lisp annotate-visible-only-p)))
-                                (and (element-drawable-p (elt elements i))
-                                     (element-in-view-port-p (elt elements i))))
+                                (and (nyxt/ps:element-drawable-p (elt elements i))
+                                     (nyxt/ps:element-in-view-port-p (elt elements i))))
                        collect (object-create (elt elements i) (elt hints i)))))))
 
   (defun hints-determine-chars-length (length alphabet)

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -9,7 +9,7 @@
     (ps:chain -string (from-char-code n)))
 
   (defun add-stylesheet ()
-    (unless (nyxt:qs document "#nyxt-stylesheet")
+    (unless (nyxt/ps:qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
                  (box-style (ps:lisp (box-style (current-mode 'web))))
@@ -116,29 +116,29 @@ identifier for every hinted element."
              (aref alphabet (rem n alphabet-length))) "")))
 
   (add-stylesheet)
-  (hints-add (nyxt:qsa document (list "a" "button" "input" "textarea" "img"))))
+  (hints-add (nyxt/ps:qsa document (list "a" "button" "input" "textarea" "img"))))
 
 (define-parenscript remove-element-hints ()
   (defun hints-remove-all ()
     "Removes all the elements"
-    (ps:dolist (element (nyxt:qsa document ".nyxt-hint"))
+    (ps:dolist (element (nyxt/ps:qsa document ".nyxt-hint"))
       (ps:chain element (remove))))
   (hints-remove-all))
 
 (define-parenscript click-element (&key nyxt-identifier)
-  (ps:chain (nyxt:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (click)))
+  (ps:chain (nyxt/ps:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (click)))
 
 (define-parenscript focus-element (&key nyxt-identifier)
-  (ps:chain (nyxt:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (focus))
-  (ps:chain (nyxt:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (select)))
+  (ps:chain (nyxt/ps:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (focus))
+  (ps:chain (nyxt/ps:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))) (select)))
 
 (define-parenscript highlight-selected-hint (&key link-hint scroll)
 
   (defun update-hints ()
-    (ps:let* ((new-element (nyxt:qs document (ps:lisp (format nil "#nyxt-hint-~a" (identifier link-hint))))))
+    (ps:let* ((new-element (nyxt/ps:qs document (ps:lisp (format nil "#nyxt-hint-~a" (identifier link-hint))))))
       (when new-element
         (unless ((ps:@ new-element class-list contains) "nyxt-highlight-hint")
-          (ps:let ((old-elements (nyxt:qsa document ".nyxt-highlight-hint")))
+          (ps:let ((old-elements (nyxt/ps:qsa document ".nyxt-highlight-hint")))
             (ps:dolist (e old-elements)
               (setf (ps:@ e class-name) "nyxt-hint"))))
         (setf (ps:@ new-element class-name) "nyxt-hint nyxt-highlight-hint")
@@ -149,7 +149,7 @@ identifier for every hinted element."
   (update-hints))
 
 (define-parenscript remove-focus ()
-  (ps:let ((old-elements (nyxt:qsa document ".nyxt-highlight-hint")))
+  (ps:let ((old-elements (nyxt/ps:qsa document ".nyxt-highlight-hint")))
     (ps:dolist (e old-elements)
       (setf (ps:@ e class-name) "nyxt-hint"))))
 

--- a/source/jump-heading.lisp
+++ b/source/jump-heading.lisp
@@ -18,7 +18,7 @@
 
 (defun get-headings (&key (buffer (current-buffer)))
   (pflet ((get-headings ()
-           (let ((headings (nyxt:qsa document "h1, h2, h3, h4, h5, h6")))
+           (let ((headings (nyxt/ps:qsa document "h1, h2, h3, h4, h5, h6")))
              (ps:chain |json| (stringify
                                (loop for heading in headings
                                      collect (ps:chain heading inner-text)))))))
@@ -30,7 +30,7 @@
 
 (defun scroll-page-to-heading (heading)
   (pflet ((scroll-page-to-heading (heading)
-            (let ((headings (nyxt:qsa document "h1, h2, h3, h4, h5, h6")))
+            (let ((headings (nyxt/ps:qsa document "h1, h2, h3, h4, h5, h6")))
               (loop for heading in headings do
                        (when (equal (ps:lisp (inner-text heading))
                                     (ps:chain heading inner-text))

--- a/source/jump-heading.lisp
+++ b/source/jump-heading.lisp
@@ -18,10 +18,7 @@
 
 (defun get-headings (&key (buffer (current-buffer)))
   (pflet ((get-headings ()
-           (defun qsa (context selector)
-             "Alias of document.querySelectorAll"
-             (ps:chain context (query-selector-all selector)))
-           (let ((headings (qsa document "h1, h2, h3, h4, h5, h6")))
+           (let ((headings (nyxt:qsa document "h1, h2, h3, h4, h5, h6")))
              (ps:chain |json| (stringify
                                (loop for heading in headings
                                      collect (ps:chain heading inner-text)))))))
@@ -33,9 +30,7 @@
 
 (defun scroll-page-to-heading (heading)
   (pflet ((scroll-page-to-heading (heading)
-            (defun qsa (context selector)
-              (ps:chain context (query-selector-all selector)))
-            (let ((headings (qsa document "h1, h2, h3, h4, h5, h6")))
+            (let ((headings (nyxt:qsa document "h1, h2, h3, h4, h5, h6")))
               (loop for heading in headings do
                        (when (equal (ps:lisp (inner-text heading))
                                     (ps:chain heading inner-text))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -49,6 +49,5 @@ It's not recommended to use `nyxt' itself to avoid clobbering internal symbols."
 
 (uiop:define-package nyxt/parenscript
     (:nicknames :nyxt/ps)
-  (:use :common-lisp :nyxt :parenscript)
-  (:import-from #:serapeum #:export-always)
+  (:use :common-lisp :parenscript :nyxt)
   (:export :qs :qsa :insert-at :element-drawable-p :element-in-view-port-p))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -46,3 +46,9 @@ It's not recommended to use `nyxt' itself to avoid clobbering internal symbols."
   (:import-from #:class-star #:define-class)
   (:import-from #:serapeum #:export-always)
   (:documentation "Mode for prompter buffer."))
+
+(uiop:define-package nyxt/parenscript
+    (:nicknames :nyxt/ps)
+  (:use :common-lisp :nyxt :parenscript)
+  (:import-from #:serapeum #:export-always)
+  (:export :qs :qsa :insert-at :element-drawable-p :element-in-view-port-p))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -46,8 +46,3 @@ It's not recommended to use `nyxt' itself to avoid clobbering internal symbols."
   (:import-from #:class-star #:define-class)
   (:import-from #:serapeum #:export-always)
   (:documentation "Mode for prompter buffer."))
-
-(uiop:define-package nyxt/parenscript
-    (:nicknames :nyxt/ps)
-  (:use :common-lisp :parenscript :nyxt)
-  (:export :qs :qsa :insert-at :element-drawable-p :element-in-view-port-p))

--- a/source/parenscript-macro.lisp
+++ b/source/parenscript-macro.lisp
@@ -1,0 +1,51 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package nyxt/parenscript
+    (:nicknames :nyxt/ps)
+  (:use :common-lisp :parenscript :nyxt)
+  (:export :qs :qsa :insert-at :element-drawable-p :element-in-view-port-p))
+
+(in-package :nyxt/parenscript)
+
+(defpsmacro qs (context selector)
+  "Alias of document.querySelector"
+  `(chain ,context (query-selector ,selector)))
+
+(defpsmacro qsa (context selector)
+  "Alias of document.querySelectorAll"
+  `(chain ,context (query-selector-all ,selector)))
+
+(defpsmacro insert-at (tag input-text)
+  "Insert text at a tag."
+  `(let ((origin (chain ,tag selection-start))
+         (end (chain ,tag selection-end)))
+     (setf (chain ,tag value)
+           (+ (chain ,tag value (substring 0 origin))
+              ,input-text
+              (chain ,tag value
+                     (substring end
+                                (chain ,tag value length)))))
+     (if (= origin end)
+         (progn
+           (setf (chain ,tag selection-start) (+ origin (chain ,input-text length)))
+           (setf (chain ,tag selection-end) (chain ,tag selection-start)))
+         (progn
+           (setf (chain ,tag selection-start) origin)
+           (setf (chain ,tag selection-end) (+ origin (chain ,input-text length)))))))
+
+(defpsmacro element-drawable-p (element)
+  "Is the element drawable?"
+  `(if (or (chain ,element offset-width)
+           (chain ,element offset-height)
+           (chain ,element (get-client-rects) length))
+       t nil))
+
+(defpsmacro element-in-view-port-p (element)
+  "Is the element in the view port?"
+  `(let* ((rect (chain ,element (get-bounding-client-rect))))
+     (if (and (>= (chain rect top) 0)
+              (>= (chain rect left) 0)
+              (<= (chain rect right) (chain window inner-width))
+              (<= (chain rect bottom) (chain window inner-height)))
+         t nil)))

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -141,12 +141,6 @@ If STEPS is negative, go to previous pages instead."
             (ffi-prompt-buffer-evaluate-javascript
              (current-window)
              (ps:ps
-               (defun element-in-view-port-p (element)
-                 ;; We are only concerned with vertical visibility.
-                 (ps:let* ((rect (ps:chain element (get-bounding-client-rect))))
-                   (if (and (>= (ps:chain rect top) 0)
-                            (<= (ps:chain rect bottom) (ps:chain window inner-height)))
-                       t nil)))
                (defun step-row (row)
                  (ps:chain
                   (aref (ps:chain row parent-node rows)
@@ -155,7 +149,7 @@ If STEPS is negative, go to previous pages instead."
                                   (+ (if (< 0 (ps:lisp steps)) 1 -1)
                                      (ps:chain row row-index)))))))
                (defun find-first-element-out-of-view (row)
-                 (if (element-in-view-port-p row)
+                 (if (nyxt/ps:element-in-view-port-p row)
                      (let ((new-row (step-row row)))
                        (if (eq new-row row)
                            row
@@ -343,24 +337,8 @@ Only available if `multi-selection-p' is non-nil."
   (ffi-prompt-buffer-evaluate-javascript
    window
    (ps:ps
-     (defun insert-at (tag input-text)
-       (let ((begin (ps:chain tag selection-start))
-             (end (ps:chain tag selection-end)))
-         (setf (ps:chain tag value)
-               (+ (ps:chain tag value (substring 0 begin))
-                  input-text
-                  (ps:chain tag value
-                            (substring end
-                                       (ps:chain tag value length)))))
-         (if (= begin end)
-             (progn
-               (setf (ps:chain tag selection-start) (+ begin (ps:chain input-text length)))
-               (setf (ps:chain tag selection-end) (ps:chain tag selection-start)))
-             (progn
-               (setf (ps:chain tag selection-start) begin)
-               (setf (ps:chain tag selection-end) (+ begin (ps:chain input-text length)))))))
-     (insert-at (ps:chain document (get-element-by-id "input"))
-                (ps:lisp (ring-insert-clipboard (nyxt::clipboard-ring *browser*)))))))
+     (nyxt/ps:insert-at (ps:chain document (get-element-by-id "input"))
+                        (ps:lisp (ring-insert-clipboard (nyxt::clipboard-ring *browser*)))))))
 
 (defun prompt-buffer-history-entries (&optional (window (current-window)))
   (sera:and-let* ((first-prompt-buffer (first (nyxt::active-prompt-buffers window))))

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -3,6 +3,16 @@
 
 (in-package :nyxt)
 
+(export-always 'qs)
+(ps:defpsmacro qs (context selector)
+  "Alias of document.querySelector"
+  `(ps:chain ,context (query-selector ,selector)))
+
+(export-always 'qsa)
+(ps:defpsmacro qsa (context selector)
+  "Alias of document.querySelectorAll"
+  `(ps:chain ,context (query-selector-all ,selector)))
+
 (export-always 'define-parenscript)
 (defmacro define-parenscript (script-name args &body script-body)
   "Define parenscript function SCRIPT-NAME.
@@ -27,8 +37,6 @@ The function can be passed ARGS."
 
 (export-always 'document-get-paragraph-contents)
 (define-parenscript document-get-paragraph-contents (&key (limit 100000))
-  (defun qsa (context selector)
-    (ps:chain context (query-selector-all selector)))
   (let ((result ""))
     (loop for element in (qsa document (list "p"))
           do (setf result (+ result

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -1,51 +1,6 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-(in-package :nyxt/parenscript)
-
-(defpsmacro qs (context selector)
-  "Alias of document.querySelector"
-  `(chain ,context (query-selector ,selector)))
-
-(defpsmacro qsa (context selector)
-  "Alias of document.querySelectorAll"
-  `(chain ,context (query-selector-all ,selector)))
-
-(defpsmacro insert-at (tag input-text)
-  "Insert text at a tag."
-  `(let ((origin (chain ,tag selection-start))
-         (end (chain ,tag selection-end)))
-     (setf (chain ,tag value)
-           (+ (chain ,tag value (substring 0 origin))
-              ,input-text
-              (chain ,tag value
-                     (substring end
-                                (chain ,tag value length)))))
-     (if (= origin end)
-         (progn
-           (setf (chain ,tag selection-start) (+ origin (chain ,input-text length)))
-           (setf (chain ,tag selection-end) (chain ,tag selection-start)))
-         (progn
-           (setf (chain ,tag selection-start) origin)
-           (setf (chain ,tag selection-end) (+ origin (chain ,input-text length)))))))
-
-(defpsmacro element-drawable-p (element)
-  "Is the element drawable?"
-  `(if (or (chain ,element offset-width)
-           (chain ,element offset-height)
-           (chain ,element (get-client-rects) length))
-       t nil))
-
-(defpsmacro element-in-view-port-p (element)
-  "Is the element in the view port?"
-  `(let* ((rect (chain ,element (get-bounding-client-rect))))
-     (if (and (>= (chain rect top) 0)
-              (>= (chain rect left) 0)
-              (<= (chain rect right) (chain window inner-width))
-              (<= (chain rect bottom) (chain window inner-height)))
-         t nil)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (in-package :nyxt)
 
 (export-always 'define-parenscript)

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -103,21 +103,21 @@ BODY must return the HTML markup as a string."
 
 (defpsmacro insert-at (tag input-text)
   "Insert text at a tag."
-  `(let ((start (chain tag selection-start))
+  `(let ((origin (chain tag selection-start))
          (end (chain ,tag selection-end)))
      (setf (chain ,tag value)
-           (+ (chain ,tag value (substring 0 start))
+           (+ (chain ,tag value (substring 0 origin))
               ,input-text
               (chain ,tag value
                      (substring end
                                 (chain ,tag value length)))))
-     (if (= start end)
+     (if (= origin end)
          (progn
-           (setf (chain ,tag selection-start) (+ start (ps:chain ,input-text length)))
+           (setf (chain ,tag selection-start) (+ origin (ps:chain ,input-text length)))
            (setf (chain ,tag selection-end) (ps:chain ,tag selection-start)))
          (progn
-           (setf (chain ,tag selection-start) start)
-           (setf (chain ,tag selection-end) (+ start (ps:chain ,input-text length)))))))
+           (setf (chain ,tag selection-start) origin)
+           (setf (chain ,tag selection-end) (+ origin (ps:chain ,input-text length)))))))
 
 (defpsmacro element-drawable-p (element)
   "Is the element drawable?"

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -1,6 +1,51 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
+(in-package :nyxt/parenscript)
+
+(defpsmacro qs (context selector)
+  "Alias of document.querySelector"
+  `(chain ,context (query-selector ,selector)))
+
+(defpsmacro qsa (context selector)
+  "Alias of document.querySelectorAll"
+  `(chain ,context (query-selector-all ,selector)))
+
+(defpsmacro insert-at (tag input-text)
+  "Insert text at a tag."
+  `(let ((origin (chain ,tag selection-start))
+         (end (chain ,tag selection-end)))
+     (setf (chain ,tag value)
+           (+ (chain ,tag value (substring 0 origin))
+              ,input-text
+              (chain ,tag value
+                     (substring end
+                                (chain ,tag value length)))))
+     (if (= origin end)
+         (progn
+           (setf (chain ,tag selection-start) (+ origin (chain ,input-text length)))
+           (setf (chain ,tag selection-end) (chain ,tag selection-start)))
+         (progn
+           (setf (chain ,tag selection-start) origin)
+           (setf (chain ,tag selection-end) (+ origin (chain ,input-text length)))))))
+
+(defpsmacro element-drawable-p (element)
+  "Is the element drawable?"
+  `(if (or (chain ,element offset-width)
+           (chain ,element offset-height)
+           (chain ,element (get-client-rects) length))
+       t nil))
+
+(defpsmacro element-in-view-port-p (element)
+  "Is the element in the view port?"
+  `(let* ((rect (chain ,element (get-bounding-client-rect))))
+     (if (and (>= (chain rect top) 0)
+              (>= (chain rect left) 0)
+              (<= (chain rect right) (chain window inner-width))
+              (<= (chain rect bottom) (chain window inner-height)))
+         t nil)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (in-package :nyxt)
 
 (export-always 'define-parenscript)
@@ -90,47 +135,3 @@ BODY must return the HTML markup as a string."
       ,buffer-var)
      (set-current-buffer ,buffer-var)
      ,buffer-var))
-
-(in-package :nyxt/parenscript)
-
-(defpsmacro qs (context selector)
-  "Alias of document.querySelector"
-  `(chain ,context (query-selector ,selector)))
-
-(defpsmacro qsa (context selector)
-  "Alias of document.querySelectorAll"
-  `(chain ,context (query-selector-all ,selector)))
-
-(defpsmacro insert-at (tag input-text)
-  "Insert text at a tag."
-  `(let ((origin (chain tag selection-start))
-         (end (chain ,tag selection-end)))
-     (setf (chain ,tag value)
-           (+ (chain ,tag value (substring 0 origin))
-              ,input-text
-              (chain ,tag value
-                     (substring end
-                                (chain ,tag value length)))))
-     (if (= origin end)
-         (progn
-           (setf (chain ,tag selection-start) (+ origin (ps:chain ,input-text length)))
-           (setf (chain ,tag selection-end) (ps:chain ,tag selection-start)))
-         (progn
-           (setf (chain ,tag selection-start) origin)
-           (setf (chain ,tag selection-end) (+ origin (ps:chain ,input-text length)))))))
-
-(defpsmacro element-drawable-p (element)
-  "Is the element drawable?"
-  `(if (or (ps:chain ,element offset-width)
-           (ps:chain ,element offset-height)
-           (ps:chain ,element (get-client-rects) length))
-       t nil))
-
-(defpsmacro element-in-view-port-p (element)
-  "Is the element in the view port?"
-  `(ps:let* ((rect (ps:chain ,element (get-bounding-client-rect))))
-     (if (and (>= (ps:chain rect top) 0)
-              (>= (ps:chain rect left) 0)
-              (<= (ps:chain rect right) (ps:chain window inner-width))
-              (<= (ps:chain rect bottom) (ps:chain window inner-height)))
-         t nil)))

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -3,16 +3,6 @@
 
 (in-package :nyxt)
 
-(export-always 'qs)
-(ps:defpsmacro qs (context selector)
-  "Alias of document.querySelector"
-  `(ps:chain ,context (query-selector ,selector)))
-
-(export-always 'qsa)
-(ps:defpsmacro qsa (context selector)
-  "Alias of document.querySelectorAll"
-  `(ps:chain ,context (query-selector-all ,selector)))
-
 (export-always 'define-parenscript)
 (defmacro define-parenscript (script-name args &body script-body)
   "Define parenscript function SCRIPT-NAME.
@@ -116,3 +106,20 @@ BODY must return the HTML markup as a string."
       ,buffer-var)
      (set-current-buffer ,buffer-var)
      ,buffer-var))
+
+(uiop:define-package nyxt/parenscript
+    (:nicknames :nyxt/ps)
+  (:use :common-lisp :nyxt :parenscript)
+  (:import-from #:serapeum #:export-always))
+
+(in-package :nyxt/parenscript)
+
+(export-always 'qs)
+(defpsmacro qs (context selector)
+  "Alias of document.querySelector"
+  `(chain ,context (query-selector ,selector)))
+
+(export-always 'qsa)
+(defpsmacro qsa (context selector)
+  "Alias of document.querySelectorAll"
+  `(chain ,context (query-selector-all ,selector)))

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -9,16 +9,8 @@
   (defvar *nodes* (ps:new (-Object)))
   (defvar *node-replacements* (array))
 
-  (defun qs (context selector)
-    "Alias of document.querySelector"
-    (ps:chain context (query-selector selector)))
-
-  (defun qsa (context selector)
-    "Alias of document.querySelectorAll"
-    (ps:chain context (query-selector-all selector)))
-
   (defun add-stylesheet ()
-    (unless (qs document "#nyxt-stylesheet")
+    (unless (nyxt:qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
                  (box-style (ps:lisp (box-style (current-mode 'web))))
@@ -97,7 +89,7 @@
 
   (defun remove-search-nodes ()
     "Removes all the search elements"
-    (ps:dolist (node (qsa document ".nyxt-search-node"))
+    (ps:dolist (node (nyxt:qsa document ".nyxt-search-node"))
       (ps:chain node (replace-with (aref *nodes* (ps:@ node id))))))
 
   (let ((*matches* (array))
@@ -133,12 +125,9 @@
 (define-command remove-search-hints ()
   "Remove all search hints."
   (pflet ((remove-search-hints ()
-            (defun qsa (context selector)
-              "Alias of document.querySelectorAll"
-              (ps:chain context (query-selector-all selector)))
             (defun remove-search-nodes ()
               "Removes all the search elements"
-              (ps:dolist (node (qsa document ".nyxt-search-node"))
+              (ps:dolist (node (nyxt:qsa document ".nyxt-search-node"))
                 (ps:chain node (replace-with (aref *nodes* (ps:@ node id))))))
             (remove-search-nodes)))
     (remove-search-hints)))

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -10,7 +10,7 @@
   (defvar *node-replacements* (array))
 
   (defun add-stylesheet ()
-    (unless (nyxt:qs document "#nyxt-stylesheet")
+    (unless (nyxt/ps:qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
                  (box-style (ps:lisp (box-style (current-mode 'web))))
@@ -89,7 +89,7 @@
 
   (defun remove-search-nodes ()
     "Removes all the search elements"
-    (ps:dolist (node (nyxt:qsa document ".nyxt-search-node"))
+    (ps:dolist (node (nyxt/ps:qsa document ".nyxt-search-node"))
       (ps:chain node (replace-with (aref *nodes* (ps:@ node id))))))
 
   (let ((*matches* (array))
@@ -127,7 +127,7 @@
   (pflet ((remove-search-hints ()
             (defun remove-search-nodes ()
               "Removes all the search elements"
-              (ps:dolist (node (nyxt:qsa document ".nyxt-search-node"))
+              (ps:dolist (node (nyxt/ps:qsa document ".nyxt-search-node"))
                 (ps:chain node (replace-with (aref *nodes* (ps:@ node id))))))
             (remove-search-nodes)))
     (remove-search-hints)))

--- a/source/visual-mode.lisp
+++ b/source/visual-mode.lisp
@@ -134,20 +134,6 @@ identifier for every hinted element."
     (ps:let ((hint-element (hint-create-element element hint)))
       (ps:chain document body (append-child hint-element))))
 
-  (defun element-drawable-p (element)
-    (if (or (ps:chain element offset-width)
-            (ps:chain element offset-height)
-            (ps:chain element (get-client-rects) length))
-        t nil))
-
-  (defun element-in-view-port-p (element)
-    (ps:let* ((rect (ps:chain element (get-bounding-client-rect))))
-      (if (and (>= (ps:chain rect top) 0)
-               (>= (ps:chain rect left) 0)
-               (<= (ps:chain rect right) (ps:chain window inner-width))
-               (<= (ps:chain rect bottom) (ps:chain window inner-height)))
-          t nil)))
-
   (defun object-create (element hint)
     (ps:create "type" "p" "hint" hint "identifier" hint "body" (ps:@ element |innerHTML|)))
 
@@ -158,13 +144,13 @@ identifier for every hinted element."
       (ps:chain |json|
                 (stringify
                  (loop for i from 0 to (- elements-length 1)
-                       when (and (element-drawable-p (elt elements i))
-                                 (element-in-view-port-p (elt elements i)))
+                       when (and (nyxt/ps:element-drawable-p (elt elements i))
+                                 (nyxt/ps:element-in-view-port-p (elt elements i)))
                          do (hint-add (elt elements i) (elt hints i))
-                       when (or (and (element-drawable-p (elt elements i))
+                       when (or (and (nyxt/ps:element-drawable-p (elt elements i))
                                      (not (ps:lisp annotate-visible-only-p)))
-                                (and (element-drawable-p (elt elements i))
-                                     (element-in-view-port-p (elt elements i))))
+                                (and (nyxt/ps:element-drawable-p (elt elements i))
+                                     (nyxt/ps:element-in-view-port-p (elt elements i))))
                          collect (object-create (elt elements i) (elt hints i)))))))
 
   (defun hints-determine-chars-length (length)

--- a/source/visual-mode.lisp
+++ b/source/visual-mode.lisp
@@ -80,7 +80,7 @@
 (define-parenscript add-paragraph-hints (&key annotate-visible-only-p)
   (defun qsa-text-nodes ()
     "Gets all text nodes"
-    (let ((elements (nyxt:qsa document "body, body *"))
+    (let ((elements (nyxt/ps:qsa document "body, body *"))
           child)
       (loop for element in elements
             do (setf child (ps:@ element child-nodes 0))
@@ -98,7 +98,7 @@
     (ps:chain -string (from-char-code n)))
 
   (defun add-stylesheet ()
-    (unless (nyxt:qs document "#nyxt-stylesheet")
+    (unless (nyxt/ps:qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
                  (box-style (ps:lisp (nyxt/web-mode::box-style (current-mode 'web))))
@@ -198,7 +198,7 @@ identifier for every hinted element."
     ("Body" ,(nyxt/web-mode::body hint))))
 
 (define-parenscript set-caret-on-start (&key nyxt-identifier)
-  (let ((el (nyxt:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))))
+  (let ((el (nyxt/ps:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))))
         (range (ps:chain document (create-range)))
         (sel (ps:chain window (get-selection))))
     (ps:chain window (focus))

--- a/source/visual-mode.lisp
+++ b/source/visual-mode.lisp
@@ -78,17 +78,9 @@
           (setf (mark-set mode) t))))))
 
 (define-parenscript add-paragraph-hints (&key annotate-visible-only-p)
-  (defun qs (context selector)
-    "Alias of document.querySelector"
-    (ps:chain context (query-selector selector)))
-
-  (defun qsa (context selector)
-    "Alias of document.querySelectorAll"
-    (ps:chain context (query-selector-all selector)))
-
   (defun qsa-text-nodes ()
     "Gets all text nodes"
-    (let ((elements (qsa document "body, body *"))
+    (let ((elements (nyxt:qsa document "body, body *"))
           child)
       (loop for element in elements
             do (setf child (ps:@ element child-nodes 0))
@@ -106,7 +98,7 @@
     (ps:chain -string (from-char-code n)))
 
   (defun add-stylesheet ()
-    (unless (qs document "#nyxt-stylesheet")
+    (unless (nyxt:qs document "#nyxt-stylesheet")
       (ps:try
        (ps:let* ((style-element (ps:chain document (create-element "style")))
                  (box-style (ps:lisp (nyxt/web-mode::box-style (current-mode 'web))))
@@ -206,10 +198,7 @@ identifier for every hinted element."
     ("Body" ,(nyxt/web-mode::body hint))))
 
 (define-parenscript set-caret-on-start (&key nyxt-identifier)
-  (defun qs (context selector)
-    "Alias of document.querySelector"
-    (ps:chain context (query-selector selector)))
-  (let ((el (qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))))
+  (let ((el (nyxt:qs document (ps:lisp (format nil "[nyxt-identifier=\"~a\"]" nyxt-identifier))))
         (range (ps:chain document (create-range)))
         (sel (ps:chain window (get-selection))))
     (ps:chain window (focus))


### PR DESCRIPTION
This turns our ubiquitous `qs` and `qsa` definitions into Parenscript macros, so that we have them defined in one place (renderer-script.lisp) and called everywhere, without writing any additional code.

# What's new
- `qs` and `qsa` rewritten as Parenscript macros.
- `ps:defpsmacro` used for the first time in Nyxt code, it seems (see Things to Discuss).
- Much less code duplication :D 

# Things To Discuss
Was there a reason to not define these as Parenscript macros before? I feel it's quite cool to leverage what Parenscript provides, especially with such universally useful utilities as `qs` and `qsa`, but am I missing some part of the picture?

# How Has This Been Tested
- Compiled.
- Ran.
- Tried `follow-hint`.
- It worked :)

What do you think of it? What else can we define as PS macros?