### PR TITLE
Nyxt quicklisp asd

### DIFF
--- a/.github/workflows/package-ubuntu.yml
+++ b/.github/workflows/package-ubuntu.yml
@@ -2,9 +2,9 @@ name: Build .deb package for latest Ubuntu
 
 on:
   push:
-    tags: '*'
+    # tags: '*'
     ## To test, uncomment the line below with branch name used for review.
-    # branches: [ MY-WORK-BRANCH ]
+    branches: [ nyxt-quicklisp-asd ]
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ endif
 
 lisp_eval:=$(LISP) $(LISP_FLAGS) \
 	--eval '(require "asdf")' \
+	--eval '(when (string= "$(NYXT_INTERNAL_QUICKLISP)" "true") (setf asdf:*default-source-registries* nil) (asdf:clear-configuration) (asdf:load-asd "$(makefile_dir)/nyxt-quicklisp.asd") (asdf:load-system :nyxt-quicklisp))' \
 	--eval '(asdf:load-asd "$(makefile_dir)/nyxt.asd")' \
-	--eval '(when (string= "$(NYXT_INTERNAL_QUICKLISP)" "true") (setf asdf:*default-source-registries* nil) (asdf:clear-configuration) (asdf:load-asd "$(makefile_dir)/nyxt.asd") (asdf:load-system :nyxt/quicklisp))' \
 	--eval
 lisp_quit:=--eval '(uiop:quit)'
 

--- a/build-scripts/build-ubuntu-package.sh
+++ b/build-scripts/build-ubuntu-package.sh
@@ -47,7 +47,7 @@ echo "==> Build package"
 sbcl \
     --disable-debugger \
     --eval '(require "asdf")' \
-		--eval '(asdf:load-system :nyxt/quicklisp)' \
+		--eval '(asdf:load-system :nyxt-quicklisp)' \
     --eval "(format t \"==> Quickloading linux-packaging...~%\")" \
     --eval "(ql:quickload :linux-packaging :silent t)" \
     --eval "(format t \"==> Quickloading :nyxt...~%\")" \

--- a/nyxt-quicklisp.asd
+++ b/nyxt-quicklisp.asd
@@ -18,48 +18,52 @@
                                          :ignore-error-status t
                                          :output t)))
 
-;; TODO: Extract body to top-level functions.
+(defun ensure-absolute-path (path component)
+  (if (uiop:absolute-pathname-p path)
+      path
+      (system-relative-pathname component path)))
+
+(defun load-quicklisp (component)
+  (handler-bind ((warning #'muffle-warning))
+    ;; Quicklisp's setup.lisp cannot be asdf:load-ed, we must use `load' here
+    ;; apparently, but ASDF triggers a warning on `load' calls inside ASDF
+    ;; operatings.
+    (load (format nil "~a/setup.lisp" (ensure-absolute-path *quicklisp-dir* component)))))
+
+(defun register-submodules (component)
+  ;; Ideally we should avoid writing global, stateful files to the user file
+  ;; system.  So instead of writing to the ASDF config file, we register the
+  ;; sudmodule directory with CL_SOURCE_REGISTRY.  This locally overrides
+  ;; CL_SOURCE_REGISTRY, but it's fine since submodules are only meant for
+  ;; non-developers (who probably don't set CL_SOURCE_REGISTRY).
+  ;;
+  ;; We must set this globally and we can't use
+  ;; `ql:*local-project-directories*' because the information
+  ;; would be lost within a Lisp compiler subprocess
+  ;; (e.g. as used by linux-packaging).
+  (setf (uiop:getenv "CL_SOURCE_REGISTRY")
+        (uiop:strcat
+         (namestring
+          (uiop:truenamize
+           (uiop:ensure-directory-pathname
+            (ensure-absolute-path *submodules-dir* component))))
+         ;; Double-slash tells ASDF to traverse the tree recursively.
+         "/"
+         ;; Register this directory so that nyxt.asd is included, just in case.
+         (uiop:inter-directory-separator)
+         (namestring (uiop:truenamize (uiop:pathname-directory-pathname
+                                       (asdf:system-source-file component))))
+         (if (uiop:getenv "CL_SOURCE_REGISTRY")
+             (uiop:strcat (uiop:inter-directory-separator) (uiop:getenv "CL_SOURCE_REGISTRY"))
+             ;; End with an empty string to tell ASDF to inherit configuration.
+             (uiop:inter-directory-separator))))
+  (asdf:clear-configuration)
+  (format t "; CL_SOURCE_REGISTRY: ~s~%" (uiop:getenv "CL_SOURCE_REGISTRY")))
+
 (defsystem "nyxt-quicklisp"
   :depends-on (nyxt-quicklisp/submodules)
   :perform (compile-op (o c)
-                       (handler-bind ((warning #'muffle-warning))
-                         ;; Quicklisp's setup.lisp cannot be asdf:load-ed, we
-                         ;; must use `load' here apparently, but ASDF triggers a
-                         ;; warning on `load' calls inside ASDF operatings.
-                         (load (format nil "~a/setup.lisp"
-                                       (if (uiop:absolute-pathname-p *quicklisp-dir*)
-                                           *quicklisp-dir*
-                                           (system-relative-pathname c *quicklisp-dir*)))))
-                       ;; Ideally we should avoid writing global, stateful files
-                       ;; to the user file system.  So instead of writing to the
-                       ;; ASDF config file, we register the sudmodule directory
-                       ;; with CL_SOURCE_REGISTRY.  This locally overrides
-                       ;; CL_SOURCE_REGISTRY, but it's fine since submodules are
-                       ;; only meant for non-developers (who probably don't set
-                       ;; CL_SOURCE_REGISTRY).
-                       ;;
-                       ;; We must set this globally and we can't use
-                       ;; `ql:*local-project-directories*' because the information
-                       ;; would be lost within a Lisp compiler subprocess
-                       ;; (e.g. as used by linux-packaging).
-                       (setf (uiop:getenv "CL_SOURCE_REGISTRY")
-                             (uiop:strcat
-                              (namestring
-                               (uiop:truenamize
-                                (uiop:ensure-directory-pathname
-                                 (if (uiop:absolute-pathname-p *submodules-dir*)
-                                     *submodules-dir*
-                                     (system-relative-pathname c *submodules-dir*)))))
-                              ;; Double-slash tells ASDF to traverse the tree recursively.
-                              "/"
-                              ;; Register this directory so that nyxt.asd is included, just in case.
-                              (uiop:inter-directory-separator)
-                              (namestring (uiop:truenamize (uiop:pathname-directory-pathname (asdf:system-source-file c))))
-                              (if (uiop:getenv "CL_SOURCE_REGISTRY")
-                                  (uiop:strcat (uiop:inter-directory-separator) (uiop:getenv "CL_SOURCE_REGISTRY"))
-                                  ;; End with an empty string to tell ASDF to inherit configuration.
-                                  (uiop:inter-directory-separator))))
-                       (asdf:clear-configuration)
-                       (format t "; CL_SOURCE_REGISTRY: ~s~%" (uiop:getenv "CL_SOURCE_REGISTRY"))
+                       (load-quicklisp c)
+                       (register-submodules c)
                        (funcall (read-from-string "ql:update-dist")
                                 "quicklisp" :prompt nil)))

--- a/nyxt-quicklisp.asd
+++ b/nyxt-quicklisp.asd
@@ -1,0 +1,65 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+;; This .asd is separate from nyxt.asd because running `ql:update-dist' and
+;; playing with the ASDF registries causes all sorts of issues, such as the
+;; nyxt.asd systems not being found afterwards.
+
+(defvar *quicklisp-dir* (or (uiop:getenv "NYXT_QUICKLISP_DIR")
+                           "_build/quicklisp-client"))
+(defvar *submodules-dir* (or (uiop:getenv "NYXT_SUBMODULES_DIR")
+                            "_build/submodules"))
+
+(defsystem "nyxt-quicklisp/submodules"
+  :perform (compile-op (o c)
+                       (uiop:run-program `("git"
+                                           "-C" ,(namestring (system-relative-pathname c ""))
+                                           "submodule" "update" "--init" "--force")
+                                         :ignore-error-status t
+                                         :output t)))
+
+;; TODO: Extract body to top-level functions.
+(defsystem "nyxt-quicklisp"
+  :depends-on (nyxt-quicklisp/submodules)
+  :perform (compile-op (o c)
+                       (handler-bind ((warning #'muffle-warning))
+                         ;; Quicklisp's setup.lisp cannot be asdf:load-ed, we
+                         ;; must use `load' here apparently, but ASDF triggers a
+                         ;; warning on `load' calls inside ASDF operatings.
+                         (load (format nil "~a/setup.lisp"
+                                       (if (uiop:absolute-pathname-p *quicklisp-dir*)
+                                           *quicklisp-dir*
+                                           (system-relative-pathname c *quicklisp-dir*)))))
+                       ;; Ideally we should avoid writing global, stateful files
+                       ;; to the user file system.  So instead of writing to the
+                       ;; ASDF config file, we register the sudmodule directory
+                       ;; with CL_SOURCE_REGISTRY.  This locally overrides
+                       ;; CL_SOURCE_REGISTRY, but it's fine since submodules are
+                       ;; only meant for non-developers (who probably don't set
+                       ;; CL_SOURCE_REGISTRY).
+                       ;;
+                       ;; We must set this globally and we can't use
+                       ;; `ql:*local-project-directories*' because the information
+                       ;; would be lost within a Lisp compiler subprocess
+                       ;; (e.g. as used by linux-packaging).
+                       (setf (uiop:getenv "CL_SOURCE_REGISTRY")
+                             (uiop:strcat
+                              (namestring
+                               (uiop:truenamize
+                                (uiop:ensure-directory-pathname
+                                 (if (uiop:absolute-pathname-p *submodules-dir*)
+                                     *submodules-dir*
+                                     (system-relative-pathname c *submodules-dir*)))))
+                              ;; Double-slash tells ASDF to traverse the tree recursively.
+                              "/"
+                              ;; Register this directory so that nyxt.asd is included, just in case.
+                              (uiop:inter-directory-separator)
+                              (namestring (uiop:truenamize (uiop:pathname-directory-pathname (asdf:system-source-file c))))
+                              (if (uiop:getenv "CL_SOURCE_REGISTRY")
+                                  (uiop:strcat (uiop:inter-directory-separator) (uiop:getenv "CL_SOURCE_REGISTRY"))
+                                  ;; End with an empty string to tell ASDF to inherit configuration.
+                                  (uiop:inter-directory-separator))))
+                       (asdf:clear-configuration)
+                       (format t "; CL_SOURCE_REGISTRY: ~s~%" (uiop:getenv "CL_SOURCE_REGISTRY"))
+                       (funcall (read-from-string "ql:update-dist")
+                                "quicklisp" :prompt nil)))


### PR DESCRIPTION
The Quicklisp-in-asd setup has given me enough headaches...

There is a whole class of problems we can get rid of if we just move the setup to its own .asd file.  This is what this pull request does.

WARNING: Don't merge before removing the .deb test commit!