### PR TITLE
web-mode: Use in-memory stream instead of intermediary file to displa…

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -150,6 +150,7 @@
     (inputs
      `(("alexandria" ,cl-alexandria)
        ("bordeaux-threads" ,cl-bordeaux-threads)
+       ("cl-base64" ,cl-base64)
        ("cl-calispel" ,cl-calispel)
        ("cl-containers" ,cl-containers)
        ("cl-css" ,cl-css)
@@ -164,6 +165,7 @@
        ("cluffer" ,cl-cluffer)
        ("dexador" ,cl-dexador)
        ("enchant" ,cl-enchant)
+       ("flexi-streams" ,cl-flexi-streams)
        ("fset" ,cl-fset)
        ("hu.dwim.defclass-star" ,cl-hu.dwim.defclass-star)
        ("iolib" ,cl-iolib)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -26,6 +26,7 @@
   :depends-on (alexandria
                bordeaux-threads
                calispel
+               cl-base64
                cl-css
                cl-html-diff
                cl-json
@@ -38,6 +39,7 @@
                moptilities
                dexador
                enchant
+               flexi-streams
                iolib
                iolib/os
                local-time


### PR DESCRIPTION
…y QRcode.

@ag91 This removes a whole class of problem by not writing a file :)
Also note the use of the `with-current-html-buffer` helper, makes everything easier :)

I'm introducing new deps, namely cl-base64 and flexi-streams, but both of them are already indirect dependencies so it comes for free.

That said, if anyone has better suggestions for byte (octet) streams and base64 encoding, please share!