### PR TITLE
Change `noop` to `nothing`, use it to illustrate keybinding configuration example, and briefly explain it.

### DIFF
--- a/source/command.lisp
+++ b/source/command.lisp
@@ -366,3 +366,8 @@ result."
   "A command that does nothing.
 This is useful to override bindings to do nothing."
   (values))
+
+(define-deprecated-command noop ()                 ; TODO: Replace with ESCAPE special command that allows dispatched to cancel current key stack.
+  "A command that does nothing.
+This is useful to override bindings to do nothing."
+  (values))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -362,7 +362,7 @@ result."
             (log:debug "Prompt buffer interrupted")
             nil))))))
 
-(define-command noop ()                 ; TODO: Replace with ESCAPE special command that allows dispatched to cancel current key stack.
+(define-command nothing ()                 ; TODO: Replace with ESCAPE special command that allows dispatched to cancel current key stack.
   "A command that does nothing.
 This is useful to override bindings to do nothing."
   (values))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -73,17 +73,19 @@ add the following to your configuration:")
     (:p "You can create new scheme names with " (:code "keymap:make-scheme-name")
         ".  Also see the " (:code "scheme-name") " class and the "
         (:code "define-scheme") " macro.")
-    (:p "The " (:code "override-map") " is a keymap which has priority over
+    (:p "The " (:code "override-map") " is a keymap that has priority over
 all other keymaps.  By default, it has few bindings like the one
 for " (:code "execute-command") ".  You can use it to set keys globally:")
     (:pre (:code "
 \(define-configuration buffer
   ((override-map (let ((map (make-keymap \"override-map\")))
                    (define-key map
-                     \"M-x\" 'execute-command)))))"))
-    (:p "A more flexible way is to create your own mode with your custom
-keybindings.  When this mode is added first to the buffer mode list, its
-keybindings have priorities over the other modes.")
+                     \"M-x\" 'execute-command
+                     \"C-space\" 'nothing)))))"))
+    (:p "The " (:code "nothing") " command is useful to override bindings to do
+nothing. In addition, a more flexible approach is to create your own mode with
+your custom keybindings.  When this mode is added first to the buffer mode list,
+its keybindings have priorities over the other modes.")
     (:pre (:code "
 \(defvar *my-keymap* (make-keymap \"my-map\"))
 \(define-key *my-keymap*

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -132,8 +132,8 @@ and to index the top of the page.")
        "M-b" 'history-backwards-query
        "C-f" 'history-forwards
        "C-b" 'history-backwards
-       "C-g" 'noop                      ; Emacs users may hit C-g out of habit.
-       "M-g M-g" 'follow-hint           ; Corresponds to Emacs' `goto-line'.
+       "C-g" 'nothing              ; Emacs users may hit C-g out of habit.
+       "M-g M-g" 'follow-hint              ; Corresponds to Emacs' `goto-line'.
        "M-g g" 'follow-hint-new-buffer-focus
        "C-u M-g M-g" 'follow-hint-new-buffer
        "C-u M-g g" 'follow-hint-new-buffer


### PR DESCRIPTION
This PR addresses issues #1659 (naming) and #1658 (documentation).