### PR TITLE
Correct mode's package in proxy-mode documentation

### DIFF
--- a/source/proxy-mode.lisp
+++ b/source/proxy-mode.lisp
@@ -24,7 +24,7 @@ Example to use Tor as a proxy both for browsing and downloading:
                                          :proxied-downloads-p t))))
 
 \(define-configuration buffer
-  ((default-modes (append '(proxy-mode) %slot-default%))))"
+  ((default-modes (append '(nyxt/proxy-mode) %slot-default%))))"
   ((proxy (make-instance 'nyxt:proxy
                          :url (quri:uri "socks5://localhost:9050")
                          :allowlist '("localhost" "localhost:8080")


### PR DESCRIPTION
Hi,
I'm here again messing with proxy-mode documentation :) Example copied from docs hasn't worked for me, and this is how I fixed that. As before, I have no idea what I'm doing as I'm at the begining of my journey with lisp, so if the problem was on my side, please just correct me.