### PR TITLE
tutorial.lisp: insert an explanation about application-mode on built-in tutorial

### DIFF
--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -176,6 +176,14 @@ removed from the input, they are also removed from the existing bookmark.")
     (:li (command-markup 'delete-bookmark) ": Delete queried bookmarks.")
     (:li (command-markup 'list-bookmarks) ": Display a new buffer containing the
 list of all bookmarks."))
+   (:h3 "Application mode")
+   (:p "The command " (:code "application-mode") " forwards all keys to the
+renderer. For instance, using the default binding of Nyxt (" (:code "web-cua-map") ") the
+key-binding " (:code "C-i") " executes " (:code "autofill") ". Suppose
+a user is using their email client which also uses " (:code "C-i") " for the italic command. Thus, after
+executing " (:code "application-mode") " the " (:code "C-i") " binding is associated
+with the webpage's italic command instead of " (:code "autofill") ". Finally, the
+user can return to their configuration just by executing " (:code "application-mode") " again.")
    (:h3 "Enable and Disable modes")
    (:p "The command " (:code "enable-mode") " allows the user to apply a
 mode (such as " (:code "nosound-mode") " or " (:code "dark-mode") ") to multiple


### PR DESCRIPTION
Hopefully, this fixes #1516.

Inside emacs, before commiting, I used `fill-paragraphs` and `white-space-mode`.  Depending on how `fill-paragraph` goes, it breaks the compilation because some line breaks are set in "empty" places (between strings and `(:code ....)`). I am not sure if `fill-paragraph` is the best way to keep it short. I am open to advice :wink:

I hope there will be no problem concerning whitespaces or the length of the content.