### PR TITLE
buffer: Don't update the last-access when previewing buffers.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -942,7 +942,7 @@ proceeding."
 (define-user-class buffer-source)
 
 (-> switch-buffer (&key (:id string) (:current-is-last-p boolean)) *)
-(define-command switch-buffer (&key id (current-is-last-p t))
+(define-command switch-buffer (&key id (current-is-last-p nil))
   "Switch the active buffer in the current window.
 Buffers are ordered by last access.
 With CURRENT-IS-LAST-P, the current buffer is listed last so as to list the


### PR DESCRIPTION
Also add option to show current buffer last in switch-buffer.
This makes it easier to define a custom command to not show the current buffer last.

Fixes #1491.