### PR TITLE
Scroll prompt buffer entries with mouse only when focused

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -650,3 +650,4 @@ sometimes yields the wrong result."
 (define-ffi-generic ffi-display-url (text))
 (define-ffi-generic ffi-buffer-cookie-policy (buffer value))
 (define-ffi-generic ffi-set-preferred-languages (buffer value))
+(define-ffi-generic ffi-focused-p (buffer))

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -32,9 +32,10 @@ Example:
     keymap))
 
 (export-always 'current-keymaps)
-(defun current-keymaps (&optional (buffer (if (active-prompt-buffers (current-window))
-                                              (current-prompt-buffer)
-                                              (current-buffer))))
+(defun current-keymaps (&optional (buffer (let ((prompt-buffer (current-prompt-buffer)))
+                                            (if (and prompt-buffer (ffi-focused-p prompt-buffer))
+                                                prompt-buffer
+                                                (current-buffer)))))
   "Return the list of `keymap' for the current buffer, ordered by priority.
 If non-empty, return the result of BUFFER's `current-keymaps-hook' instead."
   (let ((keymaps

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -28,6 +28,8 @@ Actions can be listed and run with `return-selection-over-action' (bound to
        "escape" 'cancel-input
        "down" 'select-next
        "up" 'select-previous
+       "button5" 'select-next
+       "button4" 'select-previous
        "home" 'select-first
        "end" 'select-last
        "pagehome" 'select-first

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -1165,3 +1165,6 @@ As a second value, return the current buffer index starting from 0."
   (webkit:webkit-web-view-go-to-back-forward-list-item
    (gtk-object buffer)
    (webkit-history-entry-gtk-object history-entry)))
+
+(define-ffi-method ffi-focused-p ((buffer gtk-buffer))
+  (gtk:gtk-widget-is-focus (gtk-object buffer)))


### PR DESCRIPTION
This is a natural follow-up to #1392 and finally a fix to #399.