### PR TITLE
Replace default-modes with initialize-modes method.

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -230,7 +230,7 @@ The rules are:
 (defun initialize-auto-mode (mode)
   (unless (last-active-modes mode)
     (setf (last-active-modes mode)
-          (mode-invocations (default-modes (buffer mode)))))
+          (mode-invocations (modes (buffer mode)))))
   (when (prompt-on-mode-toggle mode)
     (hooks:add-hook (enable-mode-hook (buffer mode))
                     (nyxt::make-handler-mode

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -131,8 +131,8 @@ Example:
   \"Blocker mode with custom hosts from `*my-blocked-hosts*'.\"
   ((nyxt/blocker-mode:hostlists (list *my-blocked-hosts* nyxt/blocker-mode:*default-hostlist*))))
 
-\(define-configuration buffer
-  ((default-modes (append '(my-blocker-mode) %slot-default%))))"
+\(defmethod initialize-modes :after ((buffer buffer))
+  (make-mode 'my-blocker-mode buffer))"
   ((hostlists (list *default-hostlist*))
    (destructor
     (lambda (mode)

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -181,8 +181,10 @@ The `%slot-default%' variable is replaced by the slot initform.
 Example that sets some defaults for all buffers:
 
 \(define-configuration (buffer web-buffer)
-  ((status-buffer-height 24)
-   (default-modes (append '(vi-normal-mode) %slot-default%))))
+  ((status-buffer-height 24)))
+
+\(defmethod initialize-mode :after ((buffer buffer))
+  (make-mode 'vi-normal-mode buffer))
 
 Example to get the `blocker-mode' command to use a new default hostlists:
 
@@ -190,7 +192,7 @@ Example to get the `blocker-mode' command to use a new default hostlists:
   ((nyxt/blocker-mode:hostlists (append (list *my-blocked-hosts*) %slot-default%))))
 
 In the above, `%slot-default%' will be substituted with the default value of
-`default-modes'.
+`hostlists'.
 
 In the last example, `nyxt/blocker-mode:user-blocker-mode' is defined to inherit
 from the original `blocker-mode' and a generated class containing the

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -160,7 +160,7 @@ identifier for every hinted element."
   (let* ((buffer (current-buffer)))
     (let ((result (prompt
                    :prompt prompt
-                   :default-modes '(element-hint-mode prompt-buffer-mode)
+                   :extra-modes '(element-hint-mode)
                    :history nil
                    :sources
                    (make-instance

--- a/source/emacs-mode.lisp
+++ b/source/emacs-mode.lisp
@@ -14,8 +14,8 @@ in your configuration file.
 
 Example:
 
-\(define-configuration buffer
-  ((default-modes (append '(emacs-mode) %slot-default%))))"
+\(defmethod initialize-modes ((buffer buffer))
+  (make-mode 'emacs-mode buffer))"
   ((glyph "ε")
    (previous-keymap-scheme-name nil
     :type (or keymap:scheme-name null)

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -63,8 +63,8 @@ To permanently bypass the \"Unacceptable TLS Certificate\" error:
 
 Example:
 
-\(define-configuration buffer
-  ((default-modes (append '(force-https-mode) %slot-default%))))"
+\(defmethod initialize-modes ((buffer buffer))
+ (make-mode 'force-https-mode buffer))"
   ((previous-url (quri:uri ""))
    (destructor
     (lambda (mode)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -278,26 +278,22 @@ CLASS can be a class symbol or a list of class symbols, as with
             buffers.")
      (:h2 "Keybinding style")
      (:p (:a :class "button"
-             :href (lisp-url `(nyxt::configure-slot
-                               'default-modes
-                               '(buffer web-buffer)
-                               :value '%slot-default%)
+             :href (lisp-url `(defmethod initialize-modes :after ((buffer buffer))
+                                (call-next-method))
                              `(nyxt/emacs-mode:emacs-mode :activate nil)
                              `(nyxt/vi-mode:vi-normal-mode :activate nil))
              "Use default (CUA)"))
      (:p (:a :class "button"
-             :href (lisp-url `(nyxt::configure-slot
-                               'default-modes
-                               '(buffer web-buffer)
-                               :value '(append '(emacs-mode) %slot-default%))
+             :href (lisp-url `(defmethod initialize-modes :after ((buffer buffer))
+                                (call-next-method)
+                                (make-mode 'emacs-mode buffer))
                              `(nyxt/emacs-mode:emacs-mode :activate t)
                              `(nyxt/vi-mode:vi-normal-mode :activate nil))
              "Use Emacs"))
      (:p (:a :class "button"
-             :href (lisp-url `(nyxt::configure-slot
-                               'default-modes
-                               '(buffer web-buffer)
-                               :value '(append '(vi-normal-mode) %slot-default%))
+             :href (lisp-url `(defmethod initialize-modes :after ((buffer buffer))
+                                (call-next-method)
+                                (make-mode 'vi-normal-mode buffer))
                              `(nyxt/vi-mode:vi-normal-mode :activate t)
                              `(nyxt/emacs-mode:emacs-mode :activate nil))
              "Use vi"))
@@ -460,7 +456,7 @@ The version number is stored in the clipboard."
 (declaim (ftype (function (function-symbol &key (:modes list))) binding-keys))
 (defun binding-keys (fn &key (modes (if (current-buffer)
                                         (modes (current-buffer))
-                                        (mapcar #'make-instance (default-mode-symbols)))))
+                                        *default-modes*)))
   ;; We can't use `(modes (make-instance 'buffer))' because modes are only
   ;; instantiated after the buffer web view, which is not possible if there is
   ;; no *browser*.

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -37,8 +37,8 @@ file " (:code (expand-path *init-file-path*)) " (create the parent folders if
 necessary).")
     (:p "Example:")
     (:pre (:code "
-\(define-configuration buffer
-  ((default-modes (append '(noscript-mode) %slot-default%))))"))
+(defmethod initialize-modes :after ((buffer buffer))
+ (make-mode 'noscript-mode buffer))"))
     (:p "The above turns on the 'noscript-mode' (disables JavaScript) by default for
 every buffer.")
     (:p "The " (:code "define-configuration") " macro can be used to customize
@@ -54,10 +54,7 @@ the `web-buffer' and the `internal-buffer' classes inherit from the `buffer'
 class.")
     (:p "You can configure a `buffer' slot and it will automatically become the
 new default for both the `internal-buffer' and `web-buffer' classes unless this
-slot is specialized by these child classes.  For example, since the
-`default-modes' slot is specialized by the `web-buffer' class, if you want to
-include `my-mode' you'll need to configure both the `buffer' and the
-`web-buffer' classes.")
+slot is specialized by these child classes.")
 
     (:h3 "Keybinding configuration")
     (:p "Nyxt supports multiple " (:i "bindings schemes") " such as CUA (the default), Emacs or VI.  Changing scheme is as simple as running the corresponding mode, e.g. "
@@ -66,12 +63,12 @@ add the following to your configuration:")
     (:ul
      (:li "VI bindings:"
       (:pre (:code "
-\(define-configuration (buffer web-buffer)
-  ((default-modes (append '(vi-normal-mode) %slot-default%))))")))
+(defmethod initialize-modes :after ((buffer buffer))
+  (make-mode 'vi-normal-mode buffer))")))
      (:li "Emacs bindings:"
       (:pre (:code "
-\(define-configuration (buffer web-buffer)
-  ((default-modes (append '(emacs-mode) %slot-default%))))"))))
+(defmethod initialize-modes :after ((buffer buffer))
+  (make-mode 'vi-normal-mode buffer))"))))
     (:p "You can create new scheme names with " (:code "keymap:make-scheme-name")
         ".  See also the " (:code "scheme-name") " class and the "
         (:code "define-scheme") " macro.")
@@ -99,8 +96,8 @@ have priorities over the other modes key bindings.")
                    scheme:emacs *my-keymap*
                    scheme:vi-normal *my-keymap*))))
 
-\(define-configuration (buffer web-buffer)
-  ((default-modes (append '(my-mode) %slot-default%))))"))
+(defmethod initialize-modes :after ((buffer buffer))
+  (make-mode 'my-mode buffer))"))
 
     (:h3 "Search engines")
     (:p "See the " (:code "search-engines") " buffer slot documentation.

--- a/source/proxy-mode.lisp
+++ b/source/proxy-mode.lisp
@@ -19,8 +19,8 @@ Example to use Tor as a proxy both for browsing and downloading:
                                          :allowlist '(\"localhost\" \"localhost:8080\")
                                          :proxied-downloads-p t))))
 
-\(define-configuration buffer
-  ((default-modes (append '(proxy-mode) %slot-default%))))"
+(defmethod initialize-modes :after ((buffer buffer))
+  (make-mode 'proxy-mode buffer))"
   ((proxy (make-instance 'proxy
                  :url (quri:uri "socks5://localhost:9050")
                  :allowlist '("localhost" "localhost:8080")

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -14,8 +14,8 @@ in your configuration file.
 
 Example:
 
-\(define-configuration buffer
-  ((default-modes (append '(vi-normal-mode) %slot-default%))))"
+(defmethod initialize-modes :after ((buffer buffer))
+  (make-mode 'vi-normal-mode buffer))"
   ((previous-keymap-scheme-name nil
     :type (or keymap:scheme-name null)
     :documentation "The previous keymap scheme that will be used when ending


### PR DESCRIPTION
Fixes #1383, #1355.

The user cannot use `define-configuration` because the `default-modes` slot is not longer writable.

Instead, you are expected to use regular CLOS.  Example to enable VI bindings everywhere:

```lisp
(defmethod initialize-modes :after ((buffer buffer) &key)
  (nyxt::make-mode 'vi-normal-mode buffer))
```

Pretty cool, nah?

Now why can't we leverage `define-configuration`?  Because this macro works over the initforms of user classes.

Here what we want is different: we want a given slot list value to cascade down the subclasses.  CLOS is perfect for that thanks to `call-next-method`.

EDIT: This implements the technique mentioned in #1005, but in a different context.  So this is useful ground work for #1005.