### PR TITLE
Add Nyxt major version feature.

### DIFF
--- a/source/package.lisp
+++ b/source/package.lisp
@@ -6,7 +6,7 @@
 (pushnew
  (intern (format nil "NYXT-~a"
                  (first (uiop:parse-version
-                         (asdf:system-version (asdf:find-system :nyxt)))))
+                         (asdf:component-version (asdf:find-system :nyxt)))))
          "KEYWORD")
  *features*)
 

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -3,6 +3,13 @@
 
 (in-package :cl-user)
 
+(pushnew
+ (intern (format nil "NYXT-~a"
+                 (first (uiop:parse-version
+                         (asdf:system-version (asdf:find-system :nyxt)))))
+         "KEYWORD")
+ *features*)
+
 ;; Some compilers (e.g. SBCL) fail to reload the system with `defpackage' when
 ;; exports are spread around.  `uiop:define-package' does not have this problem.
 (uiop:define-package nyxt


### PR DESCRIPTION
This will be useful for users and extensions to maintain backward compatibility.