### PR TITLE
Makes search-buffer-source have an user instance

### DIFF
--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -161,7 +161,10 @@
    (prompter:destructor (lambda (prompter source)
                           (declare (ignore prompter source))
                           (remove-focus))))
+  (:export-accessor-names-p t)
+  (:export-class-name-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+(define-user-class search-buffer-source)
 
 (defmethod initialize-instance :after ((source search-buffer-source) &key)
   (setf (prompter:name source)
@@ -174,7 +177,7 @@
   (prompt
    :prompt "Search text"
    :sources (list
-             (make-instance 'search-buffer-source
+             (make-instance 'user-search-buffer-source
                             :case-sensitive-p case-sensitive-p))))
 
 (define-command search-buffers (&key case-sensitive-p)


### PR DESCRIPTION
This allows the user to customize the search buffer behavior, I've made the following extension in my configuration

```lisp
(define-configuration nyxt/web-mode:search-buffer-source
  ((nyxt/web-mode:minimum-search-length 1)))
```

however one can use this for other purposes