### PR TITLE
Rename gobject-gtk renderer to gi-gtk.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -37,12 +37,12 @@ to, use your local install of Quicklisp.  For example:
 But in this case, you don't have to use `make' at all.  Instead, you could build
 Nyxt with an invocation along those lines:
 
-    sbcl --eval '(asdf:load-asd "'$(pwd)'/nyxt.asd")' --eval '(ql:quickload :nyxt/gobject/gtk-application)' --quit
+    sbcl --eval '(asdf:load-asd "'$(pwd)'/nyxt.asd")' --eval '(ql:quickload :nyxt/gi-gtk-application)' --quit
 
 or, even shorter if Nyxt is checked out in a directory traversed by ASDF (like
 ~/common-lisp):
 
-    sbcl --eval '(ql:quickload :nyxt/gobject/gtk-application)' --quit
+    sbcl --eval '(ql:quickload :nyxt/gi-gtk-application)' --quit
 
 WARNING: Make sure your Quicklisp distribution is up-to-date when using
 NYXT_INTERNAL_QUICKLISP=false.  Also check the .gitmodules file for Common Lisp

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LISP ?= sbcl
 LISP_FLAGS ?= --no-userinit --non-interactive
 
 NYXT_INTERNAL_QUICKLISP=true
-NYXT_RENDERER=gobject/gtk
+NYXT_RENDERER=gi-gtk
 
 .PHONY: help
 help:

--- a/build-scripts/gi-shell.nix
+++ b/build-scripts/gi-shell.nix
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Atlas Engineer LLC
 # SPDX-License-Identifier: BSD-3-Clause
 
+# This file is meant to be used with the nyxt/gi-gtk system
+
 { pkgs ? import <nixpkgs> {} } :
 with builtins;
 let inherit (pkgs) stdenv; in

--- a/build-scripts/shell.nix
+++ b/build-scripts/shell.nix
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Atlas Engineer LLC
 # SPDX-License-Identifier: BSD-3-Clause
 
+# This file is meant to be used with the nyxt/gtk system
+
 { pkgs ? import <nixpkgs> {} } :
 with builtins;
 let inherit (pkgs) stdenv; in

--- a/nyxt-ubuntu-package.asd
+++ b/nyxt-ubuntu-package.asd
@@ -7,7 +7,7 @@
   :defsystem-depends-on (linux-packaging)
   :class "linux-packaging:deb"
   :build-operation "linux-packaging:build-op"
-  :depends-on (nyxt/gobject/gtk)
+  :depends-on (nyxt/gi-gtk)
   :package-name "nyxt"
   :version #.(asdf:system-version (asdf:find-system :nyxt))
   :author #.(asdf:system-author (asdf:find-system :nyxt))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -19,7 +19,7 @@
                      (format nil "~a/bin" *prefix*)))
 
 (defvar *nyxt-renderer* (or (uiop:getenv "NYXT_RENDERER")
-                            "gobject/gtk"))
+                            "gi-gtk"))
 
 (defsystem "nyxt"
   :version "2" ; Pre-release 6
@@ -331,12 +331,12 @@
   :pathname "source/"
   :components ((:file "renderer-gtk")))
 
-(defsystem "nyxt/gobject/gtk"
+(defsystem "nyxt/gi-gtk"
   :depends-on (nyxt/gtk
                cl-gobject-introspection
                bordeaux-threads)
   :pathname "source/"
-  :components ((:file "renderer-gobject-gtk")))
+  :components ((:file "renderer-gi-gtk")))
 
 (defsystem "nyxt/qt"
   :depends-on (nyxt
@@ -360,8 +360,8 @@
   :build-pathname "nyxt"
   :entry-point "nyxt:entry-point")
 
-(defsystem "nyxt/gobject/gtk-application"
-  :depends-on (nyxt/gobject/gtk)
+(defsystem "nyxt/gi-gtk-application"
+  :depends-on (nyxt/gi-gtk)
   :build-operation "program-op"
   :build-pathname "nyxt"
   :entry-point "nyxt:entry-point")

--- a/source/renderer-gi-gtk.lisp
+++ b/source/renderer-gi-gtk.lisp
@@ -13,7 +13,7 @@
 
 (in-package :nyxt)
 
-(setf +renderer+ "GObject-GTK")
+(setf +renderer+ "GI-GTK")
 (handler-bind ((warning #'muffle-warning))
   (defun renderer-thread-p ()
     (string= "main thread" (bt:thread-name (bt:current-thread))))

--- a/source/renderer-gi-gtk.lisp
+++ b/source/renderer-gi-gtk.lisp
@@ -18,7 +18,7 @@
   (defun renderer-thread-p ()
     (string= "main thread" (bt:thread-name (bt:current-thread))))
   (defmethod ffi-initialize ((browser gtk-browser) urls startup-timestamp)
-    (log:debug "Initializing GObject-GTK Interface")
+    (log:debug "Initializing GI-GTK Interface")
     (setf gtk-running-p t)
     (let ((main-thread (bt:make-thread
                         (lambda ()


### PR DESCRIPTION
Also rename the gobject/gtk system to gi-gtk.

Fixes #1361.