### PR TITLE
Feature: mimic vimium `goNext`/`goPrevious` inside Nyxt

### DIFF
--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -222,6 +222,13 @@ and to index the top of the page.")
   "Scroll to top if no input element is active, forward event otherwise."
   (call-non-input-command-or-forward #'scroll-to-top :buffer buffer))
 
+(define-command go-next ()
+  "Navigate to the previous element according to the HTML rel attribute."
+  (pflet ((go-next ()
+                   (ps:chain document
+                             (query-selector-all "[rel=next]") 0 (click))))
+    (go-next)))
+
 (defun load-history-url (url-or-node
                          &key (buffer (current-buffer))
                               (message "History entry is already the current URL."))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -229,6 +229,13 @@ and to index the top of the page.")
                              (query-selector-all "[rel=next]") 0 (click))))
     (go-next)))
 
+(define-command go-previous ()
+  "Navigate to the previous element according to the HTML rel attribute."
+  (pflet ((go-previous ()
+                       (ps:chain document
+                                 (query-selector-all "[rel=prev]") 0 (click))))
+    (go-previous)))
+
 (defun load-history-url (url-or-node
                          &key (buffer (current-buffer))
                               (message "History entry is already the current URL."))


### PR DESCRIPTION
Hi guys,

I tried solving this [issue](https://github.com/atlas-engineer/nyxt/issues/947) . Since I was struggling with parenscript, I decided to attack the problem from a different perspective.

Instead of parenscript, I defined 2 new commands in Nyxt using the `define-bookmarklet-command` macro. It does not seem to make any difference in comparison to `define-command` for a GUI-only user perspective.

It works with [GNU manual](https://www.gnu.org/software/emacs/manual/html_node/emacs/Keys.html) pages and [XKCD](https://xkcd.com/2472/). This is a gif showing it in action: ![go-next and go-previous in Nyxt](https://github.com/pdelfino/public-notes/blob/main/go-next-go-previous.gif)

This approach could be good for power users that lack knowledge of Common Lisp. I think the `define-bookmarklet-command` macro is way easier to understand than parenscript itself combined with `define-parenscript` macro. But this can be just my perspective.

Since my approach was different and I did not know if you would like it, I stopped before making it more general. It only works with HTML `rel` attribute being `next` or `prev`. If you think this approach is cool, I can put synonyms such as the ones `("next" "more" "newer" ">" "›" "→" "»" "≫" ">>")` available on @jellelicht [first try](https://gist.github.com/jellelicht/99e8b0dbb2533bea1888276d3fee39b5). 

This approach **will not** work on websites [like this](https://thelocalyarn.com/excursus/secretary/flatland/07-chapter.html). But [Vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en) (the inspiration) **also does not work** on it.
 