### PR TITLE
Correct typo on application-mode activation from vi-insert-mode

### DIFF
--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -105,7 +105,7 @@ vi-normal-mode.")
         (vi-normal-mode :activate nil :buffer buffer)
         (setf (keymap-scheme-name buffer) scheme:vi-insert)
         (when (application-mode-p mode)
-          (nyxt/application-mode:application-mode :active t)))))))
+          (nyxt/application-mode:application-mode :activate t)))))))
 
 (define-command vi-button1 (&optional (buffer (or (current-prompt-buffer)
                                                   (current-buffer))))


### PR DESCRIPTION
Found while following @Ambrevar's tip on issue #1687.