### PR TITLE
command: Forbid required parameters in commands.

### DIFF
--- a/source/command.lisp
+++ b/source/command.lisp
@@ -136,6 +136,9 @@ Example:
     (unless documentation
       (warn (make-condition 'command-documentation-style-warning
                             :name name)))
+    (alex:when-let ((req-args (alex:parse-ordinary-lambda-list arglist)))
+      (error "Commands cannot have required parameters (~s), consider optional or keyword parameters instead."
+             req-args))
     (let ((before-hook (intern (str:concat (symbol-name name) "-BEFORE-HOOK")
                                (symbol-package name)))
           (after-hook (intern (str:concat (symbol-name name) "-AFTER-HOOK")


### PR DESCRIPTION
They don't make sense since commands are meant to be run interactively.