### PR TITLE
Avoid the generation of two final dots "." while inserting command docstrings automatically inside the documentation

### DIFF
--- a/source/input.lisp
+++ b/source/input.lisp
@@ -23,8 +23,7 @@
   `(markup:raw
     (format nil "<span>~a</span>"
             (str:concat (or (first (str:split ". " (documentation ,fn 'function)))
-                            (error "Undocumented function ~a." ,fn))
-                        "."))))
+                            (error "Undocumented function ~a." ,fn))))))
 
 (deftype nyxt-keymap-value ()
   '(or keymap:keymap function-symbol command))


### PR DESCRIPTION
I guess the current macro generates an extra final dot "." since the docstring already has a "."
This is what I see in my manual under version `Version 2.1.1-37-g42946c64` on Master commit  `42946c6459`:

![image](https://user-images.githubusercontent.com/7698207/124524677-5a224c80-ddd2-11eb-9642-f0b702ace7e3.png)

If I remove the last part of the string concatenation, I think it will work appropriately. Not sure if this happened **only** in few cases.

P.S.: Please double check before merging it, macros in CL are still not clear for me. Any change on macro definitions should be carefully reviewed :)