### PR TITLE
Recover from broken init

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -225,6 +225,17 @@ prevents otherwise."))
   "Get the window containing a buffer."
   (find buffer (alex:hash-table-values (windows browser)) :key #'active-buffer))
 
+(defun reset-browser (browser &key message)
+  (setf *browser*
+        (make-instance 'user-browser
+                       :startup-error-reporter-function (if message
+                                                            (lambda ()
+                                                              (echo-warning "Resetting state and restarting due to `startup' error: ~a" message)
+                                                              (error-in-new-window "*Initialization errors*" message))
+                                                            (startup-error-reporter-function browser))
+         :startup-timestamp (startup-timestamp browser)
+         :socket-thread (socket-thread browser))))
+
 (defmethod finalize ((browser browser) urls startup-timestamp)
   "Run `*after-init-hook*' then BROWSER's `startup'."
   ;; `messages-appender' requires `*browser*' to be initialized.
@@ -245,7 +256,14 @@ prevents otherwise."))
    browser
    (lambda ()
      (run-thread
-       (startup browser urls))))
+       (handler-case
+           (startup browser urls)
+         (t (c)
+           (reset-all-user-classes)
+           ;; Broken windows may have been created, let's destroy them.
+           (mapc #'ffi-window-delete (window-list))
+           (reset-browser browser :message c)
+           (startup *browser* urls))))))
   ;; Set 'init-time at the end of finalize to take the complete startup time
   ;; into account.
   (setf (slot-value *browser* 'init-time)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -225,16 +225,32 @@ prevents otherwise."))
   "Get the window containing a buffer."
   (find buffer (alex:hash-table-values (windows browser)) :key #'active-buffer))
 
-(defun reset-browser (browser &key message)
-  (setf *browser*
-        (make-instance 'user-browser
-                       :startup-error-reporter-function (if message
-                                                            (lambda ()
-                                                              (echo-warning "Resetting state and restarting due to `startup' error: ~a" message)
-                                                              (error-in-new-window "*Initialization errors*" message))
-                                                            (startup-error-reporter-function browser))
-         :startup-timestamp (startup-timestamp browser)
-         :socket-thread (socket-thread browser))))
+(defun restart-with-message (&optional condition)
+  (flet ((set-error-message (message full-message)
+           (let ((*package* (find-package :cl))) ; Switch package to use non-nicknamed packages.
+             (write-to-string
+              `(serapeum/contrib/hooks:add-hook
+                nyxt:*after-init-hook*
+                (serapeum/contrib/hooks:make-handler-void
+                 (lambda ()
+                   (setf (nyxt::startup-error-reporter-function *browser*)
+                         (lambda ()
+                           (nyxt:echo-warning "Restarted without init file due to error: ~a." ,message)
+                           (nyxt::error-in-new-window "*Initialization error*" ,full-message))))
+                 :name 'error-reporter))))))
+    (let* ((message (princ-to-string condition))
+           (full-message (format nil "Startup error: ~a.~%~&Restarted Nyxt without init file ~s."
+                                 message
+                                 (expand-path *init-file-path*)))
+           (new-command-line (append (uiop:raw-command-line-arguments)
+                                     `("--no-init"
+                                       "--eval"
+                                       ,(set-error-message message full-message)))))
+      (log:warn "Restarting with ~s."
+                (append (uiop:raw-command-line-arguments)
+                        '("--no-init")))
+      (uiop:launch-program new-command-line)
+      (quit))))
 
 (defmethod finalize ((browser browser) urls startup-timestamp)
   "Run `*after-init-hook*' then BROWSER's `startup'."
@@ -256,15 +272,23 @@ prevents otherwise."))
    browser
    (lambda ()
      (run-thread
-       (handler-case
+       ;; Restart on init error, in case `*init-file-path*' broke the state.
+       ;; We only `handler-case' when there is an init file, this way we avoid
+       ;; looping indefinitely.
+       (if (or (getf *options* :no-init)
+               (not (uiop:file-exists-p (expand-path *init-file-path*))))
            (startup browser urls)
-         (t (c)
-           (reset-all-user-classes)
-           ;; Broken windows may have been created, let's destroy them.
-           (mapc #'ffi-window-delete (window-list))
-           (reset-browser browser :message c)
-           (startup *browser* urls))))))
-  ;; Set 'init-time at the end of finalize to take the complete startup time
+           (handler-case (startup browser urls)
+             (error (c)
+               (log:error "Startup failed (probably due to a mistake in ~s):~&~a"
+                          (expand-path *init-file-path*) c)
+               (if *run-from-repl-p*
+                   (progn
+                     (quit)
+                     (reset-all-user-classes)
+                     (apply #'start (append *options* (list :urls urls :no-init t))))
+                   (restart-with-message c))))))))
+  ;; Set `init-time' at the end of finalize to take the complete startup time
   ;; into account.
   (setf (slot-value *browser* 'init-time)
         (local-time:timestamp-difference (local-time:now) startup-timestamp))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -258,7 +258,7 @@ separated from one another, so that each has its own behaviour and settings."))
 The mode instances are stored in the `modes' BUFFER slot.
 
 The default modes returned by this method are appended to the default modes
-inherited from the superclasses.  Duplicates are removed."))
+inherited from the superclasses."))
 
 (defmethod default-modes :around ((buffer buffer))
   "Remove the duplicates from the `default-modes'."

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -130,6 +130,12 @@ This is useful for local changes to a class, or to add generated superclasses."
                                :direct-superclasses superclasses-with-original
                                :documentation (documentation class-sym 'type)))))
 
+(defun reset-user-class (class-sym)
+  (set-user-class class-sym (gethash class-sym *user-classes*)))
+
+(defun reset-all-user-classes ()
+  (mapc #'reset-user-class (alex:hash-table-keys *user-classes*)))
+
 (defun user-class-p (class-specifier)
   (sera:true (gethash (if (symbolp class-specifier)
                           class-specifier

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -202,6 +202,8 @@ CLASS-SYM to NEW-SUPERCLASSES.  The class is restored when exiting BODY."
                   else do
                     (log:warn "Undefined slot ~a in ~a" (first slot) final-name)))
          (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+       ;; TODO: Register the user methods and add function to remove them, like
+       ;; `reset-user-class'.
        ;; Non-standard accessors, e.g. `default-modes':
        ,@(loop for slot in (remove-if #'standard-method-combination-p (first slots)
                                       :key #'first)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -546,8 +546,8 @@ Finally, run the browser, load URL-STRINGS if any, then run
       (load-or-eval :remote nil)
       (setf *browser* (make-instance 'user-browser
                                      :startup-error-reporter-function startup-error-reporter
-                                     :startup-timestamp startup-timestamp))
-      (setf (socket-thread *browser*) thread)
+                                     :startup-timestamp startup-timestamp
+                                     :socket-thread thread))
       ;; Defaulting to :nyxt-user is convenient when evaluating code (such as
       ;; remote execution or the integrated REPL).
       ;; This must be done in a separate thread because the calling thread may

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -105,12 +105,16 @@ The socket can also be set from the NYXT_SOCKET environment variable.")
        :short #\e
        :long "eval"
        :arg-parser #'identity
-       :description "Eval the Lisp expressions.  Can be specified multiple times.")
+       :description "Eval the Lisp expressions.  Can be specified multiple times.
+Without --quit or --remote, the evaluation is done after parsing the init file
+(if any) and before initializing the browser.")
       (:name :load
        :short #\l
        :long "load"
        :arg-parser #'identity
-       :description "Load the Lisp file.  Can be specified multiple times.")
+       :description "Load the Lisp file.  Can be specified multiple times.
+Without --quit or --remote, the loading is done after parsing the init file
+(if any) and before initializing the browser.")
       (:name :quit
        :short #\q
        :long "quit"


### PR DESCRIPTION
This is where functional style and user classes really pay off!

Previously, if an init file was syntactically correct but would break Nyxt otherwise, the browser would fail to start in the weidest ways (e.g. blank window).

Now startup errors are caught and the state is almost completely reinitialized, then the error is displayed as usual using the reported.

Notes:
- The user classes implementation is completely upside down, but I don't think we can easily overhaul this without breaking backward compatibility.  We can do this for 3.0.  See https://github.com/atlas-engineer/nyxt/issues/1431.

- If you want to test, in particular compare the behaviour with master, try adding this to your init file:

```lisp
(define-configuration window
  ((status-formatter 17)))
```

From KABOOM! to swooosh! :)