### PR TITLE
Automatic required arguments for commands

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -880,6 +880,7 @@ proceeding."
   (:export-class-name-p t))
 (define-user-class buffer-source)
 
+(declaim (ftype (function (&key (:id string))) switch-buffer))
 (define-command switch-buffer (&key id)
   "Switch the active buffer in the current window."
   (if id

--- a/source/command-commands.lisp
+++ b/source/command-commands.lisp
@@ -74,13 +74,11 @@ keyword parameters."
                            :prompt "Execute extended command"
                            :sources (make-instance 'user-command-source)
                            :hide-suggestion-count-p t)))
-          (argument-list (swank::arglist (fn command)))
-          (required-arguments (nth-value 0 (alex:parse-ordinary-lambda-list
-                                            argument-list)))
-          (optional-arguments (nth-value 1 (alex:parse-ordinary-lambda-list
-                                            argument-list)))
-          (key-arguments (nth-value 3 (alex:parse-ordinary-lambda-list
-                                       argument-list))))
+          (argument-list (swank::arglist (fn command))))
+     (multiple-value-bind (required-arguments optional-arguments rest key-arguments
+                           aok? aux key?)
+         (alex:parse-ordinary-lambda-list argument-list)
+       (declare (ignore rest aok? aux key?)))
      (apply command
             (append
              (when required-arguments

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -48,7 +48,12 @@ We need a `command' class for multiple reasons:
   called.  The only way to do this is to persist the command instances."))
 
 (defmethod initialize-instance :after ((command command) &key)
-  (closer-mop:set-funcallable-instance-function command (fn command)))
+  (closer-mop:set-funcallable-instance-function command
+                                                (lambda (&rest args)
+                                                  (apply (fn command)
+                                                         (or args
+                                                             (mapcar #'prompt-argument
+                                                                     (parse-function-lambda-list-types (fn command))))))))
 
 (defmethod print-object ((command command) stream)
   (print-unreadable-object (command stream :type t :identity t)

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -347,11 +347,15 @@ This is blocking, see `run-async' for an asynchronous way to run commands."
 See `run' for a way to run commands in a synchronous fashion and return the
 result."
   (run-thread
-    (with-current-buffer (current-buffer) ; See `run' for why we bind current buffer.
-      (handler-case (apply #'funcall command args)
-        (nyxt-prompt-buffer-canceled ()
-          (log:debug "Prompt buffer interrupted")
-          nil)))))
+    ;; It's important to rebind `args' since it may otherwise be shared with the
+    ;; caller.
+    (let ((command command)
+          (args args))
+      (with-current-buffer (current-buffer) ; See `run' for why we bind current buffer.
+        (handler-case (apply #'funcall command args)
+          (nyxt-prompt-buffer-canceled ()
+            (log:debug "Prompt buffer interrupted")
+            nil))))))
 
 (define-command noop ()                 ; TODO: Replace with ESCAPE special command that allows dispatched to cancel current key stack.
   "A command that does nothing.


### PR DESCRIPTION
This is an alternative to https://github.com/atlas-engineer/nyxt/pull/1582 which wanted to forbid required arguments in commands.

As @jmercouris suggested in #1582, we could instead prompt the user to fill in the required argument when the command is called.  This would make command writing must faster when the input is trivial (raw-sources).
We could even infer the prompt buffer source from the argument type.

To this end, I started overhauling `execute-extended-command`.  It now prefills the values and does type-checking!
It also fixes  https://github.com/atlas-engineer/nyxt/issues/1586.

To do:
- Once `execute-extended-command` is approved, implement the above idea for general command calls!