### PR TITLE
Replace all ftype declarations by sera:->.

### DIFF
--- a/source/application-mode.lisp
+++ b/source/application-mode.lisp
@@ -4,6 +4,7 @@
 (uiop:define-package :nyxt/application-mode
   (:use :common-lisp :nyxt)
   (:import-from #:keymap #:define-key #:define-scheme)
+  (:import-from #:serapeum #:->)
   (:documentation "Forward all keybindings to the web view except those in the `override-map'."))
 (in-package :nyxt/application-mode)
 
@@ -33,8 +34,7 @@ See the mode `keymap-scheme' for special bindings."
                       (make-handler-keymaps-buffer #'keep-override-map))
       (echo "Application-mode enabled.")))))
 
-(declaim (ftype (function (list-of-keymaps buffer) (values list-of-keymaps buffer))
-                keep-override-map))
+(-> keep-override-map (list-of-keymaps buffer) (values list-of-keymaps buffer))
 (defun keep-override-map (keymaps buffer)
   (if (nyxt::active-prompt-buffers (current-window))
       (values keymaps buffer)

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -50,7 +50,9 @@
 In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
   (url-equal (url e1) (url e2)))
 
-(declaim (ftype (function (quri:uri &key (:title string) (:date (or local-time:timestamp null)) (:tags t)) t) bookmark-add))
+(-> bookmark-add
+    (quri:uri &key (:title string) (:date (or local-time:timestamp null)) (:tags t))
+    t)
 (export-always 'bookmark-add)
 (defun bookmark-add (url &key date title tags)
   (with-data-access (bookmarks (bookmarks-path (current-buffer)))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -388,14 +388,14 @@ current buffer."
 (defmethod get-unique-buffer-identifier ((browser browser))
   (format nil "~s" (incf (slot-value browser 'total-buffer-count))))
 
-(declaim (ftype (function (&optional window buffer)) set-window-title))
+(-> set-window-title (&optional window buffer) *)
 (export-always 'set-window-title)
 (defun set-window-title (&optional (window (current-window)) (buffer (current-buffer)))
   "Set current window title to the return value of (titler window). "
   (declare (ignore buffer)) ; TODO: BUFFER is kept for backward compatibility.  Remove with 3.0.
   (ffi-window-set-title window (funcall (titler window) window)))
 
-(declaim (ftype (function (window) string) window-default-title))
+(-> window-default-title (window) string)
 (export-always 'window-default-title)
 (defun window-default-title (window)
   "Return a window title in the form 'Nyxt - URL'.
@@ -412,7 +412,7 @@ This is useful to tell REPL instances from binary ones."
                      url))))
 
 ;; REVIEW: Do we need :NO-FOCUS? It's not used anywhere.
-(declaim (ftype (function ((cons quri:uri *) &key (:no-focus boolean)))))
+(-> open-urls ((cons quri:uri *) &key (:no-focus boolean)) *)
 (defun open-urls (urls &key no-focus)
   "Create new buffers from URLs.
 First URL is focused if NO-FOCUS is nil."
@@ -508,10 +508,11 @@ view.")
          request-data)))))
 
 (export-always 'url-dispatching-handler)
-(declaim (ftype (function (symbol
-                           (function (quri:uri) boolean)
-                           (or string (function (quri:uri) (or quri:uri null)))))
-                url-dispatching-handler))
+(-> url-dispatching-handler
+    (symbol
+     (function (quri:uri) boolean)
+     (or string (function (quri:uri) (or quri:uri null))))
+    *)
 (defun url-dispatching-handler (name test action)
   "Return a `resource' handler that, if `add-hook'ed to the `request-resource-hook',
 will automatically apply its ACTION on the URLs that conform to TEST.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -581,7 +581,7 @@ Delete it with `ffi-buffer-delete'."
                             (quri:uri "")
                             nil)))
 
-(declaim (ftype (function (buffer &key (:downloads-only boolean))) proxy-adress))
+(-> proxy-adress (buffer &key (:downloads-only boolean)) *)
 (defun proxy-url (buffer &key (downloads-only nil))
   "Return the proxy address, nil if not set.
 If DOWNLOADS-ONLY is non-nil, then it only returns the proxy address (if any)
@@ -663,14 +663,15 @@ BUFFER's modes."
   `(("URL" ,(render-url (url buffer)))
     ("Title" ,(title buffer))))
 
-(declaim (ftype (function (&key (:title string)
-                                (:modes (or null (cons symbol *)))
-                                (:url quri:uri)
-                                (:parent-buffer (or null buffer))
-                                (:no-history-p boolean)
-                                (:load-url-p boolean)
-                                (:buffer-class (or null symbol))))
-                make-buffer))
+(-> make-buffer
+    (&key (:title string)
+          (:modes (or null (cons symbol *)))
+          (:url quri:uri)
+          (:parent-buffer (or null buffer))
+          (:no-history-p boolean)
+          (:load-url-p boolean)
+          (:buffer-class (or null symbol)))
+    *)
 (define-command make-buffer (&key (title "") modes (url (quri:uri "")) parent-buffer
                              no-history-p (load-url-p t) buffer-class)
   "Create a new buffer.
@@ -694,11 +695,12 @@ LOAD-URL-P controls whether to load URL right at buffer creation."
         (setf (url buffer) (quri:uri url)))
     buffer))
 
-(declaim (ftype (function (&key (:title string)
-                                (:modes (or null (cons symbol *)))
-                                (:url quri:uri)
-                                (:load-url-p boolean)))
-                make-nosave-buffer))
+(-> make-nosave-buffer
+    (&key (:title string)
+          (:modes (or null (cons symbol *)))
+          (:url quri:uri)
+          (:load-url-p boolean))
+    *)
 (define-command make-nosave-buffer (&rest args
                                     &key title modes url load-url-p)
   "Create a new buffer that won't save anything to the filesystem.
@@ -706,10 +708,11 @@ See `make-buffer' for a description of the arguments."
   (declare (ignorable title modes url load-url-p))
   (apply #'make-buffer (append (list :buffer-class 'user-nosave-buffer) args)))
 
-(declaim (ftype (function (&key (:url quri:uri)
-                                (:parent-buffer (or null buffer))
-                                (:nosave-buffer-p boolean)))
-                make-buffer-focus))
+(-> make-buffer-focus
+    (&key (:url quri:uri)
+          (:parent-buffer (or null buffer))
+          (:nosave-buffer-p boolean))
+    *)
 (define-command make-buffer-focus (&key (url (quri:uri "")) parent-buffer nosave-buffer-p)
   "Switch to a new buffer.
 See `make-buffer'."
@@ -734,15 +737,17 @@ If URL is `:default', use `default-new-buffer-url'."
                          :extra-modes modes
                          :buffer-class 'user-editor-buffer))
 
-(declaim (ftype (function (browser &key (:title string)
-                                   (:data-profile data-profile)
-                                   (:extra-modes list)
-                                   (:dead-buffer buffer)
-                                   (:nosave-buffer-p boolean)
-                                   (:buffer-class symbol)
-                                   (:parent-buffer buffer)
-                                   (:no-history-p boolean)))
-                buffer-make))
+(-> buffer-make
+    (browser &key
+             (:title string)
+             (:data-profile data-profile)
+             (:extra-modes list)
+             (:dead-buffer buffer)
+             (:nosave-buffer-p boolean)
+             (:buffer-class symbol)
+             (:parent-buffer buffer)
+             (:no-history-p boolean))
+    *)
 (defun buffer-make (browser &key data-profile title extra-modes
                                  dead-buffer (buffer-class 'user-web-buffer)
                                  parent-buffer no-history-p
@@ -788,7 +793,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
     (hooks:run-hook (buffer-make-hook browser) buffer)
     buffer))
 
-(declaim (ftype (function (buffer)) add-to-recent-buffers))
+(-> add-to-recent-buffers (buffer) *)
 (defun add-to-recent-buffers (buffer)
   "Create a recent-buffer from given buffer and add it to `recent-buffers'."
   ;; Make sure it's a dead buffer:
@@ -796,7 +801,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
   (containers:delete-item-if (recent-buffers *browser*) (buffer-match-predicate buffer))
   (containers:insert-item (recent-buffers *browser*) buffer))
 
-(declaim (ftype (function (buffer)) buffer-delete))
+(-> buffer-delete (buffer) *)
 (defun buffer-delete (buffer)
   "For dummy buffers, use `ffi-buffer-delete' instead."
   (hooks:run-hook (buffer-delete-hook buffer) buffer)
@@ -935,7 +940,7 @@ proceeding."
   (:export-class-name-p t))
 (define-user-class buffer-source)
 
-(declaim (ftype (function (&key (:id string))) switch-buffer))
+(-> switch-buffer (&key (:id string)) *)
 (define-command switch-buffer (&key id)
   "Switch the active buffer in the current window."
   (if id

--- a/source/clipboard.lisp
+++ b/source/clipboard.lisp
@@ -3,7 +3,7 @@
 
 (in-package :nyxt)
 
-(declaim (ftype (function (containers:ring-buffer-reverse) string) ring-insert-clipboard))
+(-> ring-insert-clipboard (containers:ring-buffer-reverse) string)
 (export-always 'ring-insert-clipboard)
 (defun ring-insert-clipboard (ring)
   "Check if clipboard-content is most recent entry in RING.

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -325,7 +325,7 @@ With MODE-SYMBOLS and GLOBAL-P, include global commands."
        *command-list*)
       *command-list*))
 
-(declaim (ftype (function (function) (or null command)) function-command))
+(-> function-command (function) (or null command))
 (defun function-command (function)
   "Return the command associated to FUNCTION, if any."
   (find-if (sera:eqs function) (list-commands) :key #'fn))

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -158,7 +158,7 @@ CLASS-SYM to NEW-SUPERCLASSES.  The class is restored when exiting BODY."
               ,@body)
          (set-user-class ',class-sym ',old-superclasses)))))
 
-(declaim (ftype (function ((or symbol function))) method-combination-name))
+(-> method-combination-name ((or symbol function)) *)
 (defun method-combination-name (fun)
   (let ((fun (if (functionp fun)
                  fun
@@ -172,7 +172,7 @@ CLASS-SYM to NEW-SUPERCLASSES.  The class is restored when exiting BODY."
      (error "Not implemented")
      (closer-mop:generic-function-method-combination fun))))
 
-(declaim (ftype (function ((or symbol function)) boolean) standard-method-combination-p))
+(-> standard-method-combination-p ((or symbol function)) boolean)
 (defun standard-method-combination-p (fun)
   (eq 'standard
       (method-combination-name fun)))

--- a/source/data-storage.lisp
+++ b/source/data-storage.lisp
@@ -198,7 +198,7 @@ Return `*global-data-profile*' otherwise."
 Return NIL on no match."
   (first (find name (package-data-profiles) :test #'string= :key #'second)))
 
-(declaim (ftype (function (string) (or string null)) find-ref-path))
+(-> find-ref-path (string) (or string null))
 (defun find-ref-path (ref)
   "Return the value of the REF found in `*options*'s `:with-path'.
 Example: when passed command line option --with-path foo=bar,
@@ -211,7 +211,7 @@ Example: when passed command line option --with-path foo=bar,
           :test #'string=)))
 
 (export-always 'expand-default-path)
-(declaim (ftype (function (data-path &key (:root string)) (or string null)) expand-default-path))
+(-> expand-default-path (data-path &key (:root string)) (or string null))
 (defun expand-default-path (path &key (root (namestring (if (str:emptyp (namestring (dirname path)))
                                                             (uiop:xdg-data-home +data-root+)
                                                             (dirname path)))))
@@ -256,8 +256,7 @@ function result as a boolean in conditions."
   nil)
 
 (export-always 'ensure-parent-exists)
-(declaim (ftype (function (trivial-types:pathname-designator) trivial-types:pathname-designator)
-                ensure-parent-exists))
+(-> ensure-parent-exists (trivial-types:pathname-designator) trivial-types:pathname-designator)
 (defun ensure-parent-exists (path)
   "Create parent directories of PATH if they don't exist and return coerced PATH."
   (let ((path (uiop:ensure-pathname path)))
@@ -309,7 +308,7 @@ Define a method for your `data-path' type to make it restorable."))
       (calispel:! (channel user-data) path))))
 
 (export-always 'expand-path)
-(declaim (ftype (function ((or null data-path)) (or string null)) expand-path))
+(-> expand-path ((or null data-path)) (or string null))
 (defun expand-path (data-path)
   "Return the expanded path of DATA-PATH or nil if there is none.
 `expand-data-path' is dispatched against `data-path' and `current-data-profile'

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -4,7 +4,9 @@
 (uiop:define-package :nyxt/dom
   (:use :common-lisp :nyxt)
   (:import-from #:class-star #:define-class)
-  (:import-from #:serapeum #:export-always)
+  (:import-from #:serapeum
+                #:export-always
+                #:->)
   (:documentation "Nyxt-specific DOM classes and functions operating on them."))
 (in-package :nyxt/dom)
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -97,7 +99,7 @@
   node)
 
 (export-always 'named-html-parse)
-(declaim (ftype (function (string) (values (or plump-dom:root null) &optional)) named-parse))
+(-> named-parse (string) (values (or plump-dom:root null) &optional))
 (defun named-html-parse (input)
   "Assign tag classes (e.g., `input-element') to the nodes in the `plump:parse'-d input."
   (name-dom-elements (plump:parse input)))
@@ -125,7 +127,7 @@
   (ps:chain -j-s-o-n (stringify (process-element (nyxt/ps:qs document "html")))))
 
 (export-always 'named-json-parse)
-(declaim (ftype (function (string) (values (or plump-dom:root null) &optional)) named-json-parse))
+(-> named-json-parse (string) (values (or plump-dom:root null) &optional))
 (defun named-json-parse (json)
   "Return a `plump:root' of a DOM-tree produced from the JSON.
 

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -44,7 +44,7 @@
     ;; Returning fragment makes WebKit choke.
     nil))
 
-(declaim (ftype (function (t fixnum string) (values string &optional)) select-from-alphabet))
+(-> select-from-alphabet (t fixnum string) (values string &optional))
 (defun select-from-alphabet (code char-length alphabet)
   (let* ((exponents (nreverse (loop for pow below char-length
                                     collect (expt (length alphabet) pow)))))
@@ -54,7 +54,7 @@
                   do (decf code (* quotinent exp)))
             'string)))
 
-(declaim (ftype (function (integer) list-of-strings) generate-hints))
+(-> generate-hints (integer) list-of-strings)
 (defun generate-hints (length)
   (let* ((alphabet (hints-alphabet (current-mode 'web)))
          (char-length (ceiling (log length (length alphabet)))))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -503,7 +503,7 @@ The version number is stored in the clipboard."
   (trivial-clipboard:text +version+)
   (echo "Version ~a" +version+))
 
-(declaim (ftype (function (function-symbol &key (:modes list))) binding-keys))
+(-> binding-keys (function-symbol &key (:modes list)) *)
 (defun binding-keys (fn &key (modes (if (current-buffer)
                                         (modes (current-buffer))
                                         (mapcar #'make-instance (default-mode-symbols)))))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -78,7 +78,7 @@ class."
   "Return a new global history tree for `history-entry' data."
   (htree:make :key 'history-tree-key :current-owner-id (id buffer)))
 
-(declaim (ftype (function (quri:uri &key (:title string) (:buffer buffer)) t) history-add))
+(-> history-add (quri:uri &key (:title string) (:buffer buffer)) *)
 (defun history-add (url &key (title "") (buffer (current-buffer)))
   "Add URL to the global/buffer-local history.
 The `implicit-visits' count is incremented."

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -28,9 +28,7 @@
 (deftype nyxt-keymap-value ()
   '(or keymap:keymap function-symbol command))
 
-(declaim (ftype (function (string &rest keymap:keymap)
-                          keymap:keymap)
-                make-keymap))
+(-> make-keymap (string &rest keymap:keymap) keymap:keymap)
 (export-always 'make-keymap)
 (defun make-keymap (name &rest parents)
   "Like `keymap:make-keymap' but only allow binding function symbols, commands
@@ -70,7 +68,7 @@ prompt-buffer keymaps."
                 (delete nil (mapcar #'keymap (modes buffer-or-prompt-buffer))))
               (delete nil (list buffer (current-prompt-buffer))))))))
 
-(declaim (ftype (function (keymap:key) boolean) pointer-event-p))
+(-> pointer-event-p (keymap:key) boolean)
 (defun pointer-event-p (key)
   "Return non-nil if key-chord is a pointer event, e.g. a mouton button click."
   (coerce (str:starts-with? "button" (keymap:key-value key))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -16,7 +16,9 @@
   (:use #:common-lisp #:trivia)
   (:import-from #:keymap #:define-key #:define-scheme)
   (:import-from #:class-star #:define-class)
-  (:import-from #:serapeum #:export-always))
+  (:import-from #:serapeum
+                #:export-always
+                #:->))
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nyxt)
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum :nyxt)
@@ -63,5 +65,7 @@ and `serapeum:':
   (:use #:common-lisp #:trivia #:nyxt)
   (:import-from #:keymap #:define-key #:define-scheme)
   (:import-from #:class-star #:define-class)
-  (:import-from #:serapeum #:export-always)
+  (:import-from #:serapeum
+                #:export-always
+                #:->)
   (:documentation "Mode for prompter buffer."))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -412,7 +412,7 @@ Return nil when key must be discarded, e.g. for modifiers."
                (member :meta-mask modifier-state))
       (alex:deletef (modifiers browser) :super-mask))))
 
-(declaim (ftype (function (list &optional gdk:gdk-event) list) translate-modifiers))
+(-> translate-modifiers (list &optional gdk:gdk-event) list)
 (defun translate-modifiers (modifier-state &optional event)
   "Return list of modifiers fit for `keymap:make-key'.
 See `gtk-browser's `modifier-translator' slot."
@@ -1213,7 +1213,7 @@ custom (the specified proxy) and none."
 (define-ffi-method ffi-display-url (text)
   (webkit:webkit-uri-for-display text))
 
-(declaim (ftype (function (webkit:webkit-cookie-manager cookie-policy)) set-cookie-policy))
+(-> set-cookie-policy (webkit:webkit-cookie-manager cookie-policy) *)
 (defun set-cookie-policy (cookie-manager cookie-policy)
   (webkit:webkit-cookie-manager-set-accept-policy
    cookie-manager

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -37,12 +37,12 @@ Can be built via `make-search-completion-function'"))
                  :fallback-url fallback-url))
 
 (export-always 'make-search-completion-function)
-(declaim (ftype (function (&key (:base-url string)
-                                (:request-function (function (string &rest *) *))
-                                (:request-args list)
-                                (:processing-function (function (*) list-of-strings)))
-                          (function (string) list-of-strings))
-                make-search-completion-function))
+(-> make-search-completion-function
+    (&key (:base-url string)
+          (:request-function (function (string &rest *) *))
+          (:request-args list)
+          (:processing-function (function (*) list-of-strings)))
+    (function (string) list-of-strings))
 (defun make-search-completion-function (&key base-url
                                           (request-function #'dex:get)
                                           request-args

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -232,9 +232,9 @@ Don't run this from a REPL, prefer `start' instead."
       (isys:sigaction isys:sigterm interrupt-sigaction (cffi:null-pointer)))
     (apply #'start (append options (list :urls free-args)))))
 
-(declaim (ftype (function ((or null trivial-types:pathname-designator)
-                           &key (:package (or null package))))
-                load-lisp))
+(-> load-lisp
+    ((or null trivial-types:pathname-designator) &key (:package (or null package)))
+    *)
 (defun load-lisp (file &key package)
   "Load the Lisp FILE (or stream).
 We accept a null FILE value so that `load-lisp' may be called over the expansion
@@ -310,7 +310,7 @@ EXPR is expected to be as per the expression sent in `listen-or-query-socket'."
           nil))))
 
 (export-always 'open-external-urls)
-(declaim (ftype (function (&rest string)) open-external-urls))
+(-> open-external-urls (&rest string) *)
 (defun open-external-urls (&rest url-strings)
   "Open URL-STRINGS on the renderer thread and return URLs.
 This is a convenience wrapper to make remote code execution to open URLs as
@@ -378,7 +378,7 @@ It takes URL-STRINGS so that the URL argument can be `cl-read' in case
                              (sb-posix:stat-mode (sb-posix:stat path)))))))
          (socket-p path))))
 
-(declaim (ftype (function ((or null (cons quri:uri *)))) listen-or-query-socket))
+(-> listen-or-query-socket ((or null (cons quri:uri *))) *)
 (defun listen-or-query-socket (urls)
   "If another Nyxt is listening on the socket, tell it to open URLS.
 Otherwise bind socket and return the listening thread."

--- a/source/time.lisp
+++ b/source/time.lisp
@@ -6,7 +6,7 @@
 ;; Convenience function for time manipulation.
 ;; This can be useful for user configs.
 
-(declaim (ftype (function (string) local-time:timestamp) asctime->timestamp))
+(-> asctime->timestamp (string) local-time:timestamp)
 (export-always 'asctime->timestamp)
 (defun asctime->timestamp (asc-timestring)
   "Convert ASC-TIMESTRING to a timestamp.

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -41,9 +41,9 @@ If a URL string cannot be converted to a `quri:uri', it is discarded from the re
   `(satisfies has-url-method-p))
 
 (export-always 'render-url)
-(declaim (ftype (function ((or quri:uri string)) string) render-url))
+(-> render-url ((or quri:uri string)) string)
 (defun render-url (url)
-    "Return decoded URL.
+  "Return decoded URL.
 If the URL contains hexadecimal-encoded characters, return their unicode counterpart."
   (let ((url (if (stringp url)
                  url
@@ -112,7 +112,7 @@ If the URL contains hexadecimal-encoded characters, return their unicode counter
                 (or (quri:ip-addr-p (quri:uri-host url))
                     (hostname-found-p (quri:uri-host url)))))))))
 
-(declaim (ftype (function (t) quri:uri) ensure-url))
+(-> ensure-url (t) quri:uri)
 (defun ensure-url (thing)
   "Return `quri:uri' derived from THING.
 If it cannot be derived, return an empty `quri:uri'."
@@ -122,20 +122,20 @@ If it cannot be derived, return an empty `quri:uri'."
            (or (ignore-errors (quri:uri thing))
                (quri:uri "")))))
 
-(declaim (ftype (function ((or quri:uri string null)) boolean) url-empty-p))
+(-> url-empty-p ((or quri:uri string null)) boolean)
 (export-always 'url-empty-p)
 (defun url-empty-p (url)
   "Small convenience function to check whether the given URL is empty."
   (the (values boolean &optional)
        (uiop:emptyp (if (quri:uri-p url) (quri:render-uri url) url))))
 
-(declaim (ftype (function (quri:uri) boolean)
-                empty-path-url-p host-only-url-p))
+(-> empty-path-url-p (quri:uri) boolean)
 (export-always 'empty-path-url-p)
 (defun empty-path-url-p (url)
   (or (string= (quri:uri-path url) "/")
       (null (quri:uri-path url))))
 
+(-> host-only-url-p (quri:uri) boolean)
 (export-always 'host-only-url-p)
 (defun host-only-url-p (url)
   (every #'null
@@ -143,7 +143,7 @@ If it cannot be derived, return an empty `quri:uri'."
                (quri:uri-fragment url)
                (quri:uri-userinfo url))))
 
-(declaim (ftype (function (quri:uri) string) schemeless-url))
+(-> schemeless-url (quri:uri) string)
 (defun schemeless-url (url)             ; Inspired by `quri:render-uri'.
   "Return URL without its scheme (e.g. it removes 'https://')."
   ;; Warning: We can't just set `quri:uri-scheme' to nil because that would
@@ -155,14 +155,14 @@ If it cannot be derived, return an empty `quri:uri'."
           (quri:uri-query url)
           (quri:uri-fragment url)))
 
-(declaim (ftype (function (quri:uri quri:uri) (or null fixnum)) url<))
+(-> url< (quri:uri quri:uri) (or null fixnum))
 (defun url< (url1 url2)
   "Like `string<' but ignore the URL scheme.
 This way, HTTPS and HTTP is ignored when comparing URIs."
   (string< (schemeless-url url1)
            (schemeless-url url2)))
 
-(declaim (ftype (function (quri:uri quri:uri) boolean) url-equal))
+(-> url-equal (quri:uri quri:uri) boolean)
 (defun url-equal (url1 url2)
   "Like `quri:uri=' but ignoring the scheme.
 URLs are equal up to `scheme='.
@@ -181,7 +181,7 @@ Authority is compared case-insensitively (RFC 3986)."
                                                   (quri:uri-authority url2)))))))
 
 (export-always 'lisp-url)
-(declaim (ftype (function (t &rest t) string) lisp-url))
+(-> lisp-url (t &rest t) string)
 (defun lisp-url (lisp-form &rest more-lisp-forms)
   "Generate a lisp:// URL from the given Lisp forms. This is useful for encoding
 functionality into internal-buffers."
@@ -190,32 +190,32 @@ functionality into internal-buffers."
               (mapcar (alex:compose #'quri:url-encode #'write-to-string)
                       (cons lisp-form more-lisp-forms)))))
 
-(declaim (ftype (function (quri:uri quri:uri) boolean) path=))
+(-> path= (quri:uri quri:uri) boolean)
 (defun path= (url1 url2)
   "Return non-nil when URL1 and URL2 have the same path."
   ;; See https://github.com/fukamachi/quri/issues/48.
   (equalp (string-right-trim "/" (or (quri:uri-path url1) ""))
           (string-right-trim "/" (or (quri:uri-path url2) ""))))
 
-(declaim (ftype (function (quri:uri quri:uri) boolean) scheme=))
+(-> scheme= (quri:uri quri:uri) boolean)
 (defun scheme= (url1 url2)
   "Return non-nil when URL1 and URL2 have the same scheme.
 HTTP and HTTPS belong to the same equivalence class."
   (or (equalp (quri:uri-scheme url1) (quri:uri-scheme url2))
       (and (quri:uri-http-p url1) (quri:uri-http-p url2))))
 
-(declaim (ftype (function (quri:uri quri:uri) boolean) domain=))
+(-> domain= (quri:uri quri:uri) boolean)
 (defun domain= (url1 url2)
   "Return non-nil when URL1 and URL2 have the same domain."
   (equalp (quri:uri-domain url1) (quri:uri-domain url2)))
 
-(declaim (ftype (function (quri:uri quri:uri) boolean) host=))
+(-> host= (quri:uri quri:uri) boolean)
 (defun host= (url1 url2)
   "Return non-nil when URL1 and URL2 have the same host.
 This is a more restrictive requirement than `domain='."
   (equalp (quri:uri-host url1) (quri:uri-host url2)))
 
-(declaim (ftype (function (quri:uri quri:uri list) boolean) url-eqs))
+(-> url-eqs (quri:uri quri:uri list) boolean)
 (defun url-eqs (url1 url2 eq-fn-list)
   "Return non-nil when URL1 and URL2 are \"equal\" as dictated by EQ-FN-LIST.
 
@@ -226,8 +226,7 @@ return a boolean.  It defines an equivalence relation induced by EQ-FN-LIST.
   ;; nil, unlike the solution below.
   (every #'identity (mapcar (lambda (fn) (funcall fn url1 url2)) eq-fn-list)))
 
-(declaim (ftype (function (string &rest string) (function (quri:uri) boolean))
-                match-scheme))
+(-> match-scheme (string &rest string) (function (quri:uri) boolean))
 (export-always 'match-scheme)
 (defun match-scheme (scheme &rest other-schemes)
   "Return a predicate for URL designators matching one of SCHEME or OTHER-SCHEMES."
@@ -236,8 +235,7 @@ return a boolean.  It defines an equivalence relation induced by EQ-FN-LIST.
         (some (alex:curry #'string= (quri:uri-scheme (url url-designator)))
               (cons scheme other-schemes)))))
 
-(declaim (ftype (function (string &rest string) (function (quri:uri) boolean))
-                match-host))
+(-> match-host (string &rest string) (function (quri:uri) boolean))
 (export-always 'match-host)
 (defun match-host (host &rest other-hosts)
   "Return a predicate for URL designators matching one of HOST or OTHER-HOSTS."
@@ -246,8 +244,7 @@ return a boolean.  It defines an equivalence relation induced by EQ-FN-LIST.
         (some (alex:curry #'string= (quri:uri-host (url url-designator)))
               (cons host other-hosts)))))
 
-(declaim (ftype (function (string &rest string) (function (quri:uri) boolean))
-                match-domain))
+(-> match-domain (string &rest string) (function (quri:uri) boolean))
 (export-always 'match-domain)
 (defun match-domain (domain &rest other-domains)
   "Return a predicate for URL designators matching one of DOMAIN or OTHER-DOMAINS."
@@ -256,8 +253,7 @@ return a boolean.  It defines an equivalence relation induced by EQ-FN-LIST.
         (some (alex:curry #'string= (quri:uri-domain (url url-designator)))
               (cons domain other-domains)))))
 
-(declaim (ftype (function (string &rest string) (function (quri:uri) boolean))
-                match-file-extension))
+(-> match-file-extension (string &rest string) (function (quri:uri) boolean))
 (export-always 'match-file-extension)
 (defun match-file-extension (extension &rest other-extensions)
   "Return a predicate for URL designators matching one of EXTENSION or OTHER-EXTENSIONS."
@@ -266,8 +262,7 @@ return a boolean.  It defines an equivalence relation induced by EQ-FN-LIST.
         (some (alex:curry #'string= (pathname-type (or (quri:uri-path (url url-designator)) "")))
               (cons extension other-extensions)))))
 
-(declaim (ftype (function (string &rest string) (function (quri:uri) boolean))
-                match-regex))
+(-> match-regex (string &rest string) (function (quri:uri) boolean))
 (export-always 'match-regex)
 (defun match-regex (regex &rest other-regex)
   "Return a predicate for URL designators matching one of REGEX or OTHER-REGEX."
@@ -276,8 +271,7 @@ return a boolean.  It defines an equivalence relation induced by EQ-FN-LIST.
         (some (alex:rcurry #'cl-ppcre:scan (render-url (url url-designator)))
               (cons regex other-regex)))))
 
-(declaim (ftype (function (string &rest string) (function (quri:uri) boolean))
-                match-url))
+(-> match-url (string &rest string) (function (quri:uri) boolean))
 (export-always 'match-url)
 (defun match-url (one-url &rest other-urls)
   "Return a predicate for URLs exactly matching ONE-URL or OTHER-URLS."

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -6,7 +6,9 @@
   (:shadow #:focus-first-input-field)
   (:import-from #:keymap #:define-key #:define-scheme)
   (:import-from #:class-star #:define-class)
-  (:import-from #:serapeum #:export-always)
+  (:import-from #:serapeum
+                #:export-always
+                #:->)
   (:documentation "Mode for web pages"))
 (in-package :nyxt/web-mode)
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -248,7 +250,7 @@ and to index the top of the page.")
                                               tag-name))))
 
 (sera:export-always 'input-tag-p)
-(declaim (ftype (function ((or string null)) boolean) input-tag-p))
+(-> input-tag-p ((or string null)) boolean)
 (defun input-tag-p (tag)
   (or (string= tag "INPUT")
       (string= tag "TEXTAREA")))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -118,7 +118,7 @@ The handlers take the window as argument."))
 
 (hooks:define-hook-type window (function (window)))
 
-(declaim (ftype (function (browser)) window-make))
+(-> window-make (browser) *)
 (export-always 'window-make)
 (defun window-make (browser)
   (let* ((window (ffi-window-make browser)))
@@ -128,7 +128,7 @@ The handlers take the window as argument."))
     (hooks:run-hook (window-make-hook browser) window)
     window))
 
-(declaim (ftype (function (window)) window-delete))
+(-> window-delete (window) *)
 (defun window-delete (window)
   "This function must be called by the renderer when a window is deleted."
   (ffi-window-delete window)


### PR DESCRIPTION
It's less verbose and reads more naturally from left to right.  It also enforces
the declaration of the return type.  When unspecified, use `*'.