### PR TITLE
Feature: `reduce-bandwidth-mode`

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -138,6 +138,7 @@
                (:file "no-sound-mode")
                (:file "no-script-mode")
                (:file "no-webgl-mode")
+               (:file "reduce-bandwidth-mode")
                (:file "download-mode")
                (:file "force-https-mode")
                (:file "reduce-tracking-mode")

--- a/source/reduce-bandwidth-mode.lisp
+++ b/source/reduce-bandwidth-mode.lisp
@@ -1,0 +1,32 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package :nyxt/reduce-bandwidth-mode
+    (:use :common-lisp :nyxt)
+  (:documentation "Reduce bandwidth."))
+(in-package :nyxt/reduce-bandwidth-mode)
+
+(define-mode reduce-bandwidth-mode ()
+  "Reduce bandwidth enabling `no-image-mode', `no-script-mode', and
+`no-webgl-mode'."
+  ((constructor (lambda (mode)
+                  (nyxt/no-image-mode:no-image-mode
+                   :activate t
+                   :buffer (buffer mode))
+                  (nyxt/no-script-mode:no-script-mode
+                   :activate t
+                   :buffer (buffer mode))
+                  (nyxt/no-webgl-mode:no-webgl-mode
+                   :activate t
+                   :buffer (buffer mode))))
+   (destructor (lambda (mode)
+                 (nyxt/no-image-mode:no-image-mode
+                  :activate nil
+                  :buffer (buffer mode))
+                 (nyxt/no-script-mode:no-script-mode
+                  :activate nil
+                  :buffer (buffer mode))
+                 (nyxt/no-webgl-mode:no-webgl-mode
+                  :activate nil
+                  :buffer (buffer mode))))))
+

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -222,6 +222,8 @@ buffer.")
          (command-docstring-first-sentence 'nyxt/no-script-mode:no-script-mode))
     (:li (command-markup 'nyxt/no-webgl-mode:no-webgl-mode) ": "
          (command-docstring-first-sentence 'nyxt/no-webgl-mode:no-webgl-mode)))
+   (:p "It is possible to enable these three modes at once
+   with: " (:code "reduce-bandwidth-mode") " .")
    (:h3 "Visual mode")
    (:p "Select text without a mouse. Nyxt's "
        (:code "visual-mode") " imitates Vim's visual mode (and comes with the


### PR DESCRIPTION
This mode enables three other modes:  `no-images`, `no-javascript`, and `no-webgl`. All of them contribute to reduce the bandwidth. Disabling `reduce-bandwidth-mode` also disables all three modes at once.