### PR TITLE
watch-mode: update docstring with 5 min info.

### DIFF
--- a/source/watch-mode.lisp
+++ b/source/watch-mode.lisp
@@ -34,8 +34,7 @@
                       times to-seconds-multipliers))))
 
 (define-mode watch-mode (nyxt/repeat-mode:repeat-mode)
-  "Reload the current buffer at regular time intervals."
-  ;; Reload every 5 minutes by default.
+  "Reload the current buffer every 5 minutes."
   ((rememberable-p t)
    (nyxt/repeat-mode:repeat-interval 300)
    (nyxt/repeat-mode:repeat-action


### PR DESCRIPTION
See the discussion here, [please](https://github.com/atlas-engineer/nyxt/issues/1702#issuecomment-891372832).

This [article](https://nyxt.atlas.engineer/article/watch-mode.org) from a few months ago nudged me. The article describes what `watch-buffer` does now. After I pressed `watch-mode`, I was expecting the prompt-buffer, since nothing appeared I thought it was a bug.

The docstring from `watch-mode` could be better. There is the 5 minutes information in a comment below the docstring. This PR only puts the comment info in the docstring info and deletes the comment.