### PR TITLE
Fix GI-GTK initialization on macOS

### DIFF
--- a/source/renderer-gi-gtk.lisp
+++ b/source/renderer-gi-gtk.lisp
@@ -18,16 +18,24 @@
   (defun renderer-thread-p ()
     (string= "main thread" (bt:thread-name (bt:current-thread))))
   (defmethod ffi-initialize ((browser gtk-browser) urls startup-timestamp)
+    "gtk:within-main-loop handles all the GTK initialization. On
+    GNU/Linux, Next could hang after 10 minutes if it's not
+    used. Conversely, on Darwin, if gtk:within-main-loop is used, no
+    drawing happens. Drawing operations on Darwin MUST originate from
+    the main thread, which the GTK main loop is not guaranteed to be
+    on."
     (log:debug "Initializing GI-GTK Interface")
     (setf gtk-running-p t)
-    (let ((main-thread (bt:make-thread
-                        (lambda ()
-                          (with-protect ("Error on GTK thread: ~a" :condition)
-                            (glib:g-set-prgname "nyxt")
-                            #+GTK-3-4
-                            (gdk:gdk-set-program-class "Nyxt")
-                            (gir:invoke ((gir:ffi "Gtk" "3.0") 'main))))
-                        :name "main thread")))
-      (finalize browser urls startup-timestamp)
-      (unless *run-from-repl-p*
-        (bt:join-thread main-thread)))))
+    (flet ((main-func ()
+             (with-protect ("Error on GTK thread: ~a" :condition)
+               (glib:g-set-prgname "nyxt")
+               #+GTK-3-4
+               (gdk:gdk-set-program-class "Nyxt")
+               (gir:invoke ((gir:ffi "Gtk" "3.0") 'main)))))
+          (finalize browser urls startup-timestamp)
+          #-darwin
+          (let ((main-thread (bt:make-thread #'main-func :name "main thread")))
+            (unless *run-from-repl-p*
+              (bt:join-thread main-thread)))
+          #+darwin
+          (main-func))))


### PR DESCRIPTION
This fix is similar to d0a4161. The unpatched code crashes on macOS with the following output:

```
WARNING:
   Type initializer for class 'GdkX11DeviceXI2' (GType 'GDK-X11-DEVICE-XI2') is invalid: foreign symbol 'gdk_x11_device_xi2_get_type'
WARNING:
   Type initializer for class 'GdkX11DeviceManagerCore' (GType 'GDK-X11-DEVICE-MANAGER-CORE') is invalid: foreign symbol 'gdk_x11_device_manager_core_get_type'
WARNING:
   Type initializer for class 'GdkX11DeviceManagerXI2' (GType 'GDK-X11-DEVICE-MANAGER-XI2') is invalid: foreign symbol 'gdk_x11_device_manager_xi2_get_type'
WARNING:
   Type initializer for class 'GtkPlug' (GType 'GTK-PLUG') is invalid: foreign symbol 'gtk_plug_get_type'
WARNING:
   Type initializer for class 'GtkSocket' (GType 'GTK-SOCKET') is invalid: foreign symbol 'gtk_socket_get_type'
<INFO> [16:54:47] Listening to socket "nyxt/nyxt.socket".
Nyxt version 2.0.0
<INFO> [16:54:47] Loading Lisp file "/Users/midchildan/.config/nyxt/auto-config.lisp".
<DEBUG> [16:54:47] Lisp file "/Users/midchildan/.config/nyxt/init.lisp" does not exist.
<DEBUG> [16:54:47] Initializing GI-GTK Interface
CORRUPTION WARNING in SBCL pid 3273 pthread 0x700005d2b000:
Memory fault at 0x10 (pc=0x7fff75747452, fp=0x1dc9f280, sp=0x1dc9ee50) pthread 0x700005d2b000
The integrity of this image is possibly compromised.
Continuing with fingers crossed.
<WARN> [16:54:48] Warning: Error on GTK thread: Unhandled memory fault at #x10.
```

I've tested the fix on macOS and NixOS.