### PR TITLE
Serialize data-paths (e.g. history) safely

### DIFF
--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -440,10 +440,7 @@ Auto-mode is re-enabled once the page is reloaded."
               rules))))
 
 (defmethod store ((profile data-profile) (path auto-mode-rules-data-path) &key &allow-other-keys)
-  (with-data-file (file path
-                        :direction :output
-                        :if-does-not-exist :create
-                        :if-exists :supersede)
+  (with-data-file-output (file path)
     (let ((*package* (find-package :nyxt/auto-mode))
           (rules (get-data path)))
       (write-string ";; List of auto-mode rules.

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -443,7 +443,7 @@ Auto-mode is re-enabled once the page is reloaded."
   (with-data-file (file path
                         :direction :output
                         :if-does-not-exist :create
-                        :if-exists :overwrite)
+                        :if-exists :supersede)
     (let ((*package* (find-package :nyxt/auto-mode))
           (rules (get-data path)))
       (write-string ";; List of auto-mode rules.

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -54,7 +54,7 @@ If HOSTLIST has a `path', persist it locally."
         (when path
           (handler-case
               (alex:write-string-into-file hosts (ensure-parent-exists path)
-                                           :if-exists :overwrite
+                                           :if-exists :supersede
                                            :if-does-not-exist :create)
             (error (c)
               (log:error "Could not persist hostlist ~s: ~a" path c))))

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -297,10 +297,7 @@ rest in background buffers."
 
 (defmethod store ((profile data-profile) (path bookmarks-data-path) &key &allow-other-keys)
   "Store the bookmarks to the buffer `bookmarks-path'."
-  (with-data-file (file path
-                        :direction :output
-                        :if-does-not-exist :create
-                        :if-exists :supersede)
+  (with-data-file-output (file path)
     ;; TODO: Make sorting customizable?  Note that `store-sexp-bookmarks' is
     ;; already a customizable function.
     (setf (get-data path)

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -300,7 +300,7 @@ rest in background buffers."
   (with-data-file (file path
                         :direction :output
                         :if-does-not-exist :create
-                        :if-exists :overwrite)
+                        :if-exists :supersede)
     ;; TODO: Make sorting customizable?  Note that `store-sexp-bookmarks' is
     ;; already a customizable function.
     (setf (get-data path)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -618,7 +618,7 @@ the "
 
 (defun dump-command-descriptions (file)
   "Dump the command descriptions as an HTML file."
-  (with-open-file (f file :direction :output :if-exists :overwrite)
+  (with-open-file (f file :direction :output :if-exists :supersede)
     (format f "~a" (markup:markup
                     (:p "Listed below are the current commands, their
                          documentation, and their source. Non-command

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -193,10 +193,7 @@ instance of Nyxt."
 
 (defmethod store ((profile data-profile) (path history-data-path) &key &allow-other-keys)
   "Store the global/buffer-local history to the PATH."
-  (with-data-file (file path
-                        :direction :output
-                        :if-does-not-exist :create
-                        :if-exists :supersede)
+  (with-data-file-output (file path)
     ;; We READ the output of serialize-sexp to make it more human-readable.
     (let ((*package* (find-package :nyxt))
           (*print-length* nil))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -196,7 +196,7 @@ instance of Nyxt."
   (with-data-file (file path
                         :direction :output
                         :if-does-not-exist :create
-                        :if-exists :overwrite)
+                        :if-exists :supersede)
     ;; We READ the output of serialize-sexp to make it more human-readable.
     (let ((*package* (find-package :nyxt))
           (*print-length* nil))

--- a/source/style-mode.lisp
+++ b/source/style-mode.lisp
@@ -63,7 +63,7 @@ If nil, look for CSS in `style-file' or `style-url'.")
         (error ()
           (log:info "Downloading ~s." (expand-path path))
           (let ((file-contents (dex:get (render-url url))))
-            (with-open-file (f (expand-path path) :direction :output :if-exists :overwrite)
+            (with-open-file (f (expand-path path) :direction :output :if-exists :supersede)
               (format f "~a" file-contents))
             file-contents))))))
 


### PR DESCRIPTION
In the course of the last 2 weeks, my global history file got corrupted twice.
This happens, I believe, when an error occurs while the file is persisted.

To protect against this, we can persist the file to a temporary one and rename it to the final path when done.

@jmercouris @aartaka Can you test if this works for you?
(Considering backing up your files!)