### PR TITLE
tutorial.lisp: add information about enable and disable modes on the manual

### DIFF
--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -176,7 +176,12 @@ removed from the input, they are also removed from the existing bookmark.")
     (:li (command-markup 'delete-bookmark) ": Delete queried bookmarks.")
     (:li (command-markup 'list-bookmarks) ": Display a new buffer containing the
 list of all bookmarks."))
-
+   (:h3 "Enable and Disable modes")
+   (:p "The command " (:code "enable-mode") " allows the user to apply a
+mode (such as " (:code "nosound-mode") " or " (:code "dark-mode") ") to multiple
+buffers at once. Conversely, it is possible to revert this action
+executing "(:code "disable-mode") " while choosing exactly the same buffers and
+the same mode previously selected.")
    (:h3 "Visual mode")
    (:p "Select text without a mouse. Nyxt's "
        (:code "visual-mode") " imitates Vim's visual mode (and comes with the


### PR DESCRIPTION
Hi,

As discussed in a previous private email, here is a suggestion to insert the commands `enable-mode` and `disable-mode` on the manual. I tried to keep the style similar to the other parts. Not sure if I did manage to do that, though. I can iterate the content. Thanks!