### PR TITLE
window: Add `title' slot to allow customizing the window title.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -825,7 +825,7 @@ proceeding."
     ;; So that `current-buffer' returns the new value if buffer was
     ;; switched inside a `with-current-buffer':
     (setf %buffer nil)
-    (set-window-title window buffer)
+    (set-window-title window)
     (print-status nil window)
     (when (and (web-buffer-p buffer)
                (eq (slot-value buffer 'load-status) :unloaded))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -7,6 +7,10 @@
 
 (define-class window ()
   ((id "")
+   (title 'window-default-title
+          :type (or function function-symbol)
+          :documentation "Title of the window.
+It's a function of the window argument that returns the title as a string.")
    (active-buffer :accessor nil :reader active-buffer :export nil)
    (active-prompt-buffers '()
                           :export nil


### PR DESCRIPTION
Should fix one of the requirements of #1573 about customizing the window title.

Question: Should we name the slot `titler` instead?