### PR TITLE
Combine-append buffer default-modes.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -30,12 +30,6 @@ See the `data-path' class and the `expand-path' function.")
 Modes are instantiated after the `default-modes' slot, with `initialize-modes'
 and not in the initform so that the instantiation form can access the
 initialized buffer.")
-   (default-modes '()
-                  :writer t
-                  :export t
-                  :type list-of-symbols
-                  :documentation "The symbols of the modes to instantiate on buffer creation.
-The mode instances are stored in the `modes' slot.")
    (enable-mode-hook (make-hook-mode)
                      :type hook-mode
                      :documentation "Hook run on every mode activation,
@@ -247,17 +241,19 @@ separated from one another, so that each has its own behaviour and settings."))
 
 (define-user-class buffer)
 
+(export-always 'default-modes)
 (defgeneric default-modes (buffer)
   (:method-combination append)
   (:method append ((buffer buffer))
     '(web-mode base-mode))
-  (:documentation "Return the default modes appended to the default modes
-inherited from the superclasses.
-Duplicates are removed."))
+  (:documentation "The symbols of the modes to instantiate on buffer creation.
+The mode instances are stored in the `modes' BUFFER slot.
+
+The default modes returned by this method are appended to the default modes
+inherited from the superclasses.  Duplicates are removed."))
 
 (defmethod default-modes :around ((buffer buffer))
-  "Return the list of default modes for BUFFER.
-Duplicates are removed."
+  "Remove the duplicates from the `default-modes'."
   (remove-duplicates (call-next-method)
                      ;; Mode at the beginning of the list have higher priorities.
                      :from-end t))

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -160,7 +160,7 @@ identifier for every hinted element."
   (let* ((buffer (current-buffer)))
     (let ((result (prompt
                    :prompt prompt
-                   :default-modes '(element-hint-mode prompt-buffer-mode)
+                   :default-modes '(element-hint-mode) ; TODO: Unknown keyword arg.
                    :history nil
                    :sources
                    (make-instance

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -160,7 +160,7 @@ identifier for every hinted element."
   (let* ((buffer (current-buffer)))
     (let ((result (prompt
                    :prompt prompt
-                   :default-modes '(element-hint-mode) ; TODO: Unknown keyword arg.
+                   :extra-modes '(element-hint-mode)
                    :history nil
                    :sources
                    (make-instance

--- a/source/force-https-mode.lisp
+++ b/source/force-https-mode.lisp
@@ -63,7 +63,7 @@ To permanently bypass the \"Unacceptable TLS Certificate\" error:
 
 Example:
 
-\(define-configuration buffer
+\(define-configuration web-buffer
   ((default-modes (append '(force-https-mode) %slot-default%))))"
   ((previous-url (quri:uri ""))
    (destructor

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -54,10 +54,7 @@ the `web-buffer' and the `internal-buffer' classes inherit from the `buffer'
 class.")
     (:p "You can configure a `buffer' slot and it will automatically become the
 new default for both the `internal-buffer' and `web-buffer' classes unless this
-slot is specialized by these child classes.  For example, since the
-`default-modes' slot is specialized by the `web-buffer' class, if you want to
-include `my-mode' you'll need to configure both the `buffer' and the
-`web-buffer' classes.")
+slot is specialized by these child classes.")
 
     (:h3 "Keybinding configuration")
     (:p "Nyxt supports multiple " (:i "bindings schemes") " such as CUA (the default), Emacs or VI.  Changing scheme is as simple as running the corresponding mode, e.g. "

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -364,6 +364,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                            '(&rest args)
                            `(&key ,@(delete-duplicates
                                      (append
+                                      '(extra-modes)
                                       (public-initargs 'prompt-buffer)
                                       (public-initargs 'prompter:prompter)))))
       "Open the prompt buffer, ready for user input.
@@ -384,11 +385,15 @@ See the documentation of `prompt-buffer' to know more about the options."
        *browser*
        (lambda ()
          (let ((prompt-buffer (apply #'make-instance 'user-prompt-buffer
-                                     (append args
+                                     (append (alex:remove-from-plist args :extra-modes)
                                              (list
                                               :window (current-window)
                                               :result-channel result-channel
                                               :interrupt-channel interrupt-channel)))))
+           ;; REVIEW: More elegant way to initialize extra modes?
+           ;; We could subclass the prompt buffer, but that more boilerplate
+           ;; code for the user.
+           (mapc (alex:rcurry #'make-mode prompt-buffer) extra-modes)
            (setf parent-thread-prompt-buffer prompt-buffer)
            (show-prompt-buffer prompt-buffer))))
       (calispel:fair-alt

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -18,8 +18,7 @@ All ARGS are declared as `ignorable'."
 
 (sera:eval-always
   (define-class prompt-buffer (user-internal-buffer prompter:prompter)
-    ((default-modes '(prompt-buffer-mode))
-     (window nil
+    ((window nil
              :type (or null window)
              :export nil
              :documentation "The window in which the prompt buffer is showing.")
@@ -130,6 +129,11 @@ invoking `prompt-buffer-history'.
 See `prompt' for how to invoke prompts.")))
 
 (define-user-class prompt-buffer)
+
+(defmethod default-modes append ((buffer prompt-buffer))
+  '(prompt-buffer-mode))
+(defmethod default-modes :around ((buffer prompt-buffer))
+  (set-difference (call-next-method) '(web-mode base-mode)))
 
 (defmethod initialize-instance :after ((prompt-buffer prompt-buffer) &key)
   (hooks:run-hook (prompt-buffer-make-hook *browser*) prompt-buffer)


### PR DESCRIPTION
This is an alternative to #1411.

It uses an `append` method combination.
Unlike what I commented in #1411, this does not allow for using `define-configuration` either.  But still, it's cleaner and less intrusive than #1411 I believe, so I'm in favour of this one.

As per `define-configuration` support, we could expand the macro to add support for generic functions.

For instance,

```lisp
(define-configuration buffer
  ((default-modes '(foo)))
```

would automatically detact that default-modes is a defgeneric with a non-standard method combination and thus expand to

```lisp
(defmethod default-modes append ((buffer buffer)
  '(foo)))
```

Thoughts?