### PR TITLE
WIP: Headless mode with prompt buffer tests

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -290,7 +290,15 @@
                cl-gobject-introspection
                bordeaux-threads)
   :pathname "source/"
-  :components ((:file "renderer-gobject-gtk")))
+  :components ((:file "renderer-gobject-gtk"))
+  :in-order-to ((test-op (test-op "nyxt/gobject/gtk/tests"))))
+
+(defsystem "nyxt/gobject/gtk/tests"
+  :depends-on (nyxt/gobject/gtk prove)
+  :components ((:file "tests/renderer-package"))
+  :perform (test-op (op c)
+                    (nyxt-run-test c "tests/renderer-offline/")
+                    (nyxt-run-test c "tests/renderer-online/" :network-needed-p t)))
 
 (defsystem "nyxt/qt"
   :depends-on (nyxt

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -13,6 +13,10 @@
 This is useful when the browser is run from a REPL so that quitting does not
 close the connection.")
 
+(defvar *headless-p* nil
+  "If non-nil, don't display anything.
+This is convenient for testing purposes or to drive Nyxt programmatically.")
+
 (export-always '*browser*)
 (defvar *browser* nil
   "The entry-point object to a complete instance of Nyxt.

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -153,6 +153,7 @@ To access the suggestion instead, see `prompter:selected-suggestion'."
   ;; TODO: Add method that returns if there is only 1 source with no filter.
   (when prompt-buffer
     (push prompt-buffer (active-prompt-buffers (window prompt-buffer)))
+    (calispel:! (prompt-buffer-channel (window prompt-buffer)) prompt-buffer)
     (prompt-render prompt-buffer)
     (run-thread
       (watch-prompt prompt-buffer))
@@ -167,6 +168,8 @@ To access the suggestion instead, see `prompter:selected-suggestion'."
   ;; Note that PROMPT-BUFFER is not necessarily first in the list, e.g. a new
   ;; prompt-buffer was invoked before the old one reaches here.
   (alex:deletef (active-prompt-buffers (window prompt-buffer)) prompt-buffer)
+  ;; The channel values are irrelevant, so is the element order:
+  (calispel:? (prompt-buffer-channel (window prompt-buffer)) 0)
   (when (resumable-p prompt-buffer)
     (flet ((prompter= (prompter1 prompter2)
              (and (string= (prompter:prompt prompter1)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -269,7 +269,8 @@ Such contexts are not needed for internal buffers."
 
        (gtk:gtk-container-add gtk-object box-layout)
        (setf (slot-value *browser* 'last-active-window) window)
-       (gtk:gtk-widget-show-all gtk-object)
+       (unless *headless-p*
+        (gtk:gtk-widget-show-all gtk-object))
        (gobject:g-signal-connect
         gtk-object "key_press_event"
         (lambda (widget event) (declare (ignore widget))
@@ -738,7 +739,8 @@ See `gtk-browser's `modifier-translator' slot."
   "Set BROWSER's WINDOW buffer to BUFFER. "
   (gtk:gtk-container-remove (box-layout window) (gtk-object (active-buffer window)))
   (gtk:gtk-box-pack-start (box-layout window) (gtk-object buffer) :expand t)
-  (gtk:gtk-widget-show (gtk-object buffer))
+  (unless *headless-p*
+    (gtk:gtk-widget-show (gtk-object buffer)))
   (when focus
     (gtk:gtk-widget-grab-focus (gtk-object buffer)))
   buffer)

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -11,6 +11,12 @@
    (active-prompt-buffers '()
                           :export nil
                           :documentation "The stack of current prompt buffers.")
+   (prompt-buffer-channel (make-channel) ; TODO: Rename `prompt-buffer-ready-channel'?
+                          :export nil
+                          :documentation "A channel one may listen to if waiting
+for the prompt buffer to be available.
+You should not rely on the value of this channel.
+The channel is popped when a prompt buffer is hidden.")
    (key-stack '()
               :documentation "A stack that keeps track of the key chords a user has pressed.")
    (last-key nil

--- a/tests/renderer-online/set-url.lisp
+++ b/tests/renderer-online/set-url.lisp
@@ -1,0 +1,46 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nyxt/tests/renderer)
+
+(plan nil)
+
+(class-star:define-class nyxt-user::test-data-profile (nyxt:data-profile)
+  ((nyxt:name :initform "test"))
+  (:documentation "Test profile."))
+
+(defmethod nyxt:expand-data-path ((profile nyxt-user::test-data-profile) (path nyxt:data-path))
+  "Don't persist data"
+  nil)
+
+(defmacro with-prompt-buffer-test (command &body body)
+  (alexandria:with-gensyms (thread)
+    `(let ((,thread (bt:make-thread (lambda () ,command))))
+       (calispel:? (prompt-buffer-channel (current-window)))
+       ,@body
+       (return-selection)
+       (bt:join-thread ,thread))))
+
+;; TODO: Use `with-prompt-buffer-test'.
+;; (with-prompt-buffer-test (set-url)
+;;   (set-prompt-input (current-prompt-buffer) "foobar"))
+
+(subtest "set-url"
+  (setf nyxt::*headless-p* t)
+  (nyxt:start :no-init t :no-auto-config t
+              :socket "/tmp/nyxt-test.socket"
+              :data-profile "test")
+  (sleep 2)                             ; TODO: Wait properly.
+  (let ((url "http://example.org/"))
+    (let ((thread (bt:make-thread (lambda () (nyxt:set-url)))))
+      (calispel:? (nyxt::prompt-buffer-channel (nyxt:current-window)))
+      (nyxt::set-prompt-input (nyxt:current-prompt-buffer) url)
+      (prompter:all-ready-p (nyxt:current-prompt-buffer))
+      (nyxt/prompt-buffer-mode:return-selection)
+      ;; (bt:join-thread thread) ; TODO: Make sure thread always returns.
+      )
+    (sleep 1)                           ; TODO: Wait properly.
+    (prove:is (nyxt:render-url (nyxt:url (nyxt:current-buffer)))
+              url)))
+
+(finalize)

--- a/tests/renderer-package.lisp
+++ b/tests/renderer-package.lisp
@@ -1,0 +1,8 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package nyxt/tests/renderer
+  (:use #:common-lisp)
+  (:use #:nyxt)
+  (:use #:prove)
+  (:import-from #:class-star #:define-class))


### PR DESCRIPTION
This is a draft that shows how we can implement headless mode (see #1168) and makes use of this feature to test:

- The renderer;
- The interactive prompt buffer.

And it works!

A few points to address:

- "set-url" hangs on and off at `prompter:all-ready-p`.  Race condition?
- We need to add a few event signals, like:
  - when Nyxt is started and ready for interactions;
  - when URL is done loading (we already have this via methods, maybe tests could just add a default-mode to the tested buffer).
 
Thoughts?