### PR TITLE
Developer manual should indicate that quicklisp needs to load the new gtk which is gi-gtk

### DIFF
--- a/documents/README.org
+++ b/documents/README.org
@@ -347,7 +347,7 @@ Then in a shell execute the following:
 2. Execute ~(require :asdf)~ if ASDF is not already loaded.
 3. Execute ~(asdf:load-asd "/full/path/to/nyxt.asd")~ to load the Nyxt
    system definition (you must use absolute pathnames).
-4. Execute ~(ql:quickload :nyxt/gtk)~ to load the Nyxt system into your
+4. Execute ~(ql:quickload :nyxt/gi-gtk)~ to load the Nyxt system into your
    Lisp image.
 5. Execute ~(nyxt:start)~ to open your first Nyxt window.
 


### PR DESCRIPTION
Hi,

This is a tiny change on the readme of Nyxt's Developer Manual. 

It fixes issue #1445 which was opened by me earlier today.

Thanks for your attention.