### PR TITLE
Search autocompletion.

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -10,8 +10,8 @@
 (export-always '(make-hook-resource make-handler-resource))
 
 (define-class proxy ()
-  ((server-address (quri:uri "socks5://127.0.0.1:9050")
-                   :documentation "The address of the proxy server.
+  ((url (quri:uri "socks5://127.0.0.1:9050")
+        :documentation "The address of the proxy server.
 It's made of three components: protocol, host and port.
 Example: \"http://192.168.1.254:8080\".")
    (allowlist '("localhost" "localhost:8080")

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -292,17 +292,17 @@ reached (during which no new progress has been made)."
 ;; need to query the cookies for URL.  Thus we need to add an IPC endpoint to
 ;; query cookies.
 (export-always 'download)
-(defmethod download ((buffer buffer) url &key cookies (proxy-address :auto))
+(defmethod download ((buffer buffer) url &key cookies (proxy-url :auto))
   "Download URL.
-When PROXY-ADDRESS is :AUTO (the default), the proxy address is guessed from the
+When PROXY-URL is :AUTO (the default), the proxy address is guessed from the
 current buffer."
   (hooks:run-hook (before-download-hook *browser*) url) ; TODO: Set URL to download-hook result?
   (match (download-engine buffer)
     (:lisp
      (alex:when-let* ((path (download-path buffer))
                       (download-dir (expand-path path)))
-       (when (eq proxy-address :auto)
-         (setf proxy-address (proxy-address buffer :downloads-only t)))
+       (when (eq proxy-url :auto)
+         (setf proxy-url (proxy-url buffer :downloads-only t)))
        (let* ((download nil))
          (with-protect ("Download error: ~a" :condition)
            (with-data-access (downloads path)
@@ -310,7 +310,7 @@ current buffer."
                    (download-manager:resolve url
                                              :directory download-dir
                                              :cookies cookies
-                                             :proxy proxy-address))
+                                             :proxy proxy-url))
              (push download downloads)
              ;; Add a watcher / renderer for monitoring download
              (let ((download-render (make-instance 'download :url (render-url url))))
@@ -431,7 +431,7 @@ Deal with REQUEST-DATA with the following rules:
         ((not (known-type-p request-data))
          (log:debug "Buffer ~a initiated download of ~s." (id buffer) (render-url url))
          (download buffer url
-                   :proxy-address (proxy-address buffer :downloads-only t)
+                   :proxy-url (proxy-url buffer :downloads-only t)
                    :cookies "")
          ;; TODO: WebKitGTK emits "load-failed" if we call
          ;; webkit-policy-decision-ignore on a download requestion.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -44,6 +44,9 @@ after the mode-specific hook.")
 after the mode-specific hook.")
    (keymap-scheme-name scheme:cua
                        :documentation "The keymap scheme that will be used for all modes in the current buffer.")
+   (search-auto-complete-p t
+                           :type boolean
+                           :documentation "Whether search suggestions are requested and displayed.")
    (search-engines (list (make-instance 'search-engine
                                         :shortcut "wiki"
                                         :search-url "https://en.wikipedia.org/w/index.php?search=~a"

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -470,7 +470,7 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                             nil)))
 
 (declaim (ftype (function (buffer &key (:downloads-only boolean))) proxy-adress))
-(defun proxy-address (buffer &key (downloads-only nil))
+(defun proxy-url (buffer &key (downloads-only nil))
   "Return the proxy address, nil if not set.
 If DOWNLOADS-ONLY is non-nil, then it only returns the proxy address (if any)
 when `proxied-downloads-p' is true."

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -463,7 +463,7 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
   (setf (slot-value buffer 'proxy) proxy)
   (if proxy
       (ffi-buffer-set-proxy buffer
-                            (server-address proxy)
+                            (url proxy)
                             (allowlist proxy))
       (ffi-buffer-set-proxy buffer
                             (quri:uri "")
@@ -478,7 +478,7 @@ when `proxied-downloads-p' is true."
          (proxied-downloads (and proxy (proxied-downloads-p proxy))))
     (when (or (and (not downloads-only) proxy)
               proxied-downloads)
-      (server-address proxy))))
+      (url proxy))))
 
 (defmethod initialize-modes ((buffer buffer))
   "Initialize BUFFER modes.

--- a/source/proxy-mode.lisp
+++ b/source/proxy-mode.lisp
@@ -15,14 +15,14 @@ Example to use Tor as a proxy both for browsing and downloading:
 
 \(define-configuration nyxt/proxy-mode:proxy-mode
   ((nyxt/proxy-mode:proxy (make-instance 'proxy
-                                         :server-address (quri:uri \"socks5://localhost:9050\")
+                                         :url (quri:uri \"socks5://localhost:9050\")
                                          :allowlist '(\"localhost\" \"localhost:8080\")
                                          :proxied-downloads-p t))))
 
 \(define-configuration buffer
   ((default-modes (append '(proxy-mode) %slot-default%))))"
   ((proxy (make-instance 'proxy
-                 :server-address (quri:uri "socks5://localhost:9050")
+                 :url (quri:uri "socks5://localhost:9050")
                  :allowlist '("localhost" "localhost:8080")
                  :proxied-downloads-p t)
           :type proxy)
@@ -33,5 +33,5 @@ Example to use Tor as a proxy both for browsing and downloading:
     (lambda (mode)
       (setf (proxy (buffer mode)) (proxy mode))
       (echo "Proxy set to ~a (allowlisting ~a)."
-            (render-url (server-address (proxy mode)))
+            (render-url (url (proxy mode)))
             (allowlist (proxy mode)))))))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -56,7 +56,7 @@ want to change the behaviour of modifiers, for instance swap 'control' and
 
 (define-class gtk-buffer ()
   ((gtk-object)
-   (proxy-url (quri:uri ""))
+   (gtk-proxy-url (quri:uri ""))
    (proxy-ignored-hosts '())
    (data-manager-path (make-instance 'data-manager-data-path
                                      :dirname (uiop:xdg-cache-home +data-root+))
@@ -1024,7 +1024,7 @@ For the user-level interface, see `proxy-mode'.
 Note: WebKit supports three proxy 'modes': default (the system proxy),
 custom (the specified proxy) and none."
   (declare (type quri:uri proxy-url))
-  (setf (proxy-url buffer) proxy-url)
+  (setf (gtk-proxy-url buffer) proxy-url)
   (setf (proxy-ignored-hosts buffer) ignore-hosts)
   (let* ((context (webkit:webkit-web-view-web-context (gtk-object buffer)))
          (settings (cffi:null-pointer))
@@ -1045,7 +1045,7 @@ custom (the specified proxy) and none."
 (define-ffi-method ffi-buffer-get-proxy ((buffer gtk-buffer))
   "Return the proxy URL and list of ignored hosts (a list of strings) as second value."
   (the (values (or quri:uri null) list-of-strings)
-       (values (proxy-url buffer)
+       (values (gtk-proxy-url buffer)
                (proxy-ignored-hosts buffer))))
 
 (define-ffi-method ffi-buffer-set-zoom-level ((buffer gtk-buffer) value)

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -54,7 +54,13 @@ BASE-URL is a one-placeholder format string (e.g.,
 REQUEST-FUNCTION is the function to make this request with. Defaults to
 `dex:get'. Takes a URL built from user input and BASE-URL.
 PROCESSING-FUNCTION is a function to process whatever the REQUEST-FUNCTION
-returns. Should return a list of strings."
+returns. Should return a list of strings.
+
+Example (Tor-proxied completion function for Wikipedia):
+\(make-search-completion-function
+ :base-url \"https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=~a\"
+ :processing-function (alex:compose #'second #'json:decode-json-from-string)
+ :request-args '(:proxy \"socks5://localhost:9050\"))"
   #'(lambda (input)
       (funcall processing-function
                (apply request-function

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -41,9 +41,9 @@ Can be built via `make-search-completion-function'"))
 (defun proxied-get (url &rest args)
   "A version of `dex:get' that enables proxy in case `current-buffer' has one enabled."
   (let ((args (append args (list :proxy (and (web-buffer-p (current-buffer))
-                                             (proxy-address (current-buffer))
+                                             (proxy-url (current-buffer))
                                              (quri:render-uri
-                                              (proxy-address (current-buffer))))))))
+                                              (proxy-url (current-buffer))))))))
     (apply #'dex:get url args)))
 
 (export-always 'make-search-completion-function)


### PR DESCRIPTION
Behold! Search suggestions in Nyxt! (see an attached screenshot)

![autocompletion](https://user-images.githubusercontent.com/57838654/117065330-cfc15c00-ad40-11eb-8d43-d32c56ae40e3.png)

This adds search autocompletion requests to the default `search-engine`s, based on the new extensible mechanism:
- `completion-function` slot of `search-engine', and
- `make-search-completion-function` helper to make completion functions.

Works, loads things (although takes some time with both Wikipedia and DuckDuckGo), shows fancy search suggestions!

(I'm going to add completion functions to `nx-search-engines` right after we merge this, as this is too exciting to ignore!)

How does it look for you?

Closes #79.

EDIT: Small readability fixes.
EDIT: "deafult" typo :)
EDIT: Add a linked issue.