### PR TITLE
Remove duplicate explanation about `quit` command

### DIFF
--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -362,8 +362,7 @@ section) of the current page and jump to it.")
     (:li (command-markup 'download-open-file)
          ": Open file in Nyxt or externally.  See " (:code "open-file-function") ".")
     (:li (command-markup 'edit-with-external-editor)
-         ": Edit selected HTML input tag with an external editor.")
-    (:li (command-markup 'quit) ": Close all Nyxt windows and quit."))
+         ": Edit selected HTML input tag with an external editor."))
 
    (:h2 "The Nyxt help system")
    (:p "Nyxt provides introspective and help capabilities.  All commands,


### PR DESCRIPTION
`quit` command appears two times in the tutorial on the Miscellaneous and the Quick Start sections. Not sure if this was intentional. I guess it is just a small accident. Thus, I am submitting a patch to fix it. I am keeping it on the Quick Start since it is a crucial binding.

There is also another explanation about `quit` in `visual-mode`. But that's another thing!