### PR TITLE
[backwards-incompatible] Move (&rename) gtk-extensions-path to XDG_DATA_HOME.

### DIFF
--- a/source/renderers/gtk.lisp
+++ b/source/renderers/gtk.lisp
@@ -204,12 +204,20 @@ not return."
   "We shouldn't enable (possibly) user-identifying extensions for `nosave-data-profile'."
   nil)
 
+
 (define-class gtk-download (download)
   ((gtk-object)
    (handler-ids
     :documentation "See `gtk-buffer' slot of the same name."))
   (:accessor-name-transformer (class*:make-name-transformer name)))
 (define-user-class download (gtk-download))
+
+(defmethod expand-data-path ((profile data-profile) (path gtk-extensions-data-path))
+  "Return finalized path for gtk-extension directory."
+  (expand-default-path path :root (namestring (if (str:emptyp (namestring (dirname path)))
+                                                  (uiop:xdg-data-home +data-root+ "gtk-extensions")
+                                                  (dirname path)))))
+
 
 (defun make-web-view (&key context-buffer)
   "Return a web view instance.

--- a/source/renderers/gtk.lisp
+++ b/source/renderers/gtk.lisp
@@ -200,10 +200,8 @@ not return."
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
 (defmethod expand-data-path ((profile nosave-data-profile) (path gtk-extensions-data-path))
-  ;; REVIEW: Should we?
   "We shouldn't enable (possibly) user-identifying extensions for `nosave-data-profile'."
   nil)
-
 
 (define-class gtk-download (download)
   ((gtk-object)


### PR DESCRIPTION
This changes the WebKit extensions directory to be next to the Lispy extensions one -- in .local/share/nyxt (or other XDG_DATA_HOME value). This makes things more consistent. However, this is a backwards-incompatible change and thus something to keep until 3.0.