### PR TITLE
vi-insert-mode and application mode

### DIFF
--- a/source/application-mode.lisp
+++ b/source/application-mode.lisp
@@ -29,12 +29,8 @@ See the mode `keymap-scheme' for special bindings."
       (echo "Application-mode disabled.")))
    (constructor
     (lambda (mode)
-      (if (current-keymaps-hook (buffer mode))
-          (hooks:add-hook (current-keymaps-hook (buffer mode))
-                          (make-handler-keymaps-buffer #'keep-override-map))
-          (make-hook-keymaps-buffer
-           :combination #'hooks:combine-composed-hook
-           :handlers (list #'keep-override-map)))
+      (hooks:add-hook (current-keymaps-hook (buffer mode))
+                      (make-handler-keymaps-buffer #'keep-override-map))
       (echo "Application-mode enabled.")))))
 
 (declaim (ftype (function (list-of-keymaps buffer) (values list-of-keymaps buffer))

--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -12,7 +12,6 @@ This mode is a good candidate to be passed to `make-buffer'."
                     scheme:cua
                     (list
                      "C-q" 'quit
-                     "C-z" 'nyxt/application-mode:application-mode
                      "C-[" 'switch-buffer-previous
                      "C-]" 'switch-buffer-next
                      "M-down" 'switch-buffer

--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -12,6 +12,7 @@ This mode is a good candidate to be passed to `make-buffer'."
                     scheme:cua
                     (list
                      "C-q" 'quit
+                     "C-z" 'nyxt/application-mode:application-mode
                      "C-[" 'switch-buffer-previous
                      "C-]" 'switch-buffer-next
                      "M-down" 'switch-buffer

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -15,7 +15,14 @@ in your configuration file.
 Example:
 
 \(define-configuration buffer
-  ((default-modes (append '(vi-normal-mode) %slot-default%))))"
+  ((default-modes (append '(vi-normal-mode) %slot-default%))))
+
+In `vi-insert-mode', CUA bindings are still available unless
+`application-mode-p' is non-nil in `vi-insert-mode'.
+You can also enable `application-mode' manually to forward all keybindings to
+the web page.
+
+See also `vi-insert-mode'."
   ((glyph "vi:N")
    (previous-keymap-scheme-name nil
     :type (or keymap:scheme-name null)
@@ -48,7 +55,8 @@ vi-normal-mode.")
 
 (define-command switch-to-vi-normal-mode (&optional (mode (find-submode (or (current-prompt-buffer) (current-buffer))
                                                                         'vi-insert-mode)))
-  "Switch to the mode remembered to be the matching VI-normal one for this MODE."
+  "Switch to the mode remembered to be the matching VI-normal one for this MODE.
+See also `vi-normal-mode' and `vi-insert-mode'."
   (when mode
     (enable-modes (list (or (and (previous-vi-normal-mode mode)
                                  (mode-name (previous-vi-normal-mode mode)))
@@ -73,8 +81,13 @@ vi-normal-mode.")
     (define-scheme "vi"
       scheme:vi-insert
       (list
+       "C-z" 'nyxt/application-mode:application-mode
        "escape" 'switch-to-vi-normal-mode
        "button1" 'vi-button1)))
+   (application-mode-p nil
+                       :type boolean
+                       :documentation "Whether to default to `application-mode'
+                       when entering `vi-insert-mode'.")
    (destructor
     (lambda (mode)
       (setf (keymap-scheme-name (buffer mode))
@@ -90,11 +103,14 @@ vi-normal-mode.")
                 (previous-vi-normal-mode mode)
                 vi-normal))
         (vi-normal-mode :activate nil :buffer buffer)
-        (setf (keymap-scheme-name buffer) scheme:vi-insert))))))
+        (setf (keymap-scheme-name buffer) scheme:vi-insert)
+        (when (application-mode-p mode)
+          (nyxt/application-mode:application-mode :active t)))))))
 
 (define-command vi-button1 (&optional (buffer (or (current-prompt-buffer)
                                                   (current-buffer))))
-  "Enable VI insert mode when focus is on an input element on the web page."
+  "Enable VI insert mode when focus is on an input element on the web page.
+See also `vi-normal-mode' and `vi-insert-mode'."
   ;; First we generate a button1 event so that the web view element is clicked
   ;; (e.g. a text field gets focus).
   (ffi-generate-input-event

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -73,8 +73,6 @@ vi-normal-mode.")
     (define-scheme "vi"
       scheme:vi-insert
       (list
-       "C-i" 'autofill
-       "C-c '" 'edit-with-external-editor
        "escape" 'switch-to-vi-normal-mode
        "button1" 'vi-button1)))
    (destructor

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -67,6 +67,7 @@ and to index the top of the page.")
     (define-scheme "web"
       scheme:cua
       (list
+       "C-z" 'nyxt/application-mode:application-mode
        "C-M-right" 'history-forwards-all-query
        "C-M-left" 'history-all-query
        "C-shift-h" 'history-all-query


### PR DESCRIPTION
This addresses the main issue in https://github.com/atlas-engineer/nyxt/issues/1635, that vi-insert-mode should have a convenient way to switch to application-mode back and forth.

It also binds application-mode to C-z everywhere, including in application-mode itself to disable it.

Questions:

- Should we bind C-z in base-mode or web-mode?
- I'm realizaing that application-mode should have an indicator just like vi-*-mode.  Maybe rename and generalize the vi indicator so that it displays there as well?  For instance, when both application mode and vi-insert-mode are enabled, it would display `A I`.