### PR TITLE
Replace tutorial and manual markup:markup with `who' markup.

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -159,6 +159,7 @@
        ("cl-markup" ,cl-markup)
        ("cl-ppcre" ,cl-ppcre)
        ("cl-prevalence" ,cl-prevalence)
+       ("cl-who" ,cl-who)
        ("closer-mop" ,cl-closer-mop)
        ("cluffer" ,cl-cluffer)
        ("dexador" ,cl-dexador)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -29,10 +29,11 @@
                cl-css
                cl-html-diff
                cl-json
-               cl-markup
+               cl-markup ; TODO: Replace with cl-who everywhere.
                cl-ppcre
                cl-ppcre-unicode
                cl-prevalence
+               cl-who
                closer-mop
                cl-containers
                moptilities

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -47,6 +47,9 @@
                   (make-instance 'class-source)
                   (make-instance 'slot-source))))
 
+(defmacro markup (&body body)
+  `(who:with-html-output-to-string (ignored) (who:htm ,@body)))
+
 (defun value->html (value &key (help-mode (current-mode 'help)))
   "Return the HTML representation of VALUE."
   (cond
@@ -554,14 +557,14 @@ The version number is stored in the clipboard."
 (define-command manual ()
   "Show the manual."
   (with-current-html-buffer (buffer "*Manual*" 'nyxt/help-mode:help-mode)
-    (str:concat (markup:markup (:style (style buffer)))
+    (str:concat (markup (:style (who:str (style buffer))))
                 (manual-content))))
 
 (define-command tutorial ()
   "Show the tutorial."
   (with-current-html-buffer (buffer "*Tutorial*" 'nyxt/help-mode:help-mode)
     (str:concat
-     (markup:markup
+     (markup
       (:style (style buffer))
       (:h1 "Nyxt tutorial")
       (:p "The following tutorial introduces core concepts and

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -7,20 +7,21 @@
 
 (defmacro command-markup (fn &key (modes nil explicit-modes-p))
   "Print FN in HTML followed its bindings in parentheses."
-  ;; Warning: We should not use markup:markup here because too much use of it
-  ;; inside another `markup:markup' takes forever to expand.
-  `(markup:raw
+  `(who:str
     (format nil "<span><code>~a</code> (<code>~a</code>)</span>"
             (string-downcase (symbol-name ,fn))
             (binding-keys ,fn ,@(if explicit-modes-p
                                    (list :modes modes)
                                    '())))))
 
+(defmacro command-keys (fn)
+  "Return `binding-keys' of FN for `who' markup."
+  `(who:str
+    (binding-keys ,fn)))
+
 (defmacro command-docstring-first-sentence (fn)
-  "Print FN first docstring sentence in HTML."
-  ;; Warning: We should not use markup:markup here because too much use of it
-  ;; inside another `markup:markup' takes forever to expand.
-  `(markup:raw
+  "Print FN first docstring sentence in an HTML span."
+  `(who:str
     (format nil "<span>~a</span>"
             (sera:ensure-suffix
              (or (first (ppcre:split "\\.\\s" (documentation ,fn 'function)))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -5,12 +5,12 @@
 
 (defun manual-content ()
   (str:concat
-   (markup:markup
+   (markup
     (:h1 "Nyxt manual")
     (:p "This manual first includes the tutorial, then covers the configuration
 of Nyxt."))
    (tutorial-content)
-   (markup:markup
+   (markup
     (:h2 "Configuration")
     (:p "Nyxt is written in the Common Lisp programming language which offers a
 great perk: everything in the browser can be customized by the user, even while
@@ -105,11 +105,11 @@ keybindings have priorities over the other modes.")
     (:p "See the " (:code "search-engines") " buffer slot documentation.
 Bookmarks can also be used as search engines, see the corresponding section.")
     (:p "Nyxt comes with some default search engines for "
-        (:code (format nil "~{~a~^, ~}"
-                       (mapcar (lambda (engine)
-                                 (quri:uri-host (quri:uri (getf engine :search-url))))
-                               (rest (getf (mopu:slot-properties 'buffer 'search-engines)
-                                           :initform)))))
+        (:code (who:str (format nil "~{~a~^, ~}"
+                                (mapcar (lambda (engine)
+                                          (quri:uri-host (quri:uri (getf engine :search-url))))
+                                        (rest (getf (mopu:slot-properties 'buffer 'search-engines)
+                                                    :initform))))))
         ". "
         "The following example shows one way to add new search engines.")
     (:pre (:code "

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -4,11 +4,11 @@
 (in-package :nyxt)
 
 (defun tutorial-content ()
-  (markup:markup
+  (markup
    (:h2 "Core Concepts")
    (:h3 "Keybindings and Commands")
    (:p "Commands are invoked by pressing specific keys or from
-the " (:code "execute-command") " menu (" (:code (binding-keys 'execute-command))
+the " (:code "execute-command") " menu (" (:code (command-keys 'execute-command))
 ").")
    (:p "Keybindings are represented like this: 'C-x'. In this example, 'C' is a
 shortcut for the modifier 'control', and 'x' represents the character 'x'. To
@@ -26,17 +26,17 @@ Multiple key presses can be chained: in 'C-x C-s', you would have to press
 
    (:h3 "Quickstart keys")
    (:ul
-    (:li (:code (binding-keys 'set-url)) ": Load URL")
-    (:li (:code (binding-keys 'reload-current-buffer)) ": Reload buffer")
-    (:li (:code (binding-keys 'set-url-new-buffer)) ": Load URL in new buffer")
-    (:li (:code (binding-keys 'switch-buffer-previous)) ", " (:code (binding-keys 'switch-buffer-next)) ": Switch buffer")
-    (:li (:code (binding-keys 'nyxt/web-mode:history-backwards)) ": Backwards history")
-    (:li (:code (binding-keys 'nyxt/web-mode:history-forwards)) ": Forwards history")
-    (:li (:code (binding-keys 'nyxt/web-mode:follow-hint)) ": Follow link in current buffer")
-    (:li (:code (binding-keys 'nyxt/web-mode:follow-hint-new-buffer)) ": Follow link in new buffer")
-    (:li (:code (binding-keys 'quit)) ": Quit")
-    (:li (:code (binding-keys 'execute-command)) ": Run a command by name")
-    (:li (:code (binding-keys 'describe-bindings)) ": List all bindings for the current buffer"))
+    (:li (:code (command-keys 'set-url)) ": Load URL")
+    (:li (:code (command-keys 'reload-current-buffer)) ": Reload buffer")
+    (:li (:code (command-keys 'set-url-new-buffer)) ": Load URL in new buffer")
+    (:li (:code (command-keys 'switch-buffer-previous)) ", " (:code (command-keys 'switch-buffer-next)) ": Switch buffer")
+    (:li (:code (command-keys 'nyxt/web-mode:history-backwards)) ": Backwards history")
+    (:li (:code (command-keys 'nyxt/web-mode:history-forwards)) ": Forwards history")
+    (:li (:code (command-keys 'nyxt/web-mode:follow-hint)) ": Follow link in current buffer")
+    (:li (:code (command-keys 'nyxt/web-mode:follow-hint-new-buffer)) ": Follow link in new buffer")
+    (:li (:code (command-keys 'quit)) ": Quit")
+    (:li (:code (command-keys 'execute-command)) ": Run a command by name")
+    (:li (:code (command-keys 'describe-bindings)) ": List all bindings for the current buffer"))
 
    (:h3 "Buffers")
    (:p "Nyxt uses the concept of buffers instead of tabs. Unlike tabs, buffers


### PR DESCRIPTION
It seems that markup:markup is poorly optimized and requires a high
dynamic-space-size just to expand and compile.
`who' does not seem to suffer from this issue.


@pdelfino @jmercouris Can you test and confirm it fixes #1600?