### PR TITLE
element-frame.lisp: poll the page instead of requiring user action

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -342,7 +342,7 @@ interface.")
    (update-notifier (make-channel)
                     :type calispel:channel
                     :documentation "A channel which is written to when `filter'
-commits a change to `suggetsions'.  A notification is only send if at least
+commits a change to `suggestions'.  A notification is only sent if at least
 `notification-delay' has passed.  This is useful so that clients don't have to
 poll `suggestions' for changes.")
 

--- a/source/element-frame.lisp
+++ b/source/element-frame.lisp
@@ -178,11 +178,5 @@
        (frame-element-clear)))))
 
 (defun frame-source-selection ()
-  (alex:when-let* ((frame-source 
-                    (find-if 
-                     (lambda (s)
-                       (closer-mop:subclassp (class-of s)
-                                             (find-class 'frame-source)))
-                     (prompter:sources (current-prompt-buffer)))))
-    (remove-duplicates (mapcar #'url (frame-element-get-selection))
-                       :test #'equal)))
+  (remove-duplicates (mapcar #'url (frame-element-get-selection))
+                     :test #'equal))

--- a/source/expedition-mode.lisp
+++ b/source/expedition-mode.lisp
@@ -47,12 +47,10 @@
   "Run an expedition through a set of URLs selected with a rectangle."
   (let* ((urls (reverse
                 (prompt
-                 :extra-modes '(nyxt/web-mode::frame-select-mode)
                  :prompt "Start expedition with the following links:"
                  :sources (list (make-instance 'nyxt/web-mode::frame-source
                                                :buffer buffer
-                                               :multi-selection-p t
-                                               :channel (make-instance 'calispel:channel)))
+                                               :multi-selection-p t))
                  :after-destructor
                  (lambda ()
                    (with-current-buffer buffer

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -280,8 +280,8 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                      (:div :class "source-name"
                            :style (if (and (hide-single-source-header-p prompt-buffer)
                                            (sera:single sources))
-                                      "visibility:hidden;"
-                                      "visibility:visible")
+                                      "dislay:none;"
+                                      "display:revert")
                            (:span :class "source-glyph" "⛯")
                            (prompter:name source)
                            (if (prompter:hide-suggestion-count-p source)
@@ -295,8 +295,8 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                (:tr :style (if (or (eq (prompter:hide-attribute-header-p source) :always)
                                                    (and (eq (prompter:hide-attribute-header-p source) :single)
                                                         (sera:single (prompter:active-attributes-keys source))))
-                                               "visibility:hidden;"
-                                               "visibility:visible;")
+                                               "display:none;"
+                                               "display:revert;")
                                     (loop for attribute-key in (prompter:active-attributes-keys source)
                                           collect (:th attribute-key)))
                                (loop ;; TODO: Only print as many lines as fit the height.


### PR DESCRIPTION
I want the element frame results to update in the prompt buffer AS the user is dragging their selection. In order to achieve this I need to call `prompter::update` on some loop to invoke my `prompter:filter-preprocessor` which fetches the user selection.

Unfortunately, this does not work. I have to then press ANY key (not necessarily even in the prompt buffer), and then the sources update.