### PR TITLE
base: Bind M-space to resume-prompt.

### DIFF
--- a/source/base-mode.lisp
+++ b/source/base-mode.lisp
@@ -51,6 +51,7 @@ This mode is a good candidate to be passed to `make-buffer'."
                      "C-O" 'load-file
                      "C-j" 'list-downloads
                      "C-space" 'execute-command
+                     "M-space" 'resume-prompt
                      "C-n" 'make-window
                      "C-shift-W" 'delete-current-window
                      "C-W" 'delete-current-window


### PR DESCRIPTION
Resume-prompt is essential for some commands like searches.
But it's only so useful if it's bound to a key.

M-space mirrors C-space in how it's an entry point to commands.