### PR TITLE
Add username copying to password manager.

### DIFF
--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -27,14 +27,28 @@
                                       password-name
                                       ;; Timeout for password
                                       (format nil "~a" (sleep-timer password-interface)))
+      :input st :output '(:string :stripped t))))
+
+(defmethod clip-username ((password-interface keepassxc-interface) &key password-name service)
+  (declare (ignore service))
+  (with-input-from-string (st (master-password password-interface))
+    (execute password-interface (list "clip"
+                                      "--attribute" "username"
+                                      (password-file password-interface)
+                                      password-name
+                                      ;; Timeout for password
+                                      (format nil "~a" (sleep-timer password-interface)))
              :input st :output '(:string :stripped t))))
 
-(defmethod save-password ((password-interface keepassxc-interface) &key password-name password service)
+(defmethod save-password ((password-interface keepassxc-interface)
+                          &key password-name username password service)
   (declare (ignore service))
   (with-input-from-string (st (format nil "~a~C~a"
                                       (master-password password-interface)
                                       #\newline password))
-    (execute password-interface (list "add" "--password-prompt" (password-file password-interface)
+    (execute password-interface (list "add"
+                                      "--username" username
+                                      "--password-prompt" (password-file password-interface)
                                       (if (str:emptyp password-name)
                                           "--generate"
                                           password-name))

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -29,4 +29,8 @@
                         "-a" password-name "-s" service "-g")
                   :error-output '(:string :stripped t)))))))
 
+(defmethod clip-username ((password-interface security-interface) &key password-name service)
+  (declare (ignore password-name service))
+  (error "Username clipping is not supported by security interface."))
+
 (defmethod password-correct-p ((password-interface security-interface)) t)

--- a/libraries/password-manager/password-security.lisp
+++ b/libraries/password-manager/password-security.lisp
@@ -15,7 +15,7 @@
 (push 'security-interface *interfaces*)
 
 (defmethod list-passwords ((password-interface security-interface))
-  (error "Listing passwords not supported by security interface."))
+  (error "Listing passwords not supported by the 'security' interface."))
 
 (defmethod clip-password ((password-interface security-interface) &key password-name service)
   (clip-password-string password-interface

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -13,35 +13,35 @@
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'list-passwords))
+;; From Serapeum:
+(defmacro export-always (symbols &optional (package nil package-supplied?))
+  "Like `export', but also evaluated at compile time."
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (export ,symbols ,@(and package-supplied? (list package)))))
+
+(export-always 'list-passwords)
 (defgeneric list-passwords (password-interface)
   (:documentation "Retrieve all available passwords."))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'clip-password))
+(export-always 'clip-password)
 (defgeneric clip-password (password-interface &key password-name service)
   (:documentation "Retrieve specific password by name."))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'clip-username))
+(export-always 'clip-username)
 (defgeneric clip-username (password-interface &key password-name service)
   (:documentation "Retrieve specific login by name of the password entry."))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'save-password))
+(export-always 'save-password)
 (defgeneric save-password (password-interface
                            &key password-name username password service)
   (:documentation "Save password to database.
 If PASSWORD-NAME is empty, then generate a new password."))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'password-correct-p))
+(export-always 'password-correct-p)
 (defgeneric password-correct-p (password-interface)
   (:documentation "Return T if set password is correct, NIL otherwise."))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export 'complete-interface))
+(export-always 'complete-interface)
 (defgeneric complete-interface (password-interface)
   (:method ((password-interface password-interface))
     password-interface)
@@ -77,6 +77,5 @@ Return nil if COMMAND is not found anywhere."
    (uiop:run-program (format nil "command -v ~A" command)
                      :output '(:string :stripped t))))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (export '*interfaces*))
+(export-always '*interfaces*)
 (defvar *interfaces* (list))

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -24,8 +24,14 @@
   (:documentation "Retrieve specific password by name."))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
+  (export 'clip-username))
+(defgeneric clip-username (password-interface &key password-name service)
+  (:documentation "Retrieve specific login by name of the password entry."))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'save-password))
-(defgeneric save-password (password-interface &key password-name password service)
+(defgeneric save-password (password-interface
+                           &key password-name username password service)
   (:documentation "Save password to database.
 If PASSWORD-NAME is empty, then generate a new password."))
 

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -55,8 +55,12 @@ for which the `executable' slot is non-nil."
             (new-password (first (prompt
                                   :invisible-input-p t
                                   :prompt "New password (leave empty to generate)"
-                                  :sources (make-instance 'prompter:raw-source)))))
+                                  :sources (make-instance 'prompter:raw-source))))
+            (username (first (prompt
+                              :prompt "Username (can be empty)"
+                              :sources (make-instance 'prompter:raw-source)))))
        (password:save-password (password-interface buffer)
+                               :username username
                                :password-name password-name
                                :password new-password)))
     ((null (password-interface buffer))
@@ -122,5 +126,18 @@ for which the `executable' slot is non-nil."
                                                                    :buffer buffer
                                                                    :password-instance (password-interface buffer)))))))
           (password:clip-password (password-interface buffer) :password-name password-name)
+          (echo "Password saved to clipboard for ~a seconds." (password:sleep-timer (password-interface buffer)))))
+      (echo-warning "No password manager found.")))
+
+(define-command copy-username (&optional (buffer (current-buffer)))
+  "Query username and copy to clipboard."
+  (password-debug-info)
+  (if (password-interface buffer)
+      (with-password (password-interface buffer)
+        (let ((password-name (first (prompt
+                                     :sources (list (make-instance 'password-source
+                                                                   :buffer buffer
+                                                                   :password-instance (password-interface buffer)))))))
+          (password:clip-username (password-interface buffer) :password-name password-name)
           (echo "Password saved to clipboard for ~a seconds." (password:sleep-timer (password-interface buffer)))))
       (echo-warning "No password manager found.")))

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -138,6 +138,7 @@ for which the `executable' slot is non-nil."
                                      :sources (list (make-instance 'password-source
                                                                    :buffer buffer
                                                                    :password-instance (password-interface buffer)))))))
-          (password:clip-username (password-interface buffer) :password-name password-name)
-          (echo "Password saved to clipboard for ~a seconds." (password:sleep-timer (password-interface buffer)))))
+          (if (password:clip-username (password-interface buffer) :password-name password-name)
+              (echo "Username saved to clipboard.")
+              (echo "No username found."))))
       (echo-warning "No password manager found.")))


### PR DESCRIPTION
This adds username copying to KeePassXC and Password Store interfaces, together with a generic to implement for other interfaces. A step towards #1138.

EDIT: `command` is installed on my machine, but isn't installed in development environment xD
EDIT: Mention #1138.