### PR TITLE
status: Add ellipsis after mode list to toggle modes.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -471,13 +471,13 @@ Delete it with `ffi-buffer-delete'."
                 :margin-left "-10px")
                ("#container"
                 :display "grid"
-                ;; Columns: controls, url, tabs, modes
-                :grid-template-columns "120px 2fr 3fr 240px"
+                ;; Columns: controls, url, tabs, modes, mode-ellipsis
+                :grid-template-columns "120px 2fr 3fr 240px 2em"
                 :overflow-y "hidden")
                ("#container-vi"
                 :display "grid"
-                ;; Columns: controls, vi-status, url, tabs, modes
-                :grid-template-columns "120px 30px 2fr 3fr 240px"
+                ;; Columns: controls, vi-status, url, tabs, modes, mode-ellipsis
+                :grid-template-columns "120px 30px 2fr 3fr 240px 2em"
                 :overflow-y "hidden")
                ("#controls"
                 :background-color "rgb(80,80,80)"
@@ -521,8 +521,9 @@ Delete it with `ffi-buffer-delete'."
                 :padding-right "5px")
                (".tab:hover"
                 :color "black")
+               (".modes"
+                :background-color "gray")
                ("#modes"
-                :background-color "gray"
                 :color "white"
                 :text-align "right"
                 :padding-left "10px"

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -91,7 +91,11 @@
            (:div :id "tabs"
                  (markup:raw
                   (format-status-tabs)))
-           (:div :id "modes" :class "arrow-left"
-                 :title (list-modes buffer)
+           (:div :id "modes" :class "modes arrow-left"
                  (markup:raw
-                  (format-status-modes buffer window)))))))
+                  (format-status-modes buffer window)))
+           (:div :id "mode-ellipsis" :class "modes"
+                 :title (list-modes buffer)
+                 (:a :class "button" :href (lisp-url `(toggle-modes))
+                     :title (list-modes buffer)
+                     "…"))))))


### PR DESCRIPTION
It's also useful to list the enabled modes when too many of them cannot be displayed.

This is particularly important since e131585fd5574cfe5b1e1d7d67c4508d68bbf470: hovering over the status modes won't display the full list anymore.  The ellipsis reintroduces this behaviour.

Should close https://github.com/atlas-engineer/nyxt/issues/904.