### PR TITLE
History tree dummy buffer fix

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -354,8 +354,9 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
 (define-user-class editor-buffer)
 
 (defun make-dummy-buffer ()
-  ;; Internal buffers are lighter than full-blown buffers which can have a
-  ;; WebKit context, etc.
+  "Internal buffers are lighter than full-blown buffers which can have a
+WebKit context, etc.
+Delete it with `ffi-buffer-delete'."
   (make-instance 'user-internal-buffer))
 
 (define-class status-buffer (user-internal-buffer)
@@ -670,6 +671,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
 
 (declaim (ftype (function (buffer)) buffer-delete))
 (defun buffer-delete (buffer)
+  "For dummy buffers, use `ffi-buffer-delete' instead."
   (hooks:run-hook (buffer-delete-hook buffer) buffer)
   (let ((parent-window (find buffer (window-list) :key 'active-buffer)))
     (when parent-window

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -424,9 +424,8 @@ Otherwise go forward to the only child."
   (nyxt::with-current-html-buffer (output-buffer "*History*"
                                                  'nyxt/history-tree-mode:history-tree-mode)
     (with-data-unsafe (history (let ((dummy-buffer (nyxt::make-dummy-buffer)))
-                                 (prog1
-                                     (history-path dummy-buffer)
-                                   (delete-buffer :id (id dummy-buffer)))))
+                                 (prog1 (history-path dummy-buffer)
+                                   (ffi-buffer-delete dummy-buffer))))
       (let ((markup:*auto-escape* nil)
             (mode (find-submode output-buffer 'nyxt/history-tree-mode:history-tree-mode))
             (tree `(:ul ,(htree:map-tree

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -423,9 +423,7 @@ Otherwise go forward to the only child."
   "Open a new buffer displaying the whole history tree."
   (nyxt::with-current-html-buffer (output-buffer "*History*"
                                                  'nyxt/history-tree-mode:history-tree-mode)
-    (with-data-unsafe (history (let ((dummy-buffer (nyxt::make-dummy-buffer)))
-                                 (prog1 (history-path dummy-buffer)
-                                   (ffi-buffer-delete dummy-buffer))))
+    (with-data-unsafe (history (history-path (current-buffer)))
       (let ((markup:*auto-escape* nil)
             (mode (find-submode output-buffer 'nyxt/history-tree-mode:history-tree-mode))
             (tree `(:ul ,(htree:map-tree


### PR DESCRIPTION
Fixes #1393.

@aartaka Why did you originally go for a dummy buffer to retrieve the history data?  Am I doing something wrong by getting the current buffer history path?