### PR TITLE
Added instruction for installing Nyxt on Void Linux.

### DIFF
--- a/README.org
+++ b/README.org
@@ -81,6 +81,7 @@ systems provide packages for Nyxt:
 - [[https://aur.archlinux.org/packages/nyxt][Arch Linux AUR]] (and the [[https://aur.archlinux.org/packages/nyxt-browser-git/][-git PKGBUILD]])
 - [[https://nixos.org/nix/][Nix]]: Install with =nix-env --install nyxt=.
 - [[https://guix.gnu.org][Guix]]: Install with =guix install nyxt=.
+- [[https://voidlinux.org/][Void]]: Install with =xbps-install nyxt=.
 
 To perform an installation from source, please see the [[file:documents/README.org][developer readme]].
 


### PR DESCRIPTION
Added that Void Linux also provides a package for Nyxt, and how to install it.