### PR TITLE
Original desire of issue 1310: As a page is loaded, cheaply check it is frequently visited and not already bookmarked

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -106,6 +106,7 @@
                #+quicklisp
                (:file "lisp-system")
                ;; Core Modes
+               (:file "bookmark-frequent-visits-mode")
                (:file "editor-mode")
                (:file "plaintext-editor-mode")
                (:file "buffer-listing-mode")

--- a/source/bookmark-frequent-visits-mode.lisp
+++ b/source/bookmark-frequent-visits-mode.lisp
@@ -1,0 +1,51 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package :nyxt/bookmark-frequent-visits-mode
+    (:use :common-lisp :trivia :nyxt :alexandria)
+  (:documentation "Mode to bookmark frequently visited URLs."))
+(in-package :nyxt/bookmark-frequent-visits-mode)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
+  (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum))
+
+(define-mode bookmark-frequent-visits-mode ()
+  "Mode to bookmark frequently visited URLs while navigating the web."
+  ((threshold 20)
+   (constructor
+    (lambda (mode)
+      (nyxt:on-signal-load-finished mode (url (current-buffer)))))))
+
+(defun bookmark-frequent-visit (threshold)
+  "Check if current URL is frequently visited and not included in the
+bookmarks. If this is the case, prompt the user about bookmarking it."
+  (labels ((bookmarked-url-p (url-address)
+             "The local function `bookmarked-url-p' returns the URL
+           address itself if it is new to the bookmark list or NIL if it is
+           already there."
+             (let ((bookmarks-address-list
+                     (mapcar #'(lambda (e) (render-url (url e)))
+                             (with-data-unsafe (bookmarks (bookmarks-path (current-buffer)))
+                               bookmarks))))
+               (if (member url-address bookmarks-address-list :test #'string=)
+                   nil
+                   url-address))))
+    (sera:and-let* ((history-entries (with-data-unsafe (history (history-path (current-buffer)))
+                                        (mapcar #'htree:data (alex:hash-table-keys (htree:entries history)))))
+                    (current-url-history
+                      (find (url (current-buffer)) history-entries :test #'equalp :key #'url))
+                    (implicit-visits-value
+                      (nyxt::implicit-visits current-url-history))
+                    (current-url-address
+                      (render-url (url current-url-history)))
+                    (threshold threshold))
+                   (run-thread
+                    (if (and (> implicit-visits-value threshold)
+                           (bookmarked-url-p current-url-address))
+                      (if-confirm ("Bookmark ~a?" current-url-address)
+                                  (bookmark-url :url current-url-address)))))))
+
+(defmethod nyxt:on-signal-load-finished ((mode bookmark-frequent-visits-mode) url)
+  (bookmark-frequent-visit (threshold mode))
+  url)


### PR DESCRIPTION
Hi guys,

This an implementation for the **original** desire on issue #1310.

I have tried doing the prescribed "algorithm":

```text
Query the implicit-visit of the current URL (zero-cost)
Compare with the threshold.
If above threshold and not already bookmarked (single hash-table lookup), bookmark.
```

In addition to the prescription, I inserted a prompt asking the user to confirm the bookmarking. 

Currently, the implementation works but as an asynchronous process to be run on REPL.

I need to learn how to insert this function to run every time a webpage is loaded on Nyxt. 
It would be nice to receive hints on how to do it :)

