### PR TITLE
Updated README for debian based systems when building from source

### DIFF
--- a/documents/README.org
+++ b/documents/README.org
@@ -139,7 +139,7 @@ directory where ASDF will find it]]):
 
 - Debian-based distributions:
   #+begin_src sh
-    sudo apt install sbcl libwebkit2gtk-4.0-dev glib-networking gsettings-desktop-schemas libfixposix-dev xclip enchant
+    sudo apt install sbcl libwebkit2gtk-4.0-dev glib-networking gsettings-desktop-schemas libfixposix-dev xclip enchant-2
   #+end_src
 
 - Fedora:


### PR DESCRIPTION
On Debian-based distros, `enchant` has been removed.
Using enchant-2 however, resolves the issue, and building from source works then (issue #1588).
Tested on Ubuntu and Pop!_OS