### PR TITLE
Replace some commands / options with prompt-buffer actions

### DIFF
--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -27,7 +27,6 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-r" 'reload-current-buffer
                      "C-R" 'reload-buffers
                      "C-m o" 'set-url-from-bookmark
-                     "C-m C-o" 'set-url-from-bookmark-new-buffer
                      "C-m s" 'bookmark-current-url
                      "C-d" 'bookmark-current-url
                      "C-m C-s" 'bookmark-buffer-url
@@ -86,7 +85,6 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-d" 'list-downloads
                      "M-x" 'execute-command
                      "C-x r j" 'set-url-from-bookmark
-                     "C-x r J" 'set-url-from-bookmark-new-buffer
                      "C-x r M" 'bookmark-current-url
                      "C-x r m" 'bookmark-buffer-url
                      "C-x r k" 'delete-bookmark
@@ -113,7 +111,6 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "R" 'reload-current-buffer
                      "r" 'reload-buffers
                      "m o" 'set-url-from-bookmark
-                     "m O" 'set-url-from-bookmark-new-buffer
                      "m m" 'bookmark-buffer-url
                      "m M" 'bookmark-current-url
                      "y u" 'copy-url

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -228,22 +228,30 @@ equals only comparing URLs."
                 (set-difference bookmarks
                                 entries :test #'equals))))))
 
-(define-command set-url-from-bookmark ()
+(define-command set-url-from-bookmark (&key (actions (list :buffer-load :new-buffer-load)))
   "Set the URL for the current buffer from a bookmark.
 With multiple selections, open the first bookmark in the current buffer, the
 rest in background buffers."
-  (prompt
-   :prompt "Open bookmark(s)"
-   ;; :default-modes '(minibuffer-tag-mode minibuffer-mode) ; TODO: Replace this behaviour.
-   :sources (make-instance 'bookmark-source
-                           :actions (list (make-command buffer-load* (suggestion-values)
-                                            "Load first selected bookmark in current buffer and the rest in new buffer(s)."
-                                            (mapc (lambda (url) (make-buffer :url url)) (rest suggestion-values))
-                                            (buffer-load (url (first suggestion-values))))
-                                          (make-command new-buffer-load (suggestion-values)
-                                            "Load bookmark(s) in new buffer(s)."
-                                            (mapc (lambda (url) (make-buffer :url url)) (rest suggestion-values))
-                                            (make-buffer-focus :url (url (first suggestion-values))))))))
+  (let* ((possible-actions
+           (list :buffer-load
+                 (make-command buffer-load* (suggestion-values)
+                   "Load first selected bookmark in current buffer and the rest in new buffer(s)."
+                   (mapc (lambda (url) (make-buffer :url url)) (rest suggestion-values))
+                   (buffer-load (url (first suggestion-values))))
+                 :new-buffer-load
+                 (make-command new-buffer-load (suggestion-values)
+                   "Load bookmark(s) in new buffer(s)."
+                   (mapc (lambda (url) (make-buffer :url url)) (rest suggestion-values))
+                   (make-buffer-focus :url (url (first suggestion-values))))))
+         (selected-actions
+           (loop for action in actions
+                 when (getf possible-actions action)
+                 collect (getf possible-actions action))))
+    (prompt
+     :prompt "Open bookmark(s)"
+     ;; :default-modes '(minibuffer-tag-mode minibuffer-mode) ; TODO: Replace this behaviour.
+     :sources (make-instance 'bookmark-source
+                             :actions selected-actions))))
 
 (defmethod serialize-object ((entry bookmark-entry) stream)
   (unless (url-empty-p (url entry))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -75,11 +75,6 @@ This can be used to resume former buffers.")
    (recent-buffers (make-ring :size 50)
                    :export nil
                    :documentation "A ring that keeps track of deleted buffers.")
-   (focus-on-reopened-buffer-p t ; TODO: Replace this with prompt-buffer Helm-style actions.
-                               :documentation "When reopening a closed buffer,
-focus on it instead of opening it in the background.
-
-Warning: This setting may be deprecated in a future release, don't rely on it.")
    (windows (make-hash-table :test #'equal)
             :export nil)
    (total-window-count 0

--- a/source/recent-buffers.lisp
+++ b/source/recent-buffers.lisp
@@ -14,7 +14,7 @@
   (containers:delete-item-if (recent-buffers *browser*)
                              (buffer-match-predicate buffer))
   (let ((new-buffer (buffer-make *browser* :dead-buffer buffer)))
-    (reload-buffer new-buffer)
+    (reload-buffers (list new-buffer))
     new-buffer))
 
 (define-class recent-buffer-source (prompter:source)

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -101,7 +101,8 @@ Example (Tor-proxied completion function for Wikipedia):
 
 (define-class search-engine-url-source (prompter:source)
   ((prompter:name "Search Engines")
-   (prompter:constructor (delete nil (mapcar #'fallback-url (all-search-engines))))))
+   (prompter:constructor (delete nil (mapcar #'fallback-url (all-search-engines))))
+   (prompter:multi-selection-p t)))
 
 (define-command query-selection-in-search-engine ()
   "Search selected text using the queried search engine."

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -169,7 +169,6 @@ removed from the input, they are also removed from the existing bookmark.")
     (:li (command-markup 'bookmark-url) ": Same as above but prompt for a URL first.")
     (:li (command-markup 'nyxt/web-mode:bookmark-hint) ": Same as above but prompt for a hinted URL first.")
     (:li (command-markup 'set-url-from-bookmark) ": Open bookmark in current buffer.")
-    (:li (command-markup 'set-url-from-bookmark-new-buffer) ": Open bookmark in new buffer.")
     (:li (command-markup 'delete-bookmark) ": Delete queried bookmarks.")
     (:li (command-markup 'list-bookmarks) ": Display a new buffer containing the
 list of all bookmarks."))


### PR DESCRIPTION
First commit replace focus-on-reopended-buffer-p with an action.
It also dusts of the old recent-buffer code.

More commits to come where I'll move bookmark and history related commands to actions.