### PR TITLE
Fix invalid .desktop entry

### DIFF
--- a/assets/nyxt.desktop
+++ b/assets/nyxt.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Version=VERSION
 Name=Nyxt
 Comment=Be Productive
 GenericName=Web Browser
@@ -12,5 +11,4 @@ Icon=nyxt
 Categories=GTK;Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
 StartupNotify=true
-Actions=NewWindow;
 StartupWMClass=nyxt

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -332,17 +332,8 @@ See `asdf::*immutable-systems*'."
             (flet ((ensure-parent-exists (file)
                      (uiop:ensure-all-directories-exist
                       (list (directory-namestring file)))))
-              (let ((desktop-file (format nil "~a/applications/nyxt.desktop" *datadir*)))
-                (ensure-parent-exists desktop-file)
-                (with-open-file (desktop-stream desktop-file :direction :output
-                                                             :if-exists :supersede)
-                  (princ
-                   (funcall (read-from-string "str:replace-all")
-                            "VERSION"
-                            (symbol-value (read-from-string "nyxt:+version+"))
-                            (funcall (read-from-string "alexandria:read-file-into-string")
-                                     (system-relative-pathname c "assets/nyxt.desktop")))
-                   desktop-stream)))
+              (uiop:copy-file (system-relative-pathname c "assets/nyxt.desktop")
+                              (format nil "~a/applications/nyxt.desktop" *datadir*))
               (mapc (lambda (icon-size)
                       (let ((icon-file (format nil "~a/icons/hicolor/~ax~a/apps/nyxt.png"
                                                *datadir* icon-size icon-size)))


### PR DESCRIPTION
This was failing a `desktop-file-validate`. I didn't notice it causing any actual user issues. I'm still able to use it from my launcher. But the failures surprised me and I didn't want to leave them lying around.

```
➜  nyxt git:(fix-freedesktop-entry) ✗ desktop-file-validate ~/.local/share/applications/nyxt.desktop
/home/eihli/.local/share/applications/nyxt.desktop: error: value "2.0.0-106-g041373c3" for key "Version" in group "Desktop Entry" is not a known version
/home/eihli/.local/share/applications/nyxt.desktop: error: action "NewWindow" is defined, but there is no matching "Desktop Action NewWindow" group
```

Remove an Actions entry that doesn't have a corresponding action group
and update the version to be compatible with the spec.

https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html

```
Version of the Desktop Entry Specification that the desktop entry
conforms with. Entries that confirm with this version of the
specification should use 1.5. Note that the version field is not
required to be present.
```

I don't see any changes from 1.4 to 1.5
https://specifications.freedesktop.org/desktop-entry-spec/latest/ape.html
but the changes from 1.0 to 1.4 have all been really minor and I don't
expect this desktop file to be using any esoteric changes that might be
from 1.4 to 1.5. And I see the latest version of Manjaro is shipping
with `desktop-file-validate` tool that validates against 1.4, I expect
most other versions to be similar, and figured it would be better to
specify a lower more widespread version when it contains all the spec we
need.

https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html

```
Each action is identified by a string, following the same format as key
names (see the section called “Entries”). Each identifier is associated
with an action group that must be present in the .desktop file. The
action group is a group named Desktop Action %s, where %s is the action
identifier.
```