### PR TITLE
browser.lisp: remove ffi-prompt-buffer-evaluate-javascript

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -602,8 +602,6 @@ sometimes yields the wrong result."
 (define-ffi-generic ffi-buffer-load (buffer url))
 (define-ffi-generic ffi-buffer-evaluate-javascript (buffer javascript))
 (define-ffi-generic ffi-buffer-evaluate-javascript-async (buffer javascript))
-(define-ffi-generic ffi-prompt-buffer-evaluate-javascript (window javascript))
-(define-ffi-generic ffi-prompt-buffer-evaluate-javascript-async (window javascript))
 (define-ffi-generic ffi-buffer-enable-javascript (buffer value))
 (define-ffi-generic ffi-buffer-enable-javascript-markup (buffer value))
 (define-ffi-generic ffi-buffer-enable-smooth-scrolling (buffer value))

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -138,8 +138,8 @@ Actions can be listed and run with `return-selection-over-action' (bound to
 If STEPS is negative, go to previous pages instead."
   (unless (= 0 steps)
     (let ((step-page-index              ; TODO: Add multi-source support.
-            (ffi-prompt-buffer-evaluate-javascript
-             (current-window)
+            (ffi-buffer-evaluate-javascript
+             prompt-buffer
              (ps:ps
                (defun step-row (row)
                  (ps:chain
@@ -345,10 +345,10 @@ Only available if `multi-selection-p' is non-nil."
       (trivial-clipboard:text text)
       (echo "Copied ~s to clipboard." text))))
 
-(define-command prompt-buffer-paste (&optional (window (current-window)))
+(define-command prompt-buffer-paste ()
   "Paste clipboard text to input."
-  (ffi-prompt-buffer-evaluate-javascript
-   window
+  (ffi-buffer-evaluate-javascript
+   (current-prompt-buffer)
    (ps:ps
      (nyxt/ps:insert-at (ps:chain document (get-element-by-id "input"))
                         (ps:lisp (ring-insert-clipboard (nyxt::clipboard-ring *browser*)))))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -214,8 +214,8 @@ storing its value in a slot of the child."
 (defun prompt-render-prompt (prompt-buffer)
   (let* ((suggestions (prompter:all-suggestions prompt-buffer))
          (marks (prompter:all-marks prompt-buffer)))
-    (ffi-prompt-buffer-evaluate-javascript-async
-     (window prompt-buffer)
+    (ffi-buffer-evaluate-javascript-async
+     prompt-buffer
      (ps:ps
        (setf (ps:chain document (get-element-by-id "prompt-extra") |innerHTML|)
              (ps:lisp
@@ -283,8 +283,8 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                                              "marked")
                                                     (loop for (nil attribute) in (prompter:active-attributes suggestion :source source)
                                                           collect (markup:markup (:td attribute))))))))))))))
-      (ffi-prompt-buffer-evaluate-javascript-async
-       (window prompt-buffer)
+      (ffi-buffer-evaluate-javascript-async
+       prompt-buffer
        (ps:ps
          (setf (ps:chain document (get-element-by-id "suggestions") |innerHTML|)
                (ps:lisp
@@ -295,16 +295,16 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
     (prompt-render-prompt prompt-buffer)))
 
 (defun erase-document (prompt-buffer)
-  (ffi-prompt-buffer-evaluate-javascript-async
-   (window prompt-buffer)
+  (ffi-buffer-evaluate-javascript-async
+   prompt-buffer
    (ps:ps
      (ps:chain document (open))
      (ps:chain document (close)))))
 
 (defun prompt-render-skeleton (prompt-buffer)
   (erase-document prompt-buffer)
-  (ffi-prompt-buffer-evaluate-javascript-async
-   (window prompt-buffer)
+  (ffi-buffer-evaluate-javascript-async
+   prompt-buffer
    (ps:ps (ps:chain document
                     (write
                      (ps:lisp (markup:markup
@@ -326,8 +326,8 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                              '(:hidden "true")))))))))))))
 
 (defun prompt-render-focus (prompt-buffer)
-  (ffi-prompt-buffer-evaluate-javascript-async
-   (window prompt-buffer)
+  (ffi-buffer-evaluate-javascript-async
+   prompt-buffer
    (ps:ps (ps:chain document
                     (get-element-by-id "input")
                     (focus)))))
@@ -356,13 +356,11 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
 
 (defun set-prompt-buffer-input (input)
   "Set HTML INPUT in PROMPT-BUFFER."
-  (let ((window (current-window)))
-    (when (first (active-prompt-buffers window))
-      (ffi-prompt-buffer-evaluate-javascript
-       window
-       (ps:ps
-         (setf (ps:chain document (get-element-by-id "input") value)
-               (ps:lisp input)))))))
+  (ffi-buffer-evaluate-javascript
+   (current-prompt-buffer)
+   (ps:ps
+     (setf (ps:chain document (get-element-by-id "input") value)
+           (ps:lisp input)))))
 
 (export-always 'prompt)
 (sera:eval-always


### PR DESCRIPTION
This distinction between evaluating javascript within the prompt
buffer and within a regular buffer is no longer meaningful.