### PR TITLE
Allow Nyxt to load extensions

### DIFF
--- a/.github/workflows/package-ubuntu.yml
+++ b/.github/workflows/package-ubuntu.yml
@@ -2,9 +2,9 @@ name: Build .deb package for latest Ubuntu
 
 on:
   push:
-    tags: '*'
+    # tags: '*'
     ## To test, uncomment the line below with branch name used for review.
-    # branches: [ MY-WORK-BRANCH ]
+    branches: [ nx-load ]
 
 jobs:
   build:

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -311,6 +311,11 @@
                      :executable t
                      :compression (uiop:getenv "NYXT_COMPRESS"))))
 
+(defmethod perform :before ((o image-op) (c system))
+  "Register immutable systems to prevent compiled images of Nyxt from
+trying to recompile dependencies"
+  (map () 'asdf:register-immutable-system (asdf:already-loaded-systems)))
+
 (defsystem "nyxt/install"
   :depends-on (alexandria
                str


### PR DESCRIPTION
### Synopsis
I've added the following to the end of `start.lisp`:

```
(map () 'asdf:register-preloaded-system (asdf:already-loaded-systems))
(map () 'asdf:register-immutable-system (asdf:already-loaded-systems))
```

This prevents attempted recompilation of already loaded systems in an image of Nyxt. This is critical for loading on NixOS. It prevents ASDF from attempting to recompile systems that it cannot (they are located in non-writable directories).

This therefore allows you to do:

```
(asdf:load-asd "/home/jmercouris/Source/Lisp/nx-kaomoji/nx-kaomoji.asd")
(asdf:load-system :nx-kaomoji :force-not t)
```

notice the key argument of `:force-not`. This is important. You can read more about it in the ASDF source code. Here is the documentation from `asdf::*immutable-systems*`:

```
"A hash-set (equal hash-table mapping keys to T) of systems that are immutable,
i.e. already loaded in memory and not to be refreshed from the filesystem.
They will be treated specially by find-system, and passed as :force-not argument to make-plan.

For instance, to can deliver an image with many systems precompiled, that *will not* check the
filesystem for them every time a user loads an extension, what more risk a problematic upgrade
 or catastrophic downgrade, before you dump an image, you may use:
   (map () 'asdf:register-immutable-system (asdf:already-loaded-systems))

Note that direct access to this variable from outside ASDF is not supported.
Please call REGISTER-IMMUTABLE-SYSTEM to add new immutable systems, and
contact maintainers if you need a stable API to do more than that."
```

### Questions
Please let me know if this also works for Guix. I believe it should also alleviate any problems on Ubuntu as well, though I do not have a deb to test against.

Also, please let me know if you can think of a better place to add (perhaps it belongs somewhere in the asd?):

```
(map () 'asdf:register-preloaded-system (asdf:already-loaded-systems))
(map () 'asdf:register-immutable-system (asdf:already-loaded-systems))
```