### PR TITLE
Extend mode keymap scheme

### DIFF
--- a/libraries/keymap/keymap.lisp
+++ b/libraries/keymap/keymap.lisp
@@ -327,6 +327,15 @@ Parents are ordered by priority, the first parent has highest priority.")))
 (defun keymap-p (object)
   (typep object 'keymap))
 
+(defun copy-keymap (keymap)
+  (let ((new-keymap (apply #'make-keymap (name keymap)
+                           (parents keymap))))
+    (setf (bound-type new-keymap)
+          (bound-type keymap))
+    (setf (entries new-keymap)
+          (entries keymap))
+    new-keymap))
+
 ;; "keyspec" is better then "keydesc" since the strings are well specified,
 ;; while a "description" could be anything.
 (deftype keyspecs-type ()

--- a/libraries/keymap/scheme.lisp
+++ b/libraries/keymap/scheme.lisp
@@ -16,6 +16,10 @@
 keymap parents are automatically set to the keymaps corresponding to the given
 schemes.  See `define-scheme'.")))
 
+(defmethod print-object ((scheme-name scheme-name) stream)
+  (print-unreadable-object (scheme-name stream :type t :identity t)
+    (format stream "~a" (name scheme-name))))
+
 (declaim (ftype (function (string &rest scheme-name) (values scheme-name &optional))
                 make-scheme-name))
 (defun make-scheme-name (name &rest parents)

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -73,7 +73,17 @@ add the following to your configuration:")
     (:p "You can create new scheme names with " (:code "keymap:make-scheme-name")
         ".  Also see the " (:code "scheme-name") " class and the "
         (:code "define-scheme") " macro.")
-    (:p "The " (:code "override-map") " is a keymap that has priority over
+     (:p "To extend the bindings of a specific mode, you can extend the mode with "
+         (:code "define-configuration") " and extend its binding scheme with "
+         (:code "define-scheme") ". For example:")
+     (:pre (:code "
+\(define-configuration base-mode
+  ((keymap-scheme
+    (define-scheme (:name-prefix \"my-base\" :import %slot-default%)
+      scheme:vi-normal
+      (list \"g b\" (make-command switch-buffer* ()
+                    (switch-buffer :current-is-last-p t)))))))"))
+     (:p "The " (:code "override-map") " is a keymap that has priority over
 all other keymaps.  By default, it has few bindings like the one
 for " (:code "execute-command") ".  You can use it to set keys globally:")
     (:pre (:code "
@@ -85,7 +95,10 @@ for " (:code "execute-command") ".  You can use it to set keys globally:")
     (:p "The " (:code "nothing") " command is useful to override bindings to do
 nothing. In addition, a more flexible approach is to create your own mode with
 your custom keybindings.  When this mode is added first to the buffer mode list,
-its keybindings have priorities over the other modes.")
+its keybindings have priorities over the other modes.
+Note that this kind of global keymaps also have priority over regular character
+insertion, so you should probably not bind anything without modifiers in such a
+keymap.")
     (:pre (:code "
 \(defvar *my-keymap* (make-keymap \"my-map\"))
 \(define-key *my-keymap*


### PR DESCRIPTION
At last, we can now easily customize mode bindings!

This has been a long term complaint :/ 

Please test and let me know if you like how I've extented `define-scheme`.

Fixes https://github.com/atlas-engineer/nyxt/issues/1581.