### PR TITLE
status-buffer: vi mode indicator

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -395,7 +395,7 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                 :padding-left "10px"
                 :text-align "center")
                (".overlap"
-                :grid-column-start "span 2")
+                :grid-column "span 3")
                ("#url"
                 :background-color "rgb(120,120,120)"
                 :min-width "100px"

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -382,14 +382,20 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                 :clip-path "polygon(0 50%, 100% 100%, 100% 0)")
                ("#container"
                 :display "grid"
-                ;; Columns: controls, arrow, url, arrow, tabs, arrow, modes
-                :grid-template-columns "115px 10px 1fr 10px 2fr 10px 250px"
+                ;; Columns: controls, arrow, vi-status, arrow, url, arrow, tabs, arrow, modes
+                :grid-template-columns "115px 10px 20px 10px 1fr 10px 2fr 10px 250px"
                 :overflow-y "hidden")
                ("#controls"
                 :background-color "rgb(80,80,80)"
                 :padding-left "5px"
                 :overflow "hidden"
                 :white-space "nowrap")
+               ("#vi-mode"
+                :margin-left "-10px"
+                :padding-left "10px"
+                :text-align "center")
+               (".overlap"
+                :grid-column-start "span 2")
                ("#url"
                 :background-color "rgb(120,120,120)"
                 :min-width "100px"

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -281,7 +281,7 @@ instance must be non-nil.")
         (:code "~/.local/share/nyxt/extensions")".")
     (:p "Extensions are regular Common Lisp systems.")
     (:p "A catalogue of extensions is available in the "
-        (:code "document/EXTENSIONS.org") "file in the source repository.")
+        (:code "document/EXTENSIONS.org") " file in the source repository.")
 
     (:h2 "Troubleshooting")
     (:h3 "Playing videos")

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -24,6 +24,17 @@
    (:a :class "button" :title "Execute" :href (lisp-url '(nyxt:execute-command)) "⚙")
    (:a :class "button" :title "Buffers" :href (lisp-url '(nyxt::list-buffers)) "≡")))
 
+(export-always 'format-status-vi-mode)
+(defun format-status-vi-mode (&optional (buffer (current-buffer)))
+  (cond ((find-submode buffer 'vi-normal-mode)
+         (markup:markup
+          (:a :class "button" :title "Vi normal mode" :href (lisp-url '(nyxt/vi-mode:vi-insert-mode)) "N")))
+        ((find-submode buffer 'vi-insert-mode)
+         (markup:markup
+          (:a :class "button" :title "Vi insert mode" :href (lisp-url '(nyxt/vi-mode:vi-normal-mode)) "I")))
+        (t (markup:markup
+            (:span "")))))
+
 (export-always 'format-status-load-status)
 (defun format-status-load-status (buffer)
   (markup:markup
@@ -54,13 +65,27 @@
                        (lisp-url `(nyxt::switch-buffer-or-query-domain ,domain)) domain))))))
 
 (defun format-status (window)
-  (let ((buffer (current-buffer window)))
+  (let* ((buffer (current-buffer window))
+         (vi-mode-color (cond ((find-submode buffer 'vi-normal-mode)
+                               "background-color:rgb(100,100,100);")
+                              ((find-submode buffer 'vi-insert-mode)
+                               "background-color:rgb(105,38,38);")))
+         (url-class (if vi-mode-color
+                        ""
+                        "")))
+                        ;; "overlap")))
     (markup:markup
      (:div :id "container"
            (:div :id "controls"
+                 :class url-class
                  (markup:raw (format-status-buttons)))
            (:div :class "arrow arrow-right"
                  :style "background-color:rgb(80,80,80)" "")
+           (:div :id "vi-mode"
+                 :style vi-mode-color
+                 (markup:raw (format-status-vi-mode buffer)))
+           (:div :class "arrow arrow-right"
+                 :style vi-mode-color "")
            (:div :id "url"
                  (markup:raw
                   (format-status-load-status buffer)

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -28,10 +28,12 @@
 (defun format-status-vi-mode (&optional (buffer (current-buffer)))
   (cond ((find-submode buffer 'vi-normal-mode)
          (markup:markup
-          (:a :class "button" :title "Vi normal mode" :href (lisp-url '(nyxt/vi-mode:vi-insert-mode)) "N")))
+          (:div
+           (:a :class "button" :title "vi-normal-mode" :href (lisp-url '(nyxt/vi-mode:vi-insert-mode)) "N"))))
         ((find-submode buffer 'vi-insert-mode)
          (markup:markup
-          (:a :class "button" :title "Vi insert mode" :href (lisp-url '(nyxt/vi-mode:vi-normal-mode)) "I")))
+          (:div
+           (:a :class "button" :title "vi-insert-mode" :href (lisp-url '(nyxt/vi-mode:vi-normal-mode)) "I"))))
         (t (markup:markup
             (:span "")))))
 
@@ -69,24 +71,26 @@
          (vi-mode-color (cond ((find-submode buffer 'vi-normal-mode)
                                "background-color:rgb(100,100,100);")
                               ((find-submode buffer 'vi-insert-mode)
-                               "background-color:rgb(105,38,38);")))
-         (url-class (if vi-mode-color
-                        ""
-                        "")))
-                        ;; "overlap")))
+                               "background-color:#37a8e4;")))
+         ;; hide vi-mode status and adjacent arrow when not enabled
+         (vi-mode-display (when (not vi-mode-color)
+                              "display: none;"))
+         (vi-mode-style (concatenate 'string vi-mode-color vi-mode-display))
+         (url-class (when (not vi-mode-color)
+                             "overlap")))
     (markup:markup
      (:div :id "container"
            (:div :id "controls"
-                 :class url-class
                  (markup:raw (format-status-buttons)))
            (:div :class "arrow arrow-right"
                  :style "background-color:rgb(80,80,80)" "")
            (:div :id "vi-mode"
-                 :style vi-mode-color
+                 :style vi-mode-style
                  (markup:raw (format-status-vi-mode buffer)))
            (:div :class "arrow arrow-right"
-                 :style vi-mode-color "")
+                 :style vi-mode-style "")
            (:div :id "url"
+                 :class url-class
                  (markup:raw
                   (format-status-load-status buffer)
                   (format-status-url buffer)))


### PR DESCRIPTION
This adds a vi mode indicator in the status buffer when `vi-normal-mode` or `vi-insert-mode` are enabled. There is some flickering in the status buffer when changing modes - I'm not sure how to fix that.
Also, my branch's history is messed up, but I assume that you'll squash the commits :)