### PR TITLE
Add support for GTK clipboard(2)

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -276,7 +276,9 @@
                cl-cffi-gtk
                cl-webkit2)
   :pathname "source/"
-  :components ((:file "renderer-gtk")))
+  :serial t
+  :components ((:file "clipboard-gtk")
+               (:file "renderer-gtk")))
 
 (defsystem "nyxt/gi-gtk"
   :depends-on (nyxt/gtk

--- a/source/clipboard-gtk.lisp
+++ b/source/clipboard-gtk.lisp
@@ -1,0 +1,7 @@
+(in-package :gtk)
+
+(defcfun ("gtk_clipboard_wait_for_text" gtk-clipboard-wait-for-text)
+  (g-string :free-from-foreign t)
+  (clipboard (g-object gtk-clipboard)))
+
+(export 'gtk-clipboard-wait-for-text)

--- a/source/clipboard.lisp
+++ b/source/clipboard.lisp
@@ -4,12 +4,24 @@
 (in-package :nyxt)
 
 (-> ring-insert-clipboard (containers:ring-buffer-reverse) string)
+
+(export-always 'clipboard-text)
+(defgeneric clipboard-text (browser)
+  (:documentation "Get text currently residing in BROWSER's clipboard")
+  (:method ((browser browser))
+    (ignore-errors (trivial-clipboard:text))))
+
+(defgeneric (setf clipboard-text) (text browser)
+  (:documentation "Set content of BROWSER's clipboard to TEXT")
+  (:method (text (browser browser))
+    (trivial-clipboard:text text)))
+
 (export-always 'ring-insert-clipboard)
 (defun ring-insert-clipboard (ring)
   "Check if clipboard-content is most recent entry in RING.
 If not, insert clipboard-content into RING.
 Return most recent entry in RING."
-  (let ((clipboard-content (ignore-errors (trivial-clipboard:text))))
+  (let ((clipboard-content (clipboard-text *browser*)))
     (when clipboard-content
       (unless (string= clipboard-content (unless (containers:empty-p ring)
                                            (containers:first-item ring)))
@@ -19,4 +31,6 @@ Return most recent entry in RING."
 (export-always 'copy-to-clipboard)
 (defun copy-to-clipboard (input)
   "Save INPUT text to clipboard, and ring."
-  (containers:insert-item (clipboard-ring *browser*) (trivial-clipboard:text input)))
+  (containers:insert-item
+   (clipboard-ring *browser*)
+   (setf (clipboard-text *browser*) input)))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -1309,3 +1309,13 @@ As a second value, return the current buffer index starting from 0."
 
 (define-ffi-method ffi-focused-p ((buffer gtk-buffer))
   (gtk:gtk-widget-is-focus (gtk-object buffer)))
+
+;; Working with clipboard
+(define-ffi-method (setf clipboard-text) (text (gtk-browser gtk-browser))
+  (gtk:gtk-clipboard-set-text
+   (gtk:gtk-clipboard-get "CLIPBOARD")
+   text))
+
+(define-ffi-method clipboard-text ((gtk-browser gtk-browser))
+  (gtk:gtk-clipboard-wait-for-text
+   (gtk:gtk-clipboard-get "CLIPBOARD")))


### PR DESCRIPTION
The original patch which uses `cl-cffi-gtk`