### PR TITLE
tutorial.lisp: copy and paste commands

### DIFF
--- a/source/password.lisp
+++ b/source/password.lisp
@@ -108,7 +108,7 @@ for which the `executable' slot is non-nil."
          ,@body)))
 
 (define-command copy-password-prompt-details (&optional (buffer (current-buffer)))
-  "Copy password prompting for all the details without suggestion."
+  "Copy password prompting for all the details without suggestions."
   (password-debug-info)
   (if (password-interface buffer)
       (let* ((password-name (first (prompt

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -125,26 +125,27 @@ to quickly find whatever buffer you are looking for.")
     (:li (command-markup 'switch-buffer-previous) ": Go to previous buffer."))
    (:h3 "Copying and Pasting")
    (:p "Unlike other web browsers, Nyxt provides powerful ways of copying
-   and pasting content via different commands. Starting from the classic:")
+   and pasting content via different commands. Starting from:")
    (:ul
-    (:li (command-markup 'nyxt/web-mode:copy) ": Copy selected text to clipboard.")
-    (:li (command-markup 'nyxt/web-mode:paste) ": Paste from the clipboard into active-element."))
+    (:li (command-markup 'nyxt/web-mode:copy) ": " (command-docstring-first-sentence 'nyxt/web-mode:copy))
+    (:li (command-markup 'nyxt/web-mode:paste) ": " (command-docstring-first-sentence 'nyxt/web-mode:paste)))
    (:p "Passing through webpage's data:")
    (:ul
-    (:li (command-markup 'copy-url) ": Save the current URL to the clipboard.")
-    (:li (command-markup 'copy-title) ": Save current page title to the clipboard.")
-    (:li (command-markup 'nyxt/web-mode:copy-placeholder) ": Copy placeholder text to clipboard.")
-    (:li (command-markup 'nyxt/web-mode:copy-hint-url) ": Show a set of element
-    hints, and copy the URL of the user inputted one."))
+    (:li (command-markup 'copy-url) ": " (command-docstring-first-sentence 'copy-url))
+    (:li (command-markup 'copy-title) ": " (command-docstring-first-sentence 'copy-title))
+    (:li (command-markup 'nyxt/web-mode:copy-placeholder) ": " (command-docstring-first-sentence 'nyxt/web-mode:copy-placeholder))
+    (:li (command-markup 'nyxt/web-mode:copy-hint-url) ": " (command-docstring-first-sentence 'nyxt/web-mode:copy-hint-url)))
    (:p "Leveraging password managers: ")
-   (:ul
-    (:li (command-markup 'copy-username) ": Query username and copy to clipboard.")
-    (:li (command-markup 'copy-password) ": Query password and copy to clipboard.")
-    (:li (command-markup 'copy-password-prompt-details) ": Copy password prompting for all the details without suggestion."))
+   #+nil
+   (:ul 
+    (:li (command-markup 'copy-username) ": " (command-docstring-first-sentence 'copy-username))
+    (:li (command-markup 'copy-password) ": " (command-docstring-first-sentence 'copy-password))
+    (:li (command-markup 'copy-password-prompt-details) ": " (command-docstring-first-sentence 'copy-password-prompt-details)))
    (:p "And more: ")
+   #+nil 
    (:ul
-    (:li (command-markup 'nyxt/web-mode:paste-from-clipboard-ring) ": Show browser clipboard ring and paste selected entry.")
-    (:li (command-markup 'copy-system-information) ": Save system information into the clipboard. Especially useful when reporting bugs."))
+    (:li (command-markup 'nyxt/web-mode:paste-from-clipboard-ring) ": " (command-docstring-first-sentence 'nyxt/web-mode:paste-from-clipboard-ring))
+    (:li (command-markup 'copy-system-information) ": " (command-docstring-first-sentence 'copy-system-information)))
    (:h3 "Link navigation")
    (:p "Link-hinting allows you to visit URLs on a page without using the mouse.
 Invoke one of the commands below: several hints will appear on screen and all

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -125,26 +125,26 @@ to quickly find whatever buffer you are looking for.")
     (:li (command-markup 'switch-buffer-previous) ": Go to previous buffer."))
    (:h3 "Copying and Pasting")
    (:p "Unlike other web browsers, Nyxt provides powerful ways of copying
-   and pasting content via different commands. Starting from classic:")
+   and pasting content via different commands. Starting from the classic:")
    (:ul
     (:li (command-markup 'nyxt/web-mode:copy) ": Copy selected text to clipboard.")
-    (:li (command-markup 'nyxt/web-mode:paste) ": Paste from clipboard into active-element."))
-   (:p "Passing through webpage's metadata:")
+    (:li (command-markup 'nyxt/web-mode:paste) ": Paste from the clipboard into active-element."))
+   (:p "Passing through webpage's data:")
    (:ul
-    (:li (command-markup 'copy-url) ": Save current URL to clipboard.")
-    (:li (command-markup 'copy-title) ": Save current page title to clipboard.")
-    (:li (command-markup 'nyxt/web-mode:copy-placeholder) ": Copy placeholder text to clipboard."))
-   (:p "Leveraging Nyxt's password manager: ")
+    (:li (command-markup 'copy-url) ": Save the current URL to the clipboard.")
+    (:li (command-markup 'copy-title) ": Save current page title to the clipboard.")
+    (:li (command-markup 'nyxt/web-mode:copy-placeholder) ": Copy placeholder text to clipboard.")
+    (:li (command-markup 'nyxt/web-mode:copy-hint-url) ": Show a set of element
+    hints, and copy the URL of the user inputted one."))
+   (:p "Leveraging password managers: ")
    (:ul
     (:li (command-markup 'copy-username) ": Query username and copy to clipboard.")
     (:li (command-markup 'copy-password) ": Query password and copy to clipboard.")
     (:li (command-markup 'copy-password-prompt-details) ": Copy password prompting for all the details without suggestion."))
    (:p "And more: ")
    (:ul
-    (:li (command-markup 'nyxt/web-mode:copy-hint-url) ": Show a set of element
-    hints, and copy the URL of the user inputted one.")
-    (:li (command-markup 'copy-system-information) ": Save system information into the clipboard.")
-    (:li (command-markup 'nyxt/web-mode:paste-from-clipboard-ring) ": Show browser clipboard ring and paste selected entry."))
+    (:li (command-markup 'nyxt/web-mode:paste-from-clipboard-ring) ": Show browser clipboard ring and paste selected entry.")
+    (:li (command-markup 'copy-system-information) ": Save system information into the clipboard. Especially useful when reporting bugs."))
    (:h3 "Link navigation")
    (:p "Link-hinting allows you to visit URLs on a page without using the mouse.
 Invoke one of the commands below: several hints will appear on screen and all

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -123,6 +123,28 @@ full URL including the 'http://' prefix.")
 to quickly find whatever buffer you are looking for.")
     (:li (command-markup 'switch-buffer-next) ": Go to next buffer.")
     (:li (command-markup 'switch-buffer-previous) ": Go to previous buffer."))
+   (:h3 "Copying and Pasting")
+   (:p "Unlike other web browsers, Nyxt provides powerful ways of copying
+   and pasting content via different commands. Starting from classic:")
+   (:ul
+    (:li (command-markup 'nyxt/web-mode:copy) ": Copy selected text to clipboard.")
+    (:li (command-markup 'nyxt/web-mode:paste) ": Paste from clipboard into active-element."))
+   (:p "Passing through webpage's metadata:")
+   (:ul
+    (:li (command-markup 'copy-url) ": Save current URL to clipboard.")
+    (:li (command-markup 'copy-title) ": Save current page title to clipboard.")
+    (:li (command-markup 'nyxt/web-mode:copy-placeholder) ": Copy placeholder text to clipboard."))
+   (:p "Leveraging Nyxt's password manager: ")
+   (:ul
+    (:li (command-markup 'copy-username) ": Query username and copy to clipboard.")
+    (:li (command-markup 'copy-password) ": Query password and copy to clipboard.")
+    (:li (command-markup 'copy-password-prompt-details) ": Copy password prompting for all the details without suggestion."))
+   (:p "And more: ")
+   (:ul
+    (:li (command-markup 'nyxt/web-mode:copy-hint-url) ": Show a set of element
+    hints, and copy the URL of the user inputted one.")
+    (:li (command-markup 'copy-system-information) ": Save system information into the clipboard.")
+    (:li (command-markup 'nyxt/web-mode:paste-from-clipboard-ring) ": Show browser clipboard ring and paste selected entry."))
    (:h3 "Link navigation")
    (:p "Link-hinting allows you to visit URLs on a page without using the mouse.
 Invoke one of the commands below: several hints will appear on screen and all

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -535,7 +535,7 @@ Otherwise go forward to the only child."
      (:ul (nyxt::history-html-list :limit limit)))))
 
 (define-command paste ()
-  "Paste from clipboard into active-element."
+  "Paste from clipboard into active element."
   ;; On some systems like Xorg, clipboard pasting happens just-in-time.  So if we
   ;; copy something from the context menu 'Copy' action, upon pasting we will
   ;; retrieve the text from the GTK thread.  This is prone to create


### PR DESCRIPTION
Hi guys,

As discussed on issue #1577  and [here](https://github.com/atlas-engineer/nyxt/commit/2716a69bbf54eb38480de27cf6ccc08c181e37fd#commitcomment-52850352) I think the tutorial should 
describe the powerful features of copying and pasting provided by Nyxt.

There are 11 commands. I am aware that some (3) may be
conflated, that some (new) bindings may be created, and that some commands
might have their name changed. Even so, I thought that doing this PR
could be useful.

Either to trigger the mentioned changes or to help people understand
the current version. This content would have helped me 8 weeks ago
when I was new to Nyxt.

Basically, I used the docstrings from the command definition. The
exception was adding that `copy-system-information` could be useful
for bug reports and introducing the article `the` in some definitions
(Grammarly suggestion). The docstrings could incorporate these
changes.

Finally, I noticed an inconsistency on `copy` commands explanations. The
definitions use sometimes *copies* and sometimes *saves*. Maybe it would be better to use
just one verb (I prefer *save*).