### PR TITLE
Fix `control c`  `control v` as the key binding for `copy` in cua, add `paste` in CUA, and add `copy` in `vi-normal-mode`

### DIFF
--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -88,6 +88,7 @@ and to index the top of the page.")
        "C-u C-M-j" 'follow-hint-nosave-buffer
        "C-x C-w" 'copy-hint-url
        "C-c" 'copy
+       "C-v" 'paste
        "button9" 'history-forwards
        "button8" 'history-backwards
        "C-+" 'zoom-page

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -166,6 +166,7 @@ and to index the top of the page.")
       (list
        "H" 'history-backwards
        "L" 'history-forwards
+       "y" 'copy
        "M-h" 'history-backwards-query
        "M-l" 'history-forwards-query
        "M-H" 'history-all-query

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -107,7 +107,7 @@ and to index the top of the page.")
        "C-down" 'scroll-to-bottom
        "C-up" 'scroll-to-top
        "C-i" 'autofill
-       "C-c '" 'edit-with-external-editor
+       "C-e '" 'edit-with-external-editor
        ;; Leave SPACE and arrow keys unbound so that the renderer decides whether to
        ;; navigate textboxes (arrows), insert or scroll (space).
        "pageup" 'scroll-page-up


### PR DESCRIPTION
The keybinding for `copy` (`C-c`) was not working due to the overshadow from `edit-from-external-editor` (`C-c '`). I have changed it to be `C-e '`. The "e" is a mnemonic reference to "edit". I spotted the problem happening and @jmercouris figured out its root.

Also, there was no keybinding for `paste` in CUA. So, I added it.

Finally, there was no keybinding for `copy` in `vi-normal-mode`. So, I added.

There is no keybinding for `paste` in `vi-normal-mode`. But, I am not sure if it makes sense to have one. Please, tell me if it does make sense.