### PR TITLE
Remember page scroll positions

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -714,6 +714,9 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
     (buffers-delete (id buffer))
     ;; (setf (id buffer) "") ; TODO: Reset ID?
     (with-data-access (history (history-path buffer))
+      (setf (nyxt::scroll-position
+             (htree:data (htree:current (htree:owner history (id buffer)))))
+            (nyxt:document-scroll-position))
       (htree:delete-owner history (id buffer)))
     (add-to-recent-buffers buffer)
     (store (data-profile buffer) (history-path buffer))))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -25,7 +25,11 @@ include implicit visits.")
                     :type integer
                     :documentation "
 Number of times the URL was visited by following a link on a page.  This does
-not include explicit visits."))
+not include explicit visits.")
+   (scroll-position '()
+                    :type list-of-numbers
+                    :documentation "The scroll position user was at when last visiting the page.
+Is a list of a form (Y &OPTIONAL X)."))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))
   (:documentation "
 Entry for the global history.

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -29,7 +29,7 @@ not include explicit visits.")
    (scroll-position '()
                     :type list-of-numbers
                     :documentation "The scroll position user was at when last visiting the page.
-Is a list of a form (Y &OPTIONAL X)."))
+It's a list of a form (Y &OPTIONAL X)."))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))
   (:documentation "
 Entry for the global history.

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -35,11 +35,11 @@ The function can be passed ARGS."
 
 (export-always 'document-scroll-position)
 (defmethod document-scroll-position (&optional (buffer (current-buffer)))
-  "Get current scroll position of set it.
-If passed no arguments, returns a list of two elements: vertical (Y) and
-horisontal (X) offset.
-If `setf'-d to a single value (or a single list) -- sets Y to it.
-If `setf'-d to a list of two values -- sets Y to `first' and X to `second' element."
+  "Get current scroll position or set it.
+If passed no arguments, return a list of two elements: vertical (Y) and
+horizontal (X) offset.
+If `setf'-d to a single value (or a single list) -- set Y to it.
+If `setf'-d to a list of two values -- set Y to `first' and X to `second' element."
   (with-current-buffer buffer
     (mapcar #'parse-integer
             (str:split "," (%document-scroll-position)))))

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -25,6 +25,31 @@ The function can be passed ARGS."
                   collect (transform-definition name lambda-list body))
        ,@body)))
 
+(define-parenscript %document-scroll-position (&optional (y 0 y-provided-p) (x 0 x-provided-p))
+  (let ((x (ps:lisp x))
+        (y (ps:lisp y)))
+    (if (or (ps:lisp x-provided-p) (ps:lisp y-provided-p))
+        (ps:chain window (scroll-to x y))
+        (list (ps:chain window page-y-offset)
+              (ps:chain window page-x-offset)))))
+
+(export-always 'document-scroll-position)
+(defmethod document-scroll-position (&optional (buffer (current-buffer)))
+  "Get current scroll position of set it.
+If passed no arguments, returns a list of two elements: vertical (Y) and
+horisontal (X) offset.
+If `setf'-d to a single value (or a single list) -- sets Y to it.
+If `setf'-d to a list of two values -- sets Y to `first' and X to `second' element."
+  (with-current-buffer buffer
+    (mapcar #'parse-integer
+            (str:split "," (%document-scroll-position)))))
+
+(defmethod (setf document-scroll-position) (value &optional (buffer (current-buffer)))
+  (with-current-buffer buffer
+      (destructuring-bind (y &optional x)
+          (uiop:ensure-list value)
+        (%document-scroll-position y x))))
+
 (export-always 'document-get-paragraph-contents)
 (define-parenscript document-get-paragraph-contents (&key (limit 100000))
   (let ((result ""))

--- a/source/types.lisp
+++ b/source/types.lisp
@@ -30,6 +30,8 @@ Example:
 (define-list-type 'symbol)
 (export-always 'list-of-characters)
 (define-list-type 'character)
+(export-always 'list-of-numbers)
+(define-list-type 'number)
 (export-always 'list-of-strings)
 (define-list-type 'string)
 (export-always 'list-of-keymaps)

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -536,7 +536,11 @@ Otherwise go forward to the only child."
       ;; any load, e.g. when clicking on an anchor.
       (with-current-buffer (buffer mode)
         (nyxt::history-add url :title (title (buffer mode))
-                               :buffer (buffer mode)))))
+                               :buffer (buffer mode))
+        (with-data-access (history (history-path (buffer mode)))
+          (setf (nyxt::scroll-position
+                 (htree:data (htree:current (htree:owner history (id (buffer mode))))))
+                (nyxt:document-scroll-position))))))
 
   url)
 
@@ -555,5 +559,10 @@ Otherwise go forward to the only child."
     (nyxt::history-add url :title (title (buffer mode))
                            :buffer (buffer mode)))
   (reset-page-zoom :buffer (buffer mode)
-               :ratio (current-zoom-ratio (buffer mode)))
+                   :ratio (current-zoom-ratio (buffer mode)))
+  (with-data-unsafe (history (history-path (buffer mode)))
+    (alex:when-let ((scroll-position
+                     (nyxt::scroll-position
+                      (htree:data (htree:current (htree:owner history (id (buffer mode))))))))
+      (setf (nyxt:document-scroll-position) scroll-position)))
   url)


### PR DESCRIPTION
This adds a simple scroll position saving to history. It works lightning fast and most probably does what you mean.

# What's New:
- `document-scroll-position` method (see "Things To Discuss" about it being a method) that calls internal `%document-scroll-position` parenscript function.
- Small additions to `nyxt/web-mode:on-signal-notify-uri` and `nyxt/web-mode:on-signal-load-finished` to store and restore scroll position respectively.
- `list-of-numbers` type for convenience (how about we actually write a `list-of` type with a placeholder for anything?).

# Things To Discuss:
- The current architecture, although effective, rings some imperfection bell to me. Maybe:
  - Make `document-scroll-position` an FFI method?
  - Make it a `buffer` slot?
- Maybe use current DOM element instead of current scroll position? Feels right semantically, but it's a pain to implement, even with #1365.

# How Has This Been Tested:
- Compiled.
- Ran.
- Moved in between several pages in history, back and forth.
- Position is restored up to a pixel!

How does it look to you?