### PR TITLE
dom: Complete relative URLs in follow-hint & friends.

### DIFF
--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -167,6 +167,20 @@ JSON should have the format like what `get-document-body-json' produces:
       (json-to-plump json root)
       (name-dom-elements root))))
 
+(defmethod url :around ((element plump:element))
+  (alex:when-let* ((result (call-next-method))
+                   (url (nyxt::ensure-url result)))
+    (render-url
+     (if (valid-url-p result)
+         url
+         (apply #'quri:copy-uri (url (current-buffer))
+                (append (when (quri:uri-scheme url) `(:scheme ,(quri:uri-scheme url)))
+                        (when (quri:uri-userinfo url) `(:userinfo ,(quri:uri-userinfo url)))
+                        (when (quri:uri-host url) `(:host ,(quri:uri-host url)))
+                        (when (quri:uri-port url) `(:port ,(quri:uri-port url)))
+                        (when (quri:uri-path url) `(:path ,(quri:uri-path url)))
+                        (when (quri:uri-fragment url) `(:fragment ,(quri:uri-fragment url)))))))))
+
 (defmethod url ((element plump:element))
   (when (plump:has-attribute element "href")
     (plump:get-attribute element "href")))

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -168,18 +168,20 @@ JSON should have the format like what `get-document-body-json' produces:
       (name-dom-elements root))))
 
 (defmethod url :around ((element plump:element))
-  (alex:when-let* ((result (call-next-method))
-                   (url (nyxt::ensure-url result)))
-    (render-url
-     (if (valid-url-p result)
-         url
-         (apply #'quri:copy-uri (url (current-buffer))
-                (append (when (quri:uri-scheme url) `(:scheme ,(quri:uri-scheme url)))
-                        (when (quri:uri-userinfo url) `(:userinfo ,(quri:uri-userinfo url)))
-                        (when (quri:uri-host url) `(:host ,(quri:uri-host url)))
-                        (when (quri:uri-port url) `(:port ,(quri:uri-port url)))
-                        (when (quri:uri-path url) `(:path ,(quri:uri-path url)))
-                        (when (quri:uri-fragment url) `(:fragment ,(quri:uri-fragment url)))))))))
+  (flet ((merge-url* (url default-url)
+           (apply #'quri:copy-uri default-url
+                  (append (when (quri:uri-scheme url) `(:scheme ,(quri:uri-scheme url)))
+                          (when (quri:uri-userinfo url) `(:userinfo ,(quri:uri-userinfo url)))
+                          (when (quri:uri-host url) `(:host ,(quri:uri-host url)))
+                          (when (quri:uri-port url) `(:port ,(quri:uri-port url)))
+                          (when (quri:uri-path url) `(:path ,(quri:uri-path url)))
+                          (when (quri:uri-fragment url) `(:fragment ,(quri:uri-fragment url)))))))
+    (alex:when-let* ((result (call-next-method))
+                     (url (nyxt::ensure-url result)))
+      (render-url
+       (if (valid-url-p result)
+           url
+           (merge-url* url (url (current-buffer))))))))
 
 (defmethod url ((element plump:element))
   (when (plump:has-attribute element "href")


### PR DESCRIPTION
This fixes the problem with `follow-hint-new-buffer` trying to follow relative URLs and failing. This wasn't the problem for `follow-hint`, because `ffi-buffer-load` resolves URLs based on current one. New buffers have no URLs, so there's nothing to resolve based on.

# Things to discuss:
- Maybe it should belong to a wider scope, to make e.g. element-frame benefit from it?
- Maybe abstract the `(apply #'copy-url ...)` part to a separate function (`merge-urls`?), akin to `merge-pathnames` filling the blanks in pathnames.

Closes #1623 