### PR TITLE
Replace UIOP:RUN-PROGRAM with SERAPEUM:RESOLVE-EXECUTABLE

### DIFF
--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -73,9 +73,7 @@ If PASSWORD-NAME is empty, then generate a new password."))
 (defun executable-find (command)
   "Search for COMMAND in the PATH and return the absolute file name.
 Return nil if COMMAND is not found anywhere."
-  (ignore-errors
-   (uiop:run-program (format nil "command -v ~A" command)
-                     :output '(:string :stripped t))))
+  (serapeum:resolve-executable command))
 
 (export-always '*interfaces*)
 (defvar *interfaces* (list))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -428,7 +428,8 @@ See `asdf::*immutable-systems*'."
                str
                trivial-clipboard
                uiop
-               nyxt/class-star)
+               nyxt/class-star
+               serapeum)
   :pathname "libraries/password-manager/"
   :components ((:file "package")
                (:file "password")


### PR DESCRIPTION
UIOP:RUN-PROGRAM introduces a long delay on some platfroms
(e.g. on FreeBSD 13.0 with SBCL 2.1.6 built from lang/sbcl port).

This causes any new prompt buffer to take up to 30 seconds to show
up. SERAPEUM:RESOLVE-EXECUTABLE does not have such issues.

See #1630 