### PR TITLE
Buffer tree!

### DIFF
--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -18,6 +18,7 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-w" 'delete-current-buffer
                      "C-shift-tab" 'switch-buffer-previous
                      "C-tab" 'switch-buffer-next
+                     "C-`" 'switch-buffer-last
                      "C-pageup" 'switch-buffer-previous
                      "C-pagedown" 'switch-buffer-next
                      "C-l" 'set-url

--- a/source/buffer-listing-mode.lisp
+++ b/source/buffer-listing-mode.lisp
@@ -84,3 +84,37 @@
                       (:a :class "button" :href (lisp-url '(nyxt/buffer-listing-mode::show-buffers-panel)) "Update ↺")
                       (loop for buffer in (buffer-list)
                             collect (buffer-markup buffer)))))))
+
+(define-command-global list-buffer-trees ()
+  "Draw the list of buffer trees.
+Buffers have relationships.  When a buffer is spawned from another one (e.g. by
+middle-clicking on a link), the new buffer is a child buffer.
+This kind of relationships creates 'trees' of buffers."
+  (labels ((buffer-markup (buffer)
+             "Present a buffer in HTML."
+             (markup:markup
+              (:p (:a :class "button"
+                      :href (lisp-url `(nyxt::delete-buffer :id ,(id buffer))) "✕")
+                  (:a :class "button"
+                      :href (lisp-url `(nyxt::switch-buffer :id ,(id buffer))) "→")
+                  (:span (title buffer) "  "
+                         (:u (render-url (url buffer)))))))
+           (buffer-tree->html (root-buffer)
+             "Render a single buffer tree to HTML."
+             (markup:markup
+              (:div (markup:raw (buffer-markup root-buffer)))
+              (:ul
+               (loop for child-buffer in (nyxt::buffer-children root-buffer)
+                     collect (markup:markup
+                              (:li
+                               (markup:raw (buffer-tree->html child-buffer)))))))))
+    (with-current-html-buffer (buffer "*Buffers*" 'nyxt/buffer-listing-mode:buffer-listing-mode)
+      (markup:markup
+       (:style (style buffer))
+       (:h1 "Buffers")
+       (:a :class "button" :href (lisp-url '(nyxt/buffer-listing-mode::list-buffers)) "Update")
+       (:br "")
+       (:div
+        (loop for buffer in (buffer-list)
+              unless (nyxt::buffer-parent buffer)
+                collect (buffer-tree->html buffer)))))))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1272,6 +1272,24 @@ generate a new URL query from user input.
        :key (lambda (b) (alex:when-let ((owner (htree:owner history (id b))))
                           (htree:creator-id owner)))))))
 
+(defun buffer-first-root (&optional (buffer (current-buffer)))
+  (alex:if-let ((parent (buffer-parent buffer)))
+    (buffer-first-root parent)
+    (first (first (buffer-siblings buffer)))))
+
+(defun buffer-last-child (&optional (buffer (current-buffer)))
+  (alex:if-let ((next-siblings (second (buffer-siblings buffer))))
+    (buffer-last-child (alex:last-elt next-siblings))
+    (alex:if-let ((children (buffer-children buffer)))
+      (buffer-last-child (alex:last-elt children))
+      buffer)))
+
+(defun buffer-next-parent-sibling (&optional (buffer (current-buffer)))
+  (alex:when-let ((parent (buffer-parent buffer)))
+    (alex:if-let ((next-siblings (second (buffer-siblings buffer))))
+      (first next-siblings)
+      (buffer-next-parent-sibling parent))))
+
 (defun buffer-siblings (&optional (buffer (current-buffer)))
   (let* ((current-history (get-data (history-path buffer)))
          (buffers (remove-if (complement (sera:eqs current-history))
@@ -1290,8 +1308,7 @@ generate a new URL query from user input.
                (sort common-parent-buffers #'string< :key #'id)))
         (sera:split-sequence-if (sera:equals (id buffer))
          common-parent-buffers
-         :key #'id
-         :remove-empty-subseqs t)))))
+         :key #'id)))))
 
 (defun buffer-sibling-previous (&optional (buffer (current-buffer)))
   (alex:when-let ((previous-siblings (first (buffer-siblings buffer))))
@@ -1301,21 +1318,25 @@ generate a new URL query from user input.
   (first (second (buffer-siblings buffer))))
 
 (define-command switch-buffer-previous (&optional (buffer (current-buffer)))
-  "Switch to the previous sibling buffer.
-A sibling buffer is a buffer with the same parent.
-The 'previous' one here means the one with the closest ID below it.
-If there is no sibling, go to the parent."
-  (alex:when-let ((previous (or (buffer-sibling-previous buffer)
-                                (buffer-parent buffer))))
+  "Switch to the previous buffer in the buffer tree.
+The tree is browse in a depth-first fashion.
+When there is no previous buffer, go to the last one so as to cycle."
+  (alex:when-let ((previous (or (alex:when-let ((previous-sibling (buffer-sibling-previous buffer)))
+                                  (alex:if-let ((children (buffer-children previous-sibling)))
+                                    (buffer-last-child (first children))
+                                    previous-sibling))
+                                (buffer-parent buffer)
+                                (buffer-last-child buffer))))
     (set-current-buffer previous)))
 
 (define-command switch-buffer-next (&optional (buffer (current-buffer)))
-  "Switch to the next sibling buffer.
-A sibling buffer is a buffer with the same parent.
-The 'next' one here means the one with the closest ID above it.
-If there is no sibling, go to the parent."
-  (alex:when-let ((next (or (buffer-sibling-next buffer)
-                            (buffer-parent buffer))))
+  "Switch to the next buffer in the buffer tree.
+The tree is browse in a depth-first fashion.
+When there is no next buffer, go to the first one so as to cycle."
+  (alex:when-let ((next (or (first (buffer-children buffer))
+                            (buffer-sibling-next buffer)
+                            (buffer-next-parent-sibling buffer)
+                            (buffer-first-root buffer))))
     (set-current-buffer next)))
 
 (define-command switch-buffer-last ()

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1254,31 +1254,76 @@ generate a new URL query from user input.
                                :multi-selection-p t
                                :actions (list 'reload-buffers)))))
 
-(define-command switch-buffer-previous ()
-  "Switch to the previous buffer in the list of buffers.
-That is to say, the one with the most recent access time after the current buffer.
-The current buffer access time is set to be the last so that if we keep calling
-this command it cycles through all buffers."
-  (let* ((buffers (sort-by-time (buffer-list)))
-         (last-buffer (alex:last-elt buffers))
-         (current-buffer (current-buffer)))
-    (when (second buffers)
-      (set-current-buffer (second buffers))
-      ;; Set the last-access time after switching buffer, since switching
-      ;; buffers already sets the slot.
-      (setf (last-access current-buffer)
-            (local-time:timestamp- (last-access last-buffer) 1 :sec)))))
+(defun buffer-parent (&optional (buffer (current-buffer)))
+  (with-data-unsafe (history (history-path buffer))
+    (sera:and-let* ((owner (htree:owner history (id buffer)))
+                    (parent-id (htree:creator-id owner)))
+      (gethash parent-id (buffers *browser*)))))
 
-(define-command switch-buffer-next ()   ; TODO: Rename switch-buffer-oldest
-  "Switch to the oldest buffer in the list of buffers."
-  (let* ((buffers (sort-by-time (buffer-list)))
-         (oldest-buffer (alex:last-elt buffers)))
-    (when (eq oldest-buffer (current-buffer))
-      ;; Current buffer may already be the oldest, e.g. if other buffer was
-      ;; opened in the background.
-      (setf oldest-buffer (or (second (nreverse buffers))
-                              oldest-buffer)))
-    (set-current-buffer oldest-buffer)))
+(defun buffer-children (&optional (buffer (current-buffer)))
+  (let* ((current-history (get-data (history-path buffer)))
+         (buffers (remove-if (complement (sera:eqs current-history))
+                             (buffer-list)
+                             :key (alex:compose #'get-data #'history-path))))
+    (with-data-unsafe (history (history-path buffer))
+      (sera:filter
+       (sera:equals (id buffer))
+       buffers
+       :key (lambda (b) (alex:when-let ((owner (htree:owner history (id b))))
+                          (htree:creator-id owner)))))))
+
+(defun buffer-siblings (&optional (buffer (current-buffer)))
+  (let* ((current-history (get-data (history-path buffer)))
+         (buffers (remove-if (complement (sera:eqs current-history))
+                             (buffer-list)
+                             :key (alex:compose #'get-data #'history-path))))
+    (with-data-unsafe (history (history-path buffer))
+      (let* ((owner (htree:owner history (id buffer)))
+             (current-parent-id (when owner (htree:creator-id owner)))
+             (common-parent-buffers
+               (sera:filter
+                (sera:equals current-parent-id)
+                buffers
+                :key (lambda (b) (alex:when-let ((owner (htree:owner history (id b))))
+                                   (htree:creator-id owner)))))
+             (common-parent-buffers
+               (sort common-parent-buffers #'string< :key #'id)))
+        (sera:split-sequence-if (sera:equals (id buffer))
+         common-parent-buffers
+         :key #'id
+         :remove-empty-subseqs t)))))
+
+(defun buffer-sibling-previous (&optional (buffer (current-buffer)))
+  (alex:when-let ((previous-siblings (first (buffer-siblings buffer))))
+    (alex:last-elt previous-siblings)))
+
+(defun buffer-sibling-next (&optional (buffer (current-buffer)))
+  (first (second (buffer-siblings buffer))))
+
+(define-command switch-buffer-previous (&optional (buffer (current-buffer)))
+  "Switch to the previous sibling buffer.
+A sibling buffer is a buffer with the same parent.
+The 'previous' one here means the one with the closest ID below it.
+If there is no sibling, go to the parent."
+  (alex:when-let ((previous (or (buffer-sibling-previous buffer)
+                                (buffer-parent buffer))))
+    (set-current-buffer previous)))
+
+(define-command switch-buffer-next (&optional (buffer (current-buffer)))
+  "Switch to the next sibling buffer.
+A sibling buffer is a buffer with the same parent.
+The 'next' one here means the one with the closest ID above it.
+If there is no sibling, go to the parent."
+  (alex:when-let ((next (or (buffer-sibling-next buffer)
+                            (buffer-parent buffer))))
+    (set-current-buffer next)))
+
+(define-command switch-buffer-last ()
+  "Switch to the last showing buffer in the list of buffers.
+That is to say, the one with the most recent access time after the current buffer."
+  (let* ((buffers (sort-by-time (buffer-list))))
+    (when (second buffers)
+      (set-current-buffer (second buffers)))))
 
 (export-always 'mode-name)
 (defun mode-name (mode)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1266,11 +1266,12 @@ generate a new URL query from user input.
                              (buffer-list)
                              :key (alex:compose #'get-data #'history-path))))
     (with-data-unsafe (history (history-path buffer))
-      (sera:filter
-       (sera:equals (id buffer))
-       buffers
-       :key (lambda (b) (alex:when-let ((owner (htree:owner history (id b))))
-                          (htree:creator-id owner)))))))
+      (sort (sera:filter
+              (sera:equals (id buffer))
+              buffers
+              :key (lambda (b) (alex:when-let ((owner (htree:owner history (id b))))
+                                 (htree:creator-id owner))))
+            #'string< :key #'id))))
 
 (defun buffer-first-root (&optional (buffer (current-buffer)))
   (alex:if-let ((parent (buffer-parent buffer)))


### PR DESCRIPTION
This addresses #854 as well as some points mentioned in #1573 and in #565.

This changes the logic of `switch-buffer-previous` and `switch-buffer-next` to finally fix the long-standing issue of "jumping-around buffer last-access".

Now to go to the last visited buffer, use the new `switch-buffer-last`.

`switch-buffer-previous` visits the previous siblings (siblings are sorted by ID), `switch-buffer-next` to the next.

Questions before we can merge: can we browse the whole tree (including children and parents) with just `switch-buffer-previous` and `switch-buffer-next`?
To do so with just 2 commands we'd need to keep track of the visited parents (this is OK, can store it as a buffer slot).  Is this what we want?

Example:

- root
  - childA
    - subchildA1 
    - subchildA2
  - childB
    -  subchildB1
    - subchildB2

If we are on childA, successive calls to switch-buffer-next should visit, in order:
- subchildA1 
- subchildA2
- childB
-  subchildB1
- subchildB2
- root
- childA

and we loop.

Does that make the most sense?
