### PR TITLE
package: Unuse trivia, remove alex and sera nicknames.

### DIFF
--- a/source/package.lisp
+++ b/source/package.lisp
@@ -22,16 +22,30 @@
   (:export :repl-mode))
 
 (uiop:define-package nyxt-user
-  (:use #:common-lisp #:trivia #:nyxt)
+  (:use #:common-lisp #:nyxt)
   (:import-from #:keymap #:define-key #:define-scheme)
   (:import-from #:class-star #:define-class)
   (:documentation "
 Package left for the user to fiddle with.
 If the configuration file package is left unspecified, it default to this.
-It's not recommended to use `nyxt' itself to avoid clobbering internal symbols."))
-(eval-when (:compile-toplevel :load-toplevel :execute)
+It's not recommended to use `nyxt' itself to avoid clobbering internal symbols.
+
+By default, the `:nyxt' and `:common-lisp' packages are `:use'd.
+
+To import more symbols, you can use the `import' function.
+For instance, to access `match' directly (without having to prefix it with
+`trivia:', add this at the top of your configuration file:
+
+  (import 'trivia:match)
+
+You can also use package local nicknames if you want to abbreviate package
+prefix.
+For instance, to be able to use `alex:' and `sera:' in place of `alexandria:'
+and `serapeum:':
+
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nyxt-user)
-  (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum :nyxt-user)
+  (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum :nyxt-user)"))
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :hooks :serapeum/contrib/hooks :nyxt-user))
 
 ;; Unlike other modes, nyxt/prompt-buffer-mode is declared here because


### PR DESCRIPTION
I believe this is essential to guarantee a stable API.

First, we should not `:use` trivia.  At best we should `import-from` `match` and `match-lambda`.
But better leave this to the user, really.

Indeed, should we `use` package which we don't control, and should these packages API change, an update to the offending package may break the user configuration.

Same with local nicknames: `sera` effectively binds us to Serapeum forever.  What if we want to get rid of it?
What if we decide someday to use `a:` instead of `alex`?

For all these reasons, I believe it's better to leave it to the user to decide which symbols they want to import, and which nicknames they want to use.