### PR TITLE
Update CSS colors for coherence.

### DIFF
--- a/source/buffer-listing-mode.lisp
+++ b/source/buffer-listing-mode.lisp
@@ -56,7 +56,7 @@
        (:br "")
        (:div
         (if cluster
-            (append (list (internal-buffers-markup)) 
+            (append (list (internal-buffers-markup))
                     (loop for cluster-key being the hash-key
                           using (hash-value cluster) of (cluster-buffers)
                           collect (cluster-markup cluster-key cluster)))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -366,7 +366,9 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
                (|.button:visited|
                 :color "white")
                (|.button:active|
-                :color "white")))))
+                :color "white")
+               (a
+                :color "gray")))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:export-predicate-name-p t)
@@ -408,9 +410,9 @@ Delete it with `ffi-buffer-delete'."
     :documentation "Display the modes as a list of glyphs.")
    (style #.(cl-css:css
              '((body
-                :background "rgb(200, 200, 200)"
+                :background "lightgray"
                 :font-size "14px"
-                :color "rgb(32, 32, 32)"
+                :color "black"
                 :padding 0
                 :margin 0
                 :line-height "20px")
@@ -442,7 +444,7 @@ Delete it with `ffi-buffer-delete'."
                 :padding-left "5px"
                 :z-index "3")
                ("#url"
-                :background-color "rgb(120,120,120)"
+                :background-color "gray"
                 :min-width "100px"
                 :text-overflow "ellipsis"
                 :overflow-x "hidden"
@@ -451,7 +453,7 @@ Delete it with `ffi-buffer-delete'."
                 :padding-left "15px"
                 :z-index "2")
                ("#tabs"
-                :background-color "rgb(160,160,160)"
+                :background-color "darkgray"
                 :min-width "100px"
                 :overflow-x "scroll"
                 :text-align "left"
@@ -461,7 +463,7 @@ Delete it with `ffi-buffer-delete'."
                ("#tabs::-webkit-scrollbar"
                 :display "none")
                (.tab
-                :color "rgb(250, 250, 250)"
+                :color "white"
                 :white-space "nowrap"
                 :text-decoration "none"
                 :padding-left "5px"
@@ -469,8 +471,8 @@ Delete it with `ffi-buffer-delete'."
                (".tab:hover"
                 :color "black")
                ("#modes"
-                :background-color "rgb(120,120,120)"
-                :color "rgb(230, 230, 230)"
+                :background-color "gray"
+                :color "gainsboro"
                 :text-align "right"
                 :padding-left "10px"
                 :padding-right "5px"
@@ -480,7 +482,7 @@ Delete it with `ffi-buffer-delete'."
                ("#modes::-webkit-scrollbar"
                 :display "none")
                (.button
-                :color "rgb(250, 250, 250)"
+                :color "white"
                 :text-decoration "none"
                 :padding-left "2px"
                 :padding-right "2px"

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -472,7 +472,7 @@ Delete it with `ffi-buffer-delete'."
                 :color "black")
                ("#modes"
                 :background-color "gray"
-                :color "gainsboro"
+                :color "white"
                 :text-align "right"
                 :padding-left "10px"
                 :padding-right "5px"

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -580,8 +580,6 @@ the "
                             '((body
                                :margin-top 0
                                :margin-bottom 0)
-                              ("a"
-                               :color "gray")
                               ("#title"
                                :font-size "400%")
                               (.section

--- a/source/history-tree-mode.lisp
+++ b/source/history-tree-mode.lisp
@@ -41,7 +41,7 @@ matching buffer `id's along with buffer history entries.")
         :content "' '"
         :position "absolute"
         :width "1px"
-        :background-color "#000"
+        :background-color "black"
         :top "5px"
         :bottom "-12px"
         :left "-10px")
@@ -54,7 +54,7 @@ matching buffer `id's along with buffer history entries.")
         :content "' '"
         :position "absolute"
         :width "1px"
-        :background-color "#000"
+        :background-color "black"
         :top "5px"
         :bottom "7px"
         :height "7px"
@@ -65,5 +65,5 @@ matching buffer `id's along with buffer history entries.")
         :left "-10px"
         :width "10px"
         :height "1px"
-        :background-color "#000"
+        :background-color "black"
         :top "12px"))))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -73,7 +73,7 @@ chosen suggestions inside brackets.")
                   :border "none"
                   :outline "none"
                   :padding "3px"
-                  :background-color "#E8E8E8"
+                  :background-color "gainsboro"
                   :width "100%"
                   :autofocus "true")
                  (".source"
@@ -93,7 +93,7 @@ chosen suggestions inside brackets.")
                   :width "100%")
                  (".source-content"
                   :margin-left "16px"
-                  :background-color "#F7F7F7"
+                  :background-color "white"
                   :width "100%"
                   :table-layout "fixed")
                  (".source-content td"
@@ -104,7 +104,7 @@ chosen suggestions inside brackets.")
                   :font-weight "normal"
                   :padding-left "3px"
                   :text-align "left"
-                  :background-color "#E8E8E8")
+                  :background-color "gainsboro")
                  (".source-content td::-webkit-scrollbar"
                   :display "none")
                  ("#selection"

--- a/source/repl-mode.lisp
+++ b/source/repl-mode.lisp
@@ -29,7 +29,7 @@
                               :border "none"
                               :outline "none"
                               :padding "3px"
-                              :background-color "#E8E8E8"
+                              :background-color "gainsboro"
                               :autofocus "true")
              ("#evaluation-history"
               :font-size "12px"


### PR DESCRIPTION
This changes our hex-based CSS to named colors.

# Why?
- Named colors are easier to comprehend.
- I've started doing [systematic Nyxt theming](https://github.com/aartaka/nyxt-config/commit/4afc3d3618839bca5251756a316dc46eec7d4a92) and understood that the set of colors we use is quite small, but one cannot see ~the forest for the trees~ all this because of hex-valued colors. Thus, this patch is an improvement to make theming somewhat easier cognitively.
  - Adding to that, I plan to simply search for color names we use after we discuss and merge this patch. This will allow to make a default Nyxt color theme to derive other themes from, e.g., easily do themes like in the macro I've done.

# Things To Discuss
- @jmercouris, I've adjusted some colors 2-20 RBG points away from initial hex values. Is that alright? I feel it is, because it yields more coherence in the long term, but you can prove me wrong :)
- Maybe we should include the aforementioned bit of configuration into the upstream? This can even become a cool Common Settings part to quickly style Nyxt to one's liking :)

# How Has This Been Tested

It wasn't. Colors are not too far, though. Shouldn't cause much trouble.

How's that looking? 