### PR TITLE
Force request-resource on every request, don't allow users to customize it out

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -394,10 +394,8 @@ view.")
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(export-always 'request-resource)
-(defun request-resource (request-data)
-  "Candidate for `request-resource-hook'.
-Deal with REQUEST-DATA with the following rules:
+(defun preprocess-request (request-data)
+  "Deal with REQUEST-DATA with the following rules:
 - If a binding matches KEYS in `request-resource-scheme', run the bound function.
 - If `new-window-p' is non-nil, load in new buffer.
 - If `known-type-p' is nil, download the file.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -122,8 +122,7 @@ should find its place there.")
 `request-resource-hook' handlers run.
 The functions are expected to take key arguments like `:url'.")
    (request-resource-hook (make-hook-resource
-                           :combination #'combine-composed-hook-until-nil
-                           :handlers (list #'request-resource))
+                           :combination #'combine-composed-hook-until-nil)
                           :type hook-resource
                           :documentation "Hook run on every resource load.
 The handlers are composed, passing a `request-data'
@@ -942,7 +941,7 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
       (check-type new-url quri:uri)
       (setf url new-url)
       ;; TODO: This condition can be a source of inefficiency.  Besides, it
-      ;; partly duplicates the code in `request-resource'.  Can we factor this
+      ;; partly duplicates the code in `preprocess-request'.  Can we factor this
       ;; out?
       (cond
         ((and (internal-buffer-p buffer) (equal "lisp" (quri:uri-scheme url)))


### PR DESCRIPTION
Addresses the most urgent part of #1094, namely to force-run `request-resource`.

Breaking news: Scheme handling is done _after_ `on-decide-policy`, so unfortunately @aartaka's approach won't cut it to fix the load order problem.  As such, I've decided to not handle the schemes at all since it seemingly does not add any benefit compared to the `on-decide-policy` signal.
This is not critical for security though.

So I guess the only way forward to properly intercept requests before the load starts is to leverage `send-request` from a WebKit extension, as mentioned here: https://github.com/atlas-engineer/nyxt/issues/1094#issuecomment-832454345.

Anyways, this pull request should be good enough for 2.0.  Thoughts?