### PR TITLE
Fix dangling history owners

### DIFF
--- a/libraries/history-tree/history-tree.lisp
+++ b/libraries/history-tree/history-tree.lisp
@@ -628,13 +628,11 @@ current node result to the result of further traversal."
             (apply #'append (mapcar #'traverse (children root))))))))
 
 (export-always 'map-owned-tree)
-(defun map-owned-tree (function tree &key flatten include-root
-                                       (collect-function #'cons)
-                                       owner)
+(defun map-owned-tree (function tree owner &key flatten include-root
+                                             (collect-function #'cons))
   "Like `map-tree' but restrict traversal to OWNER's nodes."
-  (map-tree function (if (history-tree-p tree)
-                         (owned-root owner)
-                         tree)
+  (map-tree function tree
+            :owner owner
             :flatten flatten
             :include-root include-root
             :collect-function collect-function

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -446,10 +446,7 @@ If you want to save the current history file beforehand, call
     (let ((old-buffers (buffer-list)))
       (sera:and-let* ((new-history (get-data path)))
         ;; TODO: Maybe modify `history-path' of all the buffers instead of polluting history?
-        (log:info "BEFORE set-data" new-history )
         (%set-data (history-path (current-buffer)) new-history)
-        (log:info "AFTER set-data" new-history)
         (restore-history-buffers (history-path (current-buffer)))
-        (log:info "AFTER restore")
         (dolist (buffer old-buffers)
           (buffer-delete buffer))))))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -476,6 +476,7 @@ Otherwise go forward to the only child."
                                                  (:b title)
                                                  title))))))
                                 history
+                                (htree:owner history (id buffer))
                                 :include-root t
                                 :collect-function #'(lambda (a b) (str:concat a (when b
                                                                                   (spinneret:with-html-string
@@ -506,6 +507,7 @@ Otherwise go forward to the only child."
                                                       (:b title))
                                                      (t title))))))) ; Color?  Smaller?
                                   history
+                                  :owner (htree:owner history current-buffer-id)
                                   :include-root t
                                   :collect-function #'(lambda (a b) (str:concat a (when b
                                                                                     (spinneret:with-html-string


### PR DESCRIPTION
Follow up to #1692 which fixes two issues:

- `history-tree` commands.
- Owners are cleared when the session is not restored.  This was actually a long standing bug.

Might fix #1708 but to be confirmed.