### PR TITLE
Report build-time information

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,8 @@ assignees: ''
 - How you installed Nyxt (Guix pack, package manager, build from source):
 - Information from command copy-system-information:
 
-  If you can't run copy-system-information, please provide the following:
+  If you can't run copy-system-information, try `nyxt --system-information` from
+  a shell.  It this still does not work, please provide the following:
   - Nyxt version (from =M-x nyxt-version= or =nyxt --version=):
   - Lisp implementation/version (if built from source):
   - Kernel name+version:

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -50,6 +50,41 @@ execution of Nyxt.")
 (export-always '+newline+)
 (alex:define-constant +newline+ (string #\newline) :test #'equal)
 
+(alex:define-constant +nyxt-critical-dependencies+
+  '(:cl-cffi-gtk
+    :cl-gobject-introspection
+    :cl-webkit2)
+  :test #'equal)
+
+(defvar +asdf-build-information+
+  `(:version ,(asdf:asdf-version)
+    :critical-dependencies ,(mapcar (lambda (s)
+                                      (nth-value 2 (asdf:locate-system s)))
+                                    +nyxt-critical-dependencies+))
+  "Build-time ASDF information.
+Don't set this, it would lose its meaning.")
+
+(defvar +guix-build-information+
+  (when (sera:resolve-executable "guix")
+    `(:version
+      ;; `guix describe' is not reliable within `guix environment'.
+      ,(fourth (sera:tokens
+                (first (sera:lines
+                        (uiop:run-program '("guix" "--version") :output :string)))))))
+  "Build-time Guix information.
+Don't set this, it would lose its meaning.")
+
+(defvar +quicklisp-build-information+
+  #+quicklisp
+  `(:dist-version ,(ql:dist-version "quicklisp")
+    :client-version ,(ql:client-version)
+    :local-project-directories ,ql:*local-project-directories*
+    :critical-dependencies ,(mapcar #'ql-dist:find-system +nyxt-critical-dependencies+))
+  #-quicklisp
+  nil
+  "Build-time Quicklisp information.
+Don't set this, it would lose its meaning.")
+
 (export-always '+version+)
 (alex:define-constant +version+
   (or (uiop:getenv "NYXT_VERSION")      ; This is useful for build systems without Git.

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -65,6 +65,9 @@ Return nil if `*init-file-path*' is nil."
     (:name :version
      :long "version"
      :description "Print version and exit.")
+    (:name :system-information
+     :long "system-information"
+     :description "Print system information and exit.")
     (:name :init
      :short #\i
      :long "init"
@@ -439,6 +442,9 @@ Examples:
 
     ((getf options :version)
      (format t "Nyxt version ~a~&" +version+))
+
+    ((getf options :system-information)
+     (princ (system-information)))
 
     ((getf options :list-data-profiles)
      (load-lisp (expand-path *init-file-path*) :package (find-package :nyxt-user))


### PR DESCRIPTION
As discussed here: https://github.com/atlas-engineer/nyxt/issues/1410#issuecomment-841624498

This reports ASDF, Quicklisp and Guix build-time information.  This should help us.

It also adds a --system-information command line option.

QUESTION: Should I remove `--system-information` and replace it with `--verbose --version` instead?