### PR TITLE
Parallelize

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -45,6 +45,7 @@
                iolib
                iolib/os
                local-time
+               lparallel
                log4cl
                mk-string-metrics
                #-sbcl

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -319,7 +319,7 @@ Otherwise list all commands.
 With MODE-SYMBOLS and GLOBAL-P, include global commands."
   ;; TODO: Make sure we list commands of inherited modes.
   (if mode-symbols
-      (remove-if
+      (lpara:premove-if
        (lambda (command)
          (and (or (not global-p)
                   (not (global-p command)))

--- a/source/concurrency.lisp
+++ b/source/concurrency.lisp
@@ -6,7 +6,8 @@
 (defun initialize-lparallel-kernel (&key (worker-count (sera:count-cpus)))
   "Initialize the lparallel kernel with WORKER-COUNT, if not supplied set it to
 the amount of CPU cores.."
-  (setf lparallel:*kernel* (lparallel:make-kernel worker-count)))
+  (unless lpara:*kernel*
+    (setf lpara:*kernel* (lpara:make-kernel worker-count))))
 
 (export-always 'with-protect)
 (defmacro with-protect ((format-string &rest args) &body body)

--- a/source/concurrency.lisp
+++ b/source/concurrency.lisp
@@ -3,6 +3,9 @@
 
 (in-package :nyxt)
 
+;; Initialize the lparallel kernel
+(setf lparallel:*kernel* (lparallel:make-kernel kernel-worker-count))
+
 (export-always 'with-protect)
 (defmacro with-protect ((format-string &rest args) &body body)
   "Run body with muffled condition when `*run-from-repl-p*' is nil, run normally otherwise.

--- a/source/concurrency.lisp
+++ b/source/concurrency.lisp
@@ -3,8 +3,10 @@
 
 (in-package :nyxt)
 
-;; Initialize the lparallel kernel
-(setf lparallel:*kernel* (lparallel:make-kernel kernel-worker-count))
+(defun initialize-lparallel-kernel (&key (worker-count (sera:count-cpus)))
+  "Initialize the lparallel kernel with WORKER-COUNT, if not supplied set it to
+the amount of CPU cores.."
+  (setf lparallel:*kernel* (lparallel:make-kernel worker-count)))
 
 (export-always 'with-protect)
 (defmacro with-protect ((format-string &rest args) &body body)

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -47,9 +47,6 @@ be set to a string by the renderer itself. This variable exists to allow for
 reporting by users, it does not create any functional differences in the
 execution of Nyxt.")
 
-(export-always 'kernel-worker-count)
-(defparameter kernel-worker-count 32 "The amount of worker threads used by lparallel.")
-
 (export-always '+newline+)
 (alex:define-constant +newline+ (string #\newline) :test #'equal)
 

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -47,6 +47,9 @@ be set to a string by the renderer itself. This variable exists to allow for
 reporting by users, it does not create any functional differences in the
 execution of Nyxt.")
 
+(export-always 'kernel-worker-count)
+(defparameter kernel-worker-count 32 "The amount of worker threads used by lparallel.")
+
 (export-always '+newline+)
 (alex:define-constant +newline+ (string #\newline) :test #'equal)
 

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -23,6 +23,7 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nyxt)
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum :nyxt)
+  (trivial-package-local-nicknames:add-package-local-nickname :lpara :lparallel :nyxt)
   (trivial-package-local-nicknames:add-package-local-nickname :hooks :serapeum/contrib/hooks :nyxt))
 
 (uiop:define-package nyxt/repl-mode

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -456,6 +456,9 @@ Examples:
   (pushnew 'nyxt-source-registry asdf:*default-source-registries*)
   (asdf:clear-configuration)
 
+  ;; Initialize the lparallel kernel
+  (initialize-lparallel-kernel)
+
   ;; Options should be accessible anytime, even when run from the REPL.
   (setf *options* options)
 


### PR DESCRIPTION
As a follow up to: https://github.com/atlas-engineer/nyxt/issues/1683

```
(defparameter modes (mapcar #'mode-name (modes (current-buffer))))

;; NON PARALLEL VERSION
(time (prog1 "1" (list-commands :mode-symbols modes)))
Evaluation took:
  0.012 seconds of real time
  0.012358 seconds of total run time (0.012345 user, 0.000013 system)
  100.00% CPU
  34,664,147 processor cycles
  0 bytes consed

;; PARALLEL VERSION
(time (prog1 "1" (list-commands :mode-symbols modes)))
Evaluation took:
  0.005 seconds of real time
  0.052746 seconds of total run time (0.052746 user, 0.000000 system)
  1060.00% CPU
  14,406,970 processor cycles
  0 bytes consed
```

as you can see, over twice as fast, with just this one operation. There are of course dozens of places where we can utilize the cognates to dramatically improve performance. There are many operations that we do on lists and sets that we could parallelize for very significant performance increases.