### PR TITLE
Recursive describe

### DIFF
--- a/source/help-mode.lisp
+++ b/source/help-mode.lisp
@@ -10,6 +10,5 @@
 (define-mode help-mode ()
   "Mode for displaying documentation."
   ((rememberable-p nil)
-   (target nil
-           :type t
-           :documentation "The value being inspected.")))
+   (inspected-value nil
+                    :type t)))

--- a/source/help-mode.lisp
+++ b/source/help-mode.lisp
@@ -9,4 +9,7 @@
 
 (define-mode help-mode ()
   "Mode for displaying documentation."
-  ((rememberable-p nil)))
+  ((rememberable-p nil)
+   (target nil
+           :type t
+           :documentation "The value being inspected.")))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -56,13 +56,12 @@
              for i below (length value)
              collect (markup:markup
                       (:li (:a :href (lisp-url `(describe-value
-                                                 (nth ,i ,(nyxt/help-mode:target help-mode))))
+                                                 (nth ,i ,(nyxt/help-mode:inspected-value help-mode))))
                                e)))))))
     ((has-attributes-method-p value)
      (markup:markup
       (:ul
-       (loop for (attribute-key attribute-value) in (prompter:object-attributes
-                                                     value)
+       (loop for (attribute-key attribute-value) in (prompter:object-attributes value)
              collect (markup:markup
                       (:li attribute-key ": " (:code attribute-value)))))))
     (t
@@ -72,7 +71,7 @@
   "Inspect VALUE and show it in a help buffer."
   (with-current-html-buffer (buffer "*Help-value*" 'nyxt/help-mode:help-mode)
     (let ((help-mode (find-mode buffer 'help-mode)))
-      (setf (nyxt/help-mode:target help-mode) value)
+      (setf (nyxt/help-mode:inspected-value help-mode) value)
       (markup:markup
        (:style (style buffer))
        (:h1 (princ-to-string value))
@@ -90,7 +89,7 @@
                                    (str:concat "*Help-" (symbol-name input) "*")
                                    'nyxt/help-mode:help-mode)
           (let ((help-mode (find-mode buffer 'help-mode)))
-            (setf (nyxt/help-mode:target help-mode) input)
+            (setf (nyxt/help-mode:inspected-value help-mode) input)
             (markup:markup
              (:style (style buffer))
              (:h1 (format nil "~s" input)) ; Use FORMAT to keep package prefix.

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -48,12 +48,6 @@ for which the `executable' slot is non-nil."
                (class-name (class-of interface))
                (password:executable interface))))
 
-(defun has-method-p (object generic-function)
-  "Return non-nil if OBJECT is a specializer of a method of GENERIC-FUNCTION."
-  (find-if (alex:curry #'typep object)
-           (alex:mappend #'closer-mop:method-specializers
-                         (closer-mop:generic-function-methods generic-function))))
-
 (define-command save-new-password (&optional (buffer (current-buffer)))
   "Save password to password interface."
   (password-debug-info)

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -26,12 +26,16 @@ If URL-STRING cannot be converted to a `quri:uri' object, return an empty `quri:
 If a URL string cannot be converted to a `quri:uri', it is discarded from the result."
   (remove-if #'url-empty-p (mapcar #'string->url url-strings)))
 
-(defun has-url-method-p (object)
+(defun has-method-p (object generic-function)
   "Return non-nil if OBJECT has `url' specialization."
   (some (lambda (method)
           (subtypep (type-of object) (class-name
                                       (first (closer-mop:method-specializers method)))))
-        (closer-mop:generic-function-methods  #'url)))
+        (closer-mop:generic-function-methods generic-function)))
+
+(defun has-url-method-p (object)
+  "Return non-nil if OBJECT has `url' specialization."
+  (has-method-p object #'url))
 
 (deftype url-designator ()
   `(satisfies has-url-method-p))

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -27,7 +27,7 @@ If a URL string cannot be converted to a `quri:uri', it is discarded from the re
   (remove-if #'url-empty-p (mapcar #'string->url url-strings)))
 
 (defun has-method-p (object generic-function)
-  "Return non-nil if OBJECT has `url' specialization."
+  "Return non-nil if OBJECT has GENERIC-FUNCTION specialization."
   (some (lambda (method)
           (subtypep (type-of object) (class-name
                                       (first (closer-mop:method-specializers method)))))


### PR DESCRIPTION
Try describing `*interfaces*` or any global variable that's a list of things.  Now you can click on the element to describe them.

I've used the trick to store the value being inspected in the mode-local variable `target`, otherwise the `lisp://` URL may not be able to refer to the value when it's unprintable like with structures.

This may not be the most general nor future-proof design.

Thoughts?