### PR TITLE
Fix domain name resolution on SBCL.

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -2,7 +2,9 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 #+sbcl
-(sb-ext:assert-version->= 2 0 0)
+(progn
+  (sb-ext:assert-version->= 2 0 0)
+  (require 'sb-bsd-sockets))
 
 (defvar *prefix* (format nil "~a/~a"
                          (or (uiop:getenv "DESTDIR") "")

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -66,7 +66,10 @@ If the URL contains hexadecimal-encoded characters, return their unicode counter
                             ,args))))))))
 
 (defmemo lookup-hostname (name)
-  "Memoized verison of `iolib/sockets:lookup-hostname'."
+  "Resolve hostname NAME and memoize the result"
+  #+sbcl
+  (sb-bsd-sockets:get-host-by-name name)
+  #-sbcl
   (iolib/sockets:lookup-hostname name))
 
 (export-always 'valid-url-p)


### PR DESCRIPTION
This commit fixes situations when a domain name cannot be resolved
by DNS protocol but can be resolved by gethostbyname(3). These
situations can occur when the host is resolved by mDNS, for example.

This fixes #1674