### PR TITLE
Add support for GTK clipboard

### DIFF
--- a/source/clipboard.lisp
+++ b/source/clipboard.lisp
@@ -4,12 +4,24 @@
 (in-package :nyxt)
 
 (-> ring-insert-clipboard (containers:ring-buffer-reverse) string)
+
+(export-always 'clipboard-text)
+(defgeneric clipboard-text (browser)
+  (:documentation "Get text currently residing in BROWSER's clipboard")
+  (:method ((browser browser))
+    (ignore-errors (trivial-clipboard:text))))
+
+(defgeneric (setf clipboard-text) (text browser)
+  (:documentation "Set content of BROWSER's clipboard to TEXT")
+  (:method (text (browser browser))
+    (trivial-clipboard:text text)))
+
 (export-always 'ring-insert-clipboard)
 (defun ring-insert-clipboard (ring)
   "Check if clipboard-content is most recent entry in RING.
 If not, insert clipboard-content into RING.
 Return most recent entry in RING."
-  (let ((clipboard-content (ignore-errors (trivial-clipboard:text))))
+  (let ((clipboard-content (clipboard-text *browser*)))
     (when clipboard-content
       (unless (string= clipboard-content (unless (containers:empty-p ring)
                                            (containers:first-item ring)))
@@ -19,4 +31,6 @@ Return most recent entry in RING."
 (export-always 'copy-to-clipboard)
 (defun copy-to-clipboard (input)
   "Save INPUT text to clipboard, and ring."
-  (containers:insert-item (clipboard-ring *browser*) (trivial-clipboard:text input)))
+  (containers:insert-item
+   (clipboard-ring *browser*)
+   (setf (clipboard-text *browser*) input)))


### PR DESCRIPTION
Hi! I would like to add support for clipboard in GTK interface without help of any external programs. I googled and ended up with this solution. The most stupid thing about this solution is that `gtk-clipboard-request-text` does not have any timeout which specifies how long it waits for text in the clipboard, so I added a timeout to `calispel:?` to finish execution of the caller thread if there is no text in the buffer.

Can this be discussed and eventually merged?