### PR TITLE
browser.lisp: create the command to show the last element on the clipboard stack

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -568,6 +568,14 @@ sometimes yields the wrong result."
                    :if-does-not-exist :create
                    :if-exists :append))))))
 
+
+
+(define-command show-clipboard ()
+  "Show the current clipboard."
+  (echo (ring-insert-clipboard (clipboard-ring *browser*))))
+
+
+
 (defmacro define-ffi-generic (name arguments &body options)
   `(progn
      (export-always ',name)


### PR DESCRIPTION
Hi guys,

This seems to solve issue #1503. The new command shows the *last* element on the clipboard stack. It does not show all elements but it is already good enough useful (imho). In the future, I bet this could be improved to show all the clipboard stack. 
I did it mainly for learning reasons since this was close to #765. 