### PR TITLE
repeat-mode: fix `repeat-every` docstring

### DIFF
--- a/source/repeat-mode.lisp
+++ b/source/repeat-mode.lisp
@@ -42,7 +42,7 @@ Function taking a `repeat-mode' instance.")
   (nyxt/process-mode::initialize mode))
 
 (define-command-global repeat-every (&optional seconds function)
-  "Repeat a FUNCTION every SECONDS (prompts if SECONDS and/or FUNCTION are not provided)."
+  "Repeat a function every seconds (prompts if seconds and/or function are not provided)."
   (let ((seconds (or seconds
                      (ignore-errors
                       (parse-integer


### PR DESCRIPTION
Currently, `repeat-every`'s docstring has some words in upper-case format which diverges from Nyxt's pattern. Since the tutorial (manual) uses `command-docstring-first-sentence` this is going to be ugly on tutorial. Thus, I am making the words lower case.