### PR TITLE
Documentation: improve dark mode docstring

### DIFF
--- a/source/style-mode.lisp
+++ b/source/style-mode.lisp
@@ -79,7 +79,8 @@ If nil, look for CSS in `style-file' or `style-url'.")
   (apply-style mode))
 
 (define-mode dark-mode (style-mode)
-  "Mode for styling documents."
+  "A mode for styling documents with a dark background. Unlike other modes, to
+disable `dark-mode' it is necessary to disable it and reload the buffer."
   ((css-cache-path (make-instance 'css-cache-data-path
                                   :dirname (uiop:xdg-data-home
                                             nyxt::+data-root+

--- a/source/style-mode.lisp
+++ b/source/style-mode.lisp
@@ -11,7 +11,7 @@
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum))
 
 (define-mode style-mode ()
-  "Mode for styling documents."
+  "A mode for styling documents."
   ((css-cache-path (make-instance 'css-cache-data-path
                                   :dirname (uiop:xdg-data-home
                                             nyxt::+data-root+


### PR DESCRIPTION
This PR, hopefully, solves issue #1638. 

In addition, to adding the peculiarity involving the disable of dark-mode, I inserted a tailormade definition for it. Before this, the definition of `dark-mode` was the same as `style-mode`. 

In the `style-mode` docstring, I made a tiny edition. I inserted an article "A" before the word "mode". It sounded better to me (this could be too subjective). I am not saying the current way on master is wrong concerning grammar (I lack the knowledge to affirm that). 