### PR TITLE
Fix prompt memory leaks

### DIFF
--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -13,7 +13,12 @@
                   :type calispel:channel
                   :export nil
                   :documentation
-                  "Communication channel with the `update' thread."))
+                  "Communication channel with the `update' thread.")
+   (sync-interrupt-channel (make-channel)
+                           :type calispel:channel
+                           :export nil
+                           :documentation
+                           "This channel can be used to stop the queue listening."))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))
   (:documentation "This object is used to memorize which sources are ready for a
 given input.
@@ -175,6 +180,7 @@ Signal destruction by sending a value to PROMPTER's `interrupt-channel'."
         (sources prompter))
   (maybe-funcall (after-destructor prompter))
   ;; TODO: Interrupt before or after destructor?
+  (calispel:! (sync-interrupt-channel (sync-queue prompter)) t)
   (calispel:! (interrupt-channel prompter) t))
 
 (export-always 'call-follow-mode-function)
@@ -400,28 +406,36 @@ instead."
   "Block and return next PROMPTER ready source.
 It's the next source that's done updating.
 If all sources are done, return t.
-If timeout expires for one source, return nil."
-  ;; We copy `sync-queue' here so that it remains the same object throughout
-  ;; this function, since the slot is subject to be changed concurrently when
-  ;; the input is edited.
-  (alex:if-let ((sync-queue (sync-queue prompter)))
-    (if (= (length (ready-sources sync-queue))
-           (length (sources prompter)))
-        t
-        (multiple-value-bind (next-source ok)
-            (calispel:? (ready-channel sync-queue) timeout)
-          (cond
-            ((not ok)
-             nil)
-            ((null next-source)
-             nil)
-            (t
-             (push next-source (ready-sources sync-queue))
-             ;; Update selection when update is done:
-             (select-first prompter)
-             next-source))))
-    ;; No sync-queue if no input was ever set.
-    t))
+This is unblocked when the PROMPTER is `destroy'ed.
+
+TIMEOUT is deprecated."
+  (declare (ignore timeout)) ; Deprecated.
+  (when prompter
+    ;; We let-bind `sync-queue' here so that it remains the same object throughout
+    ;; this function, since the slot is subject to be changed concurrently when
+    ;; the input is edited.
+    (alex:if-let ((sync-queue (sync-queue prompter)))
+      (if (= (length (ready-sources sync-queue))
+             (length (sources prompter)))
+          t
+          (progn
+            (log:info "LISTEN" prompter (ready-channel sync-queue))
+            (calispel:fair-alt
+              ((calispel:? (ready-channel sync-queue) next-source)
+               (log:info "LISTENED" next-source)
+               (cond
+                 ((null next-source)
+                  nil)
+                 (t
+                  (push next-source (ready-sources sync-queue))
+                  ;; Update selection when update is done:
+                  (select-first prompter)
+                  next-source)))
+              ((calispel:? (sync-interrupt-channel sync-queue))
+               (log:info "LISTENING INTERRUPTED")
+               nil))))
+      ;; No sync-queue if no input was ever set.
+      t)))
 
 (export-always 'all-ready-p)
 (defun all-ready-p (prompter &optional timeout)

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -388,7 +388,7 @@ instead."
   (alex:if-let ((selection-values (resolve-selection prompter)))
     (let ((action-result (funcall action selection-values)))
       (calispel:! (result-channel prompter) action-result))
-    (calispel:! (interrupt-channel prompter) t)))
+    (destroy prompter)))
 
 (export-always 'toggle-follow)
 (defun toggle-follow (prompter &optional (source (selected-source prompter)))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -371,7 +371,7 @@ current buffer."
                                              :proxy proxy-url))
              (push download downloads)
              ;; Add a watcher / renderer for monitoring download
-             (let ((download-render (make-instance 'download :url (render-url url))))
+             (let ((download-render (make-instance 'user-download :url (render-url url))))
                (setf (destination-path download-render)
                      (download-manager:filename download))
                (push download-render (downloads *browser*))

--- a/source/debug.lisp
+++ b/source/debug.lisp
@@ -57,7 +57,7 @@ be done automatically, but then how would we access the weak pointers?
   "Return the list of all Nyxt object pointers of type CLASS-SYM.
 Example:
 
-  (sb-ext:search-roots (find-nyxt-objects 'user-web-buffer) :print nil)
+  (sb-ext:search-roots (find-nyxt-objects 'user-web-buffer) :print :verbose)
 
 Use `:print :verbose' is you want a human-readable overview.
 See also `find-object-by-address' (SBCL only)."

--- a/source/file-manager.lisp
+++ b/source/file-manager.lisp
@@ -23,7 +23,9 @@
 It's suitable for `prompter:filter-preprocessor'."
   (lambda (suggestions source input)
     (declare (ignore suggestions))
-    (let ((pathname (uiop:ensure-pathname input)))
+    (let ((pathname (uiop:ensure-pathname (if (uiop:emptyp input)
+                                              *default-pathname-defaults*
+                                              input))))
       (prompter:filter-exact-matches
        (prompter:ensure-suggestions-list
         source

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -307,7 +307,7 @@ current unmarked selection."
 
 (define-command-prompt cancel-input (prompt-buffer) ; TODO: Rename.
   "Close the prompt-buffer without further action."
-  (hide-prompt-buffer prompt-buffer))
+  (prompter:destroy prompt-buffer))
 
 (define-command-prompt toggle-follow (prompt-buffer)
   "Close the prompt-buffer without further action."

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -305,7 +305,8 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                                "display:revert;")
                                     (loop for attribute-key in (prompter:active-attributes-keys source)
                                           collect (:th attribute-key)))
-                               (loop ;; TODO: Only print as many lines as fit the height.
+                               (loop ;; TODO: Only print as many lines as fit the height.  But how can we know in advance?
+                                     ;; Maybe first make the table, then add the element one by one _if_ there are into view.
                                      with max-suggestion-count = 10
                                      repeat max-suggestion-count
                                      with cursor-index = (prompter:selected-suggestion-position prompt-buffer)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -425,8 +425,8 @@ Example use:
   :sources (list (make-instance 'prompter:source :filter #'my-suggestion-filter)))
 
 See the documentation of `prompt-buffer' to know more about the options."
-    (let ((result-channel (make-channel 1))
-          (interrupt-channel (make-channel 1))
+    (let ((result-channel (make-channel))
+          (interrupt-channel (make-channel))
           (parent-thread-prompt-buffer nil))
       (ffi-within-renderer-thread
        *browser*

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -382,7 +382,8 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                      value))))))
     (setf (prompter:input prompt-buffer) input)
     ;; TODO: Stop loop when prompt-buffer is no longer current.
-    (sera:nlet maybe-update-view ((next-source (prompter:next-ready-p prompt-buffer)))
+    (sera:nlet maybe-update-view ((next-source (when (find prompt-buffer (active-prompt-buffers (window prompt-buffer)))
+                                                 (prompter:next-ready-p prompt-buffer))))
       (cond
         ;; Nothing to do:
         ((eq t next-source)
@@ -399,8 +400,9 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
          t)
         ((null next-source) nil)
         (t ;; At least one source got updated.
-         (prompt-render-suggestions prompt-buffer)
-         (maybe-update-view (prompter:next-ready-p prompt-buffer)))))))
+           (prompt-render-suggestions prompt-buffer)
+           (maybe-update-view (when (find prompt-buffer (active-prompt-buffers (window prompt-buffer)))
+                                (prompter:next-ready-p prompt-buffer))))))))
 
 (defun set-prompt-buffer-input (input &optional (prompt-buffer (current-prompt-buffer)))
   "Set HTML INPUT in PROMPT-BUFFER."

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -195,7 +195,12 @@ To access the suggestion instead, see `prompter:selected-suggestion'."
                                (prompter:prompt prompter2))
                       (string= (prompter:input prompter1)
                                (prompter:input prompter2)))))
-          ;; Delete a previous, similar prompt, if any.
+          ;; Delete previous, similar prompts, if any.
+          (mapc (lambda (old-prompt)
+                  (when (and (prompter= old-prompt prompt-buffer)
+                             (not (eq old-prompt prompt-buffer)))
+                    (ffi-buffer-delete old-prompt)))
+                (old-prompt-buffers *browser*))
           (alex:deletef (old-prompt-buffers *browser*)
                         prompt-buffer
                         :test #'prompter=)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -185,26 +185,26 @@ To access the suggestion instead, see `prompter:selected-suggestion'."
 (export-always 'hide-prompt-buffer)
 (defun hide-prompt-buffer (prompt-buffer)
   "Hide PROMPT-BUFFER, display next active one."
-  ;; Note that PROMPT-BUFFER is not necessarily first in the list, e.g. a new
-  ;; prompt-buffer was invoked before the old one reaches here.
-  (alex:deletef (active-prompt-buffers (window prompt-buffer)) prompt-buffer)
-  (when (resumable-p prompt-buffer)
-    (flet ((prompter= (prompter1 prompter2)
-             (and (string= (prompter:prompt prompter1)
-                           (prompter:prompt prompter2))
-                  (string= (prompter:input prompter1)
-                           (prompter:input prompter2)))))
-      ;; Delete a previous, similar prompt, if any.
-      (alex:deletef (old-prompt-buffers *browser*)
-                    prompt-buffer
-                    :test #'prompter=)
-      (push prompt-buffer (old-prompt-buffers *browser*))))
-  (if (active-prompt-buffers (window prompt-buffer))
-      (let ((next-prompt-buffer (first (active-prompt-buffers (window prompt-buffer)))))
-        (show-prompt-buffer next-prompt-buffer))
-      (progn
-        (ffi-window-set-prompt-buffer-height (window prompt-buffer) 0)))
-  (prompter:destroy prompt-buffer))
+  (let ((window (window prompt-buffer)))
+    ;; Note that PROMPT-BUFFER is not necessarily first in the list, e.g. a new
+    ;; prompt-buffer was invoked before the old one reaches here.
+    (alex:deletef (active-prompt-buffers window) prompt-buffer)
+    (if (resumable-p prompt-buffer)
+        (flet ((prompter= (prompter1 prompter2)
+                 (and (string= (prompter:prompt prompter1)
+                               (prompter:prompt prompter2))
+                      (string= (prompter:input prompter1)
+                               (prompter:input prompter2)))))
+          ;; Delete a previous, similar prompt, if any.
+          (alex:deletef (old-prompt-buffers *browser*)
+                        prompt-buffer
+                        :test #'prompter=)
+          (push prompt-buffer (old-prompt-buffers *browser*)))
+        (ffi-buffer-delete prompt-buffer))
+    (if (active-prompt-buffers window)
+        (let ((next-prompt-buffer (first (active-prompt-buffers window))))
+          (show-prompt-buffer next-prompt-buffer))
+        (ffi-window-set-prompt-buffer-height window 0))))
 
 (defun suggestion-and-mark-count (prompt-buffer suggestions marks
                                   &key multi-selection-p pad-p)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -175,8 +175,9 @@ To access the suggestion instead, see `prompter:selected-suggestion'."
   (when prompt-buffer
     (push prompt-buffer (active-prompt-buffers (window prompt-buffer)))
     (prompt-render prompt-buffer)
-    (run-thread
-      (update-prompt-input prompt-buffer))
+    (run-thread "Show prompt watcher"
+      (let ((prompt-buffer prompt-buffer))
+        (update-prompt-input prompt-buffer)))
     (ffi-window-set-prompt-buffer-height
      (window prompt-buffer)
      (or height

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -318,7 +318,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                                            "marked")
                                                   (loop for (nil attribute) in (prompter:active-attributes suggestion :source source)
                                                         collect (:td attribute))))))))))
-      (ffi-buffer-evaluate-javascript-async
+      (ffi-buffer-evaluate-javascript
        prompt-buffer
        (ps:ps
          (setf (ps:chain document (get-element-by-id "suggestions") |innerHTML|)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -50,7 +50,8 @@ want to change the behaviour of modifiers, for instance swap 'control' and
    (panel-buffers-right)
    (main-buffer-container)
    (prompt-buffer-container)
-   (prompt-buffer-view)
+   (prompt-buffer-view
+    :documentation "Shared web view between all prompt buffers of this window.")
    (status-container)
    (message-container)
    (message-view)
@@ -915,9 +916,10 @@ See `gtk-browser's `modifier-translator' slot."
 
 (define-ffi-method ffi-buffer-make ((buffer gtk-buffer))
   "Initialize BUFFER's GTK web view."
-  (setf (gtk-object buffer) (make-web-view
-                             :context-buffer (unless (internal-buffer-p buffer)
-                                               buffer)))
+  (unless (gtk-object buffer) ; Buffer may already have a view, e.g. the prompt-buffer.
+    (setf (gtk-object buffer) (make-web-view
+                               :context-buffer (unless (internal-buffer-p buffer)
+                                                 buffer))))
   (if (smooth-scrolling buffer)
       (ffi-buffer-enable-smooth-scrolling buffer t)
       (ffi-buffer-enable-smooth-scrolling buffer nil))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -496,8 +496,11 @@ See `gtk-browser's `modifier-translator' slot."
         (log:debug key-string keycode character keyval-name modifiers)
         (log:debug key-string keycode character keyval-name))
     (when (prompt-buffer-p buffer)
-      (run-thread
-        (update-prompt-input buffer)))
+      (run-thread "Prompt updater"
+        ;; Rebind prompt-buffer to ensure the watcher does not mix up the
+        ;; different prompt-buffers.
+        (let ((prompt-buffer buffer))
+          (update-prompt-input prompt-buffer))))
     (if key-string
         (progn
           (alex:appendf (key-stack sender)
@@ -801,7 +804,7 @@ See `gtk-browser's `modifier-translator' slot."
            (push buffer (panel-buffers-left window)))
     (:right (gtk:gtk-box-pack-end (panel-buffer-container-right window) (gtk-object buffer))
             (push buffer (panel-buffers-right window))))
-  (setf (gtk:gtk-widget-size-request (gtk-object buffer)) 
+  (setf (gtk:gtk-widget-size-request (gtk-object buffer))
         (list (width buffer) -1))
   (gtk:gtk-widget-show (gtk-object buffer)))
 

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -42,6 +42,8 @@ want to change the behaviour of modifiers, for instance swap 'control' and
 
 (define-class gtk-window ()
   ((gtk-object)
+   (handler-ids
+    :documentation "See `gtk-buffer' slot of the same name.")
    (root-box-layout)
    (horizontal-box-layout)
    (panel-buffer-container-left)
@@ -63,6 +65,9 @@ want to change the behaviour of modifiers, for instance swap 'control' and
 
 (define-class gtk-buffer ()
   ((gtk-object)
+   (handler-ids
+    :documentation "Store all GObject signal handler IDs so that we can disconnect the signal handler when the object is finalised.
+See https://developer.gnome.org/gobject/stable/gobject-Signals.html#signal-memory-management.")
    (gtk-proxy-url (quri:uri ""))
    (proxy-ignored-hosts '())
    (data-manager-path (make-instance 'data-manager-data-path
@@ -199,6 +204,13 @@ not return."
   "We shouldn't enable (possibly) user-identifying extensions for `nosave-data-profile'."
   nil)
 
+(define-class gtk-download (download)
+  ((gtk-object)
+   (handler-ids
+    :documentation "See `gtk-buffer' slot of the same name."))
+  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+(define-user-class download (gtk-download0))
+
 (defun make-web-view (&key context-buffer)
   "Return a web view instance.
 When passed a web buffer, create a buffer-local web context.
@@ -220,26 +232,36 @@ Such contexts are not needed for internal buffers."
         (echo-warning "decide policy error: ~a" c)
         (webkit:webkit-policy-decision-ignore response-policy-decision)))))
 
+(defmacro connect-signal-function (object signal fn)
+  "Connect SIGNAL to OBJECT with a function FN.
+OBJECT must have the `gtk-object' and `handler-ids' slots.
+See also `connect-signal'."
+  `(let ((handler-id (gobject:g-signal-connect
+                      (gtk-object ,object) ,signal ,fn)))
+     (push handler-id (handler-ids ,object))))
+
 (defmacro connect-signal (object signal (&rest args) &body body)
-  "Connect SIGNAL to GTK OBJECT with a lambda that takes ARGS.
+  "Connect SIGNAL to OBJECT with a lambda that takes ARGS.
+OBJECT must have the `gtk-object' and `handler-ids' slots.
 The BODY is wrapped with `with-protect'."
   (multiple-value-bind (forms declares documentation)
       (alex:parse-body body :documentation t)
-    `(gobject:g-signal-connect
-     ,object ,signal
-     (lambda (,@args)
-       ,@(sera:unsplice documentation)
-       ,@declares
-       (with-protect ("Error in signal thread: ~a" :condition)
-         ,@forms)))))
+    `(let ((handler-id (gobject:g-signal-connect
+                        (gtk-object ,object) ,signal
+                        (lambda (,@args)
+                          ,@(sera:unsplice documentation)
+                          ,@declares
+                          (with-protect ("Error in signal thread: ~a" :condition)
+                            ,@forms)))))
+       (push handler-id (handler-ids ,object)))))
 
 (defmethod initialize-instance :after ((buffer status-buffer) &key)
   (%within-renderer-thread-async
    (lambda ()
      (with-slots (gtk-object) buffer
        (setf gtk-object (make-web-view))
-       (gobject:g-signal-connect
-        gtk-object "decide-policy"
+       (connect-signal-function
+        buffer "decide-policy"
         (make-decide-policy-handler buffer))))))
 
 (defmethod initialize-instance :after ((window gtk-window) &key)
@@ -314,20 +336,20 @@ The BODY is wrapped with `with-protect'."
        (gtk:gtk-container-add gtk-object root-box-layout)
        (setf (slot-value *browser* 'last-active-window) window)
        (gtk:gtk-widget-show-all gtk-object)
-       (connect-signal gtk-object "key_press_event" (widget event)
+       (connect-signal window "key_press_event" (widget event)
          (declare (ignore widget))
          #+darwin
          (push-modifier *browser* event)
          (on-signal-key-press-event window event))
-       (connect-signal gtk-object "key_release_event" (widget event)
+       (connect-signal window "key_release_event" (widget event)
          (declare (ignore widget))
          #+darwin
          (pop-modifier *browser* event)
          (on-signal-key-release-event window event))
-       (connect-signal gtk-object "destroy" (widget)
+       (connect-signal window "destroy" (widget)
          (declare (ignore widget))
          (on-signal-destroy window))
-       (connect-signal gtk-object "window-state-event" (widget event)
+       (connect-signal window "window-state-event" (widget event)
          (declare (ignore widget))
          (setf (fullscreen-p window)
                (find :fullscreen
@@ -599,9 +621,13 @@ See `gtk-browser's `modifier-translator' slot."
            (cookie-manager (webkit:webkit-web-context-get-cookie-manager context))
            (extensions-path (expand-path (gtk-extensions-path buffer))))
       (when extensions-path
-        (connect-signal context "initialize-web-extensions" (context)
-          (webkit:webkit-web-context-set-web-extensions-directory
-           context extensions-path)))
+        ;; TODO: Should we also use `connect-signal' here?  Does this yield a memory leak?
+        (gobject:g-signal-connect
+         context "initialize-web-extensions"
+         (lambda (context)
+           (with-protect ("Error in signal thread: ~a" :condition)
+             (webkit:webkit-web-context-set-web-extensions-directory
+              context extensions-path)))))
       (when (and buffer
                  (web-buffer-p buffer)
                  (expand-path (cookies-path buffer)))
@@ -923,43 +949,37 @@ See `gtk-browser's `modifier-translator' slot."
   (if (smooth-scrolling buffer)
       (ffi-buffer-enable-smooth-scrolling buffer t)
       (ffi-buffer-enable-smooth-scrolling buffer nil))
-  (gobject:g-signal-connect
-   (gtk-object buffer) "decide-policy"
-   (make-decide-policy-handler buffer))
-  (connect-signal (gtk-object buffer) "load-changed" (web-view load-event)
+  (connect-signal-function buffer "decide-policy" (make-decide-policy-handler buffer))
+  (connect-signal buffer "load-changed" (web-view load-event)
     (declare (ignore web-view))
     (on-signal-load-changed buffer load-event))
-  (connect-signal (gtk-object buffer) "mouse-target-changed" (web-view hit-test-result modifiers)
+  (connect-signal buffer "mouse-target-changed" (web-view hit-test-result modifiers)
     (declare (ignore web-view))
     (on-signal-mouse-target-changed buffer hit-test-result modifiers))
   ;; Mouse events are captured by the web view first, so we must intercept them here.
-  (connect-signal (gtk-object buffer) "button-press-event" (web-view event)
+  (connect-signal buffer "button-press-event" (web-view event)
     (declare (ignore web-view))
     (on-signal-button-press-event buffer event))
-  (connect-signal (gtk-object buffer) "scroll-event" (web-view event)
+  (connect-signal buffer "scroll-event" (web-view event)
     (declare (ignore web-view))
     (on-signal-scroll-event buffer event))
-  (gobject:g-signal-connect
-   (gtk-object buffer) "script-dialog"
-   #'process-script-dialog)
-  (gobject:g-signal-connect
-   (gtk-object buffer) "run-file-chooser"
-   #'process-file-chooser-request)
+  (connect-signal-function buffer "script-dialog" #'process-script-dialog)
+  (connect-signal-function buffer "run-file-chooser" #'process-file-chooser-request)
   ;; TLS certificate handling
-  (connect-signal (gtk-object buffer) "load-failed-with-tls-errors" (web-view failing-url certificate errors)
+  (connect-signal buffer "load-failed-with-tls-errors" (web-view failing-url certificate errors)
     (declare (ignore web-view errors))
     (on-signal-load-failed-with-tls-errors buffer certificate (quri:uri failing-url)))
-  (connect-signal (gtk-object buffer) "notify::uri" (web-view param-spec)
+  (connect-signal buffer "notify::uri" (web-view param-spec)
     (declare (ignore web-view param-spec))
     (on-signal-notify-uri buffer nil))
-  (connect-signal (gtk-object buffer) "notify::title" (web-view param-spec)
+  (connect-signal buffer "notify::title" (web-view param-spec)
     (declare (ignore web-view param-spec))
     (on-signal-notify-title buffer nil))
-  (connect-signal (gtk-object buffer) "web-process-crashed" (web-view)
+  (connect-signal buffer "web-process-crashed" (web-view)
     (echo-warning "Web process crashed for buffer ~a" (id buffer))
     (log:debug "Web process crashed for web view ~a" web-view)
     (delete-buffer :id (id buffer)))
-  (connect-signal (gtk-object buffer) "load-failed" (web-view load-event failing-url error)
+  (connect-signal buffer "load-failed" (web-view load-event failing-url error)
     (declare (ignore load-event web-view error))
     (unless (member (slot-value buffer 'load-status) '(:finished :failed))
       (echo "Failed to load URL ~a in buffer ~a." failing-url (id buffer))
@@ -976,7 +996,7 @@ See `gtk-browser's `modifier-translator' slot."
                 "If this site has does not support HTTPS, try with HTTP (insecure)."))))
        buffer))
     t)
-  (connect-signal (gtk-object buffer) "create" (web-view navigation-action)
+  (connect-signal buffer "create" (web-view navigation-action)
     (declare (ignore web-view))
     (let ((new-buffer (buffer-make *browser*))
           (url (webkit:webkit-uri-request-uri
@@ -987,7 +1007,7 @@ See `gtk-browser's `modifier-translator' slot."
       (gtk-object new-buffer)))
   ;; Remove "download to disk" from the right click context menu because it
   ;; bypasses request resource signal
-  (connect-signal (gtk-object buffer) "context-menu" (web-view context-menu event hit-test-result)
+  (connect-signal buffer "context-menu" (web-view context-menu event hit-test-result)
     (declare (ignore web-view event hit-test-result))
     (let ((length (webkit:webkit-context-menu-get-n-items context-menu)))
       (dolist (i (alex:iota length))
@@ -999,7 +1019,12 @@ See `gtk-browser's `modifier-translator' slot."
   buffer)
 
 (define-ffi-method ffi-buffer-delete ((buffer gtk-buffer))
-  (gtk:gtk-widget-destroy (gtk-object buffer)))
+  (mapc (lambda (handler-id)
+          (gobject:g-signal-handler-disconnect (gtk-object buffer)
+                                               handler-id))
+        (handler-ids buffer))
+  (when (slot-value buffer 'gtk-object) ; Not all buffers have their own web view, e.g. prompt buffers.
+    (gtk:gtk-widget-destroy (gtk-object buffer))))
 
 (define-ffi-method ffi-buffer-load ((buffer gtk-buffer) url)
   "Load URL in BUFFER.
@@ -1080,19 +1105,21 @@ requested a reload."
 
 (defmethod ffi-buffer-download ((buffer gtk-buffer) url)
   (let* ((webkit-download (webkit:webkit-web-view-download-uri (gtk-object buffer) url))
-         (download (make-instance 'download :url url)))
+         (download (make-instance 'user-download
+                                  :url url
+                                  :gtk-object webkit-download)))
     (setf (cancel-function download)
           #'(lambda ()
               (setf (status download) :canceled)
               (webkit:webkit-download-cancel webkit-download)))
     (push download (downloads *browser*))
-    (connect-signal webkit-download "received-data" (webkit-download data-length)
+    (connect-signal download "received-data" (webkit-download data-length)
       (declare (ignore data-length))
       (setf (bytes-downloaded download)
             (webkit:webkit-download-get-received-data-length webkit-download))
       (setf (completion-percentage download)
             (* 100 (webkit:webkit-download-estimated-progress webkit-download))))
-    (connect-signal webkit-download "decide-destination" (webkit-download suggested-file-name)
+    (connect-signal download "decide-destination" (webkit-download suggested-file-name)
       (alex:when-let* ((download-dir (download-path buffer))
                        (download-directory (expand-path download-dir))
                        (path (str:concat download-directory suggested-file-name))
@@ -1102,18 +1129,18 @@ requested a reload."
             (echo "Destination ~s exists, saving as ~s." path unique-path)
             (log:debug "Downloading file to ~s." unique-path))
         (webkit:webkit-download-set-destination webkit-download file-path)))
-    (connect-signal webkit-download "created-destination" (webkit-download destination)
+    (connect-signal download "created-destination" (webkit-download destination)
       (declare (ignore destination))
       (setf (destination-path download)
             (webkit:webkit-download-destination webkit-download)))
-    (connect-signal webkit-download "failed" (webkit-download error)
+    (connect-signal download "failed" (webkit-download error)
       (declare (ignore error))
       (unless (eq (status download) :canceled)
         (setf (status download) :failed))
       (echo "Download failed for ~s."
             (webkit:webkit-uri-request-uri
              (webkit:webkit-download-get-request webkit-download))))
-    (connect-signal webkit-download "finished" (webkit-download)
+    (connect-signal download "finished" (webkit-download)
       (declare (ignore webkit-download))
       (unless (member (status download) '(:canceled :failed))
         (setf (status download) :finished)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -209,7 +209,7 @@ not return."
    (handler-ids
     :documentation "See `gtk-buffer' slot of the same name."))
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
-(define-user-class download (gtk-download0))
+(define-user-class download (gtk-download))
 
 (defun make-web-view (&key context-buffer)
   "Return a web view instance.


### PR DESCRIPTION
Follow up to #1612.

Thanks to `nyxt/debug` I've identified what's retaining the prompt-buffers in memory (and possibly all buffers actually): it's the gobject signals!

Indeed: https://developer.gnome.org/gobject/stable/gobject-Signals.html#signal-memory-management

Turns out that the prompt buffer were only garbage collected when the signals are disconnected, which only happens when the window is destroyed.

According to the documentation, we must collect the handler IDs and disconnect them manually.
This is what this pull request does (among many other things).

It seems that _some_ prompt buffers are still not garbage collected: on closer inspection, some signal handler do not get disconnected.  I'm not sure why this happens.

Looking at `gobject.base.lisp` of `cl-cffi-gtk`, it seems that this memory management should be done for us.  Maybe it's a bug in `cl-cffi-gtk`.

We should try with a `cl-object-introspection`-only version of the renderer.  Another time, I suppose.

Or does someone have any idea?

@jmercouris @aartaka To test:

- Lots of prompt buffers.
- Downloads.
- Multiple window creation and destruction.

I suggest we test this for a day or two before merging.

Of course feedback on the code is more than welcome :)