### PR TITLE
Add link to QR code

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -159,6 +159,7 @@
        ("cl-markup" ,cl-markup)
        ("cl-ppcre" ,cl-ppcre)
        ("cl-prevalence" ,cl-prevalence)
+       ("cl-qrencode" ,cl-qrencode)
        ("closer-mop" ,cl-closer-mop)
        ("cluffer" ,cl-cluffer)
        ("dexador" ,cl-dexador)

--- a/documents/SOURCES.org
+++ b/documents/SOURCES.org
@@ -20,6 +20,7 @@ which external dependencies we are directly relying on.
 - cl-ppcre
 - cl-ppcre-unicode
 - cl-prevalence
+- cl-qrencode
 - closer-mop
 - dexador
 - enchant

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -33,6 +33,7 @@
                cl-ppcre
                cl-ppcre-unicode
                cl-prevalence
+               cl-qrencode
                closer-mop
                cl-containers
                moptilities

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -697,13 +697,6 @@ ELEMENT-SCRIPT is a Parenscript script that is passed to `ps:ps'."
   (with-current-buffer buffer
     (let* ((pathname (expand-path
                      (make-instance 'data-path :basename "qrcode.png")))
-          (url (quri:render-uri (url (current-buffer))))
-          (title (str:concat "QRcode for " url)))
-      (unwind-protect
-           (progn
-             (cl-qrencode:encode-png url :fpath pathname)
-             (make-buffer-focus :url (quri::make-uri-file :path pathname))
-             (sleep 0.1) ;; TODO it seems I cannot open the buffer in time if I delete the file at the end
-             (setf (title (current-buffer)) title)
-             )
-        (uiop:delete-file-if-exists pathname)))))
+          (url (quri:render-uri (url (current-buffer)))))
+      (cl-qrencode:encode-png url :fpath pathname)
+      (make-buffer-focus :url (quri::make-uri-file :path pathname)))))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -695,6 +695,15 @@ ELEMENT-SCRIPT is a Parenscript script that is passed to `ps:ps'."
 (define-command show-qrcode-of-current-url (&optional (buffer (current-buffer)))
   "Show the QR code containing the URL for the current buffer."
   (with-current-buffer buffer
-    (let ((pathname (str:concat (namestring uiop:*temporary-directory*) "qrcode.png")))
-        (cl-qrencode:encode-png (quri:render-uri (url (current-buffer))) :fpath pathname)
-        (uiop:run-program (list "nyxt" pathname)))))
+    (let* ((pathname (expand-path
+                     (make-instance 'data-path :basename "qrcode.png")))
+          (url (quri:render-uri (url (current-buffer))))
+          (title (str:concat "QRcode for " url)))
+      (unwind-protect
+           (progn
+             (cl-qrencode:encode-png url :fpath pathname)
+             (make-buffer-focus :url (quri::make-uri-file :path pathname))
+             (sleep 0.1) ;; TODO it seems I cannot open the buffer in time if I delete the file at the end
+             (setf (title (current-buffer)) title)
+             )
+        (uiop:delete-file-if-exists pathname)))))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -691,3 +691,10 @@ ELEMENT-SCRIPT is a Parenscript script that is passed to `ps:ps'."
   ;; Need to force document-model re-parsing.
   (setf (document-model mode) nil)
   url)
+
+(define-command show-qrcode-of-current-url (&optional (buffer (current-buffer)))
+  "Show the QR code containing the URL for the current buffer."
+  (with-current-buffer buffer
+    (let ((pathname (str:concat (namestring uiop:*temporary-directory*) "qrcode.png")))
+        (cl-qrencode:encode-png (quri:render-uri (url (current-buffer))) :fpath pathname)
+        (uiop:run-program (list "nyxt" pathname)))))


### PR DESCRIPTION
**Note: I am new to Common Lisp and Nyxt development practices and I didn't manage to build this locally (I got some errors). Some guidance would be very welcome (please @Ambrevar !), because I would like to contribute more once I get how this works :)**

This lets you easily pass the link of the page you are viewing to your
mobile phone. Thanks to Karl Voit for the idea.

For reference, I wrote more about the reasoning here:
https://ag91.github.io/blog/2021/06/29/extending-nyxt-via-emacs-how-to-leverage-common-lisp-wealth-to-get-your-links-as-qr-codes/