### PR TITLE
Documentation structural navigation

### DIFF
--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -230,7 +230,25 @@ buffer.")
     (:li (command-markup 'nyxt/no-webgl-mode:no-webgl-mode) ": "
          (command-docstring-first-sentence 'nyxt/no-webgl-mode:no-webgl-mode)))
    (:p "It is possible to enable these three modes at once
-   with: " (:code "reduce-bandwidth-mode") " .")
+   with: " (:code "reduce-bandwidth-mode") ".")
+   (:h3 "Structural navigation")
+   (:p "It is possible to navigate using the structure in between the file: ")
+   (:ul
+    (:li (command-markup 'nyxt/web-mode:jump-to-heading) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:jump-to-heading))
+    (:li (command-markup 'nyxt/web-mode:jump-to-heading-buffers) ": "
+         (command-docstring-first-sentence
+          'nyxt/web-mode:jump-to-heading-buffers)))
+   (:p "And navigate to interconnected files: ")
+   (:ul
+    (:li (command-markup 'nyxt/web-mode:go-next) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:go-next))
+    (:li (command-markup 'nyxt/web-mode:go-previous) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:go-previous))
+    (:li (command-markup 'nyxt/web-mode:go-up) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:go-up))
+    (:li (command-markup 'nyxt/web-mode:go-to-homepage) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:go-to-homepage)))
    (:h3 "Visual mode")
    (:p "Select text without a mouse. Nyxt's "
        (:code "visual-mode") " imitates Vim's visual mode (and comes with the

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -104,10 +104,17 @@ active modes, the URL, and the title of the current buffer.")
    (:h3 "Moving within a buffer")
    (:p "To move within a buffer, several commands are provided:")
    (:ul
-    (:li (command-markup 'nyxt/web-mode:scroll-down) ": Move down.")
-    (:li (command-markup 'nyxt/web-mode:scroll-up) ": Move up.")
-    (:li (command-markup 'nyxt/web-mode:scroll-to-bottom) ": Jump to bottom of page.")
-    (:li (command-markup 'nyxt/web-mode:scroll-to-top) ": Jump to top of page."))
+    (:li (command-markup 'nyxt/web-mode:scroll-down) ": " (command-docstring-first-sentence 'nyxt/web-mode:scroll-down))
+    (:li (command-markup 'nyxt/web-mode:scroll-up) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:scroll-up))
+    (:li (command-markup 'nyxt/web-mode:scroll-page-down) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:scroll-page-down))
+    (:li (command-markup 'nyxt/web-mode:scroll-page-up) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:scroll-page-up))
+    (:li (command-markup 'nyxt/web-mode:scroll-to-bottom) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:scroll-to-bottom))
+    (:li (command-markup 'nyxt/web-mode:scroll-to-top) ": "
+         (command-docstring-first-sentence 'nyxt/web-mode:scroll-to-top)))
    (:h3 "Setting the URL")
    (:p "When ambiguous URLs are inputted, Nyxt will attempt the best guess it
 can. If you do not supply a protocol in a URL, HTTPS will be assumed. To

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -242,7 +242,7 @@ and to index the top of the page.")
     (buffer-load (str:concat scheme "://" authority))))
 
 (define-command go-up ()
-  "Navigate to the upper level in URL path hierarchy."
+  "Navigate to the upper level in the URL path hierarchy."
   (let* ((url (url (current-buffer)))
          (path (quri:uri-path url))
          (path-splited (str:split "/" path :omit-nulls t))


### PR DESCRIPTION
This PR:

- inserts `scroll-page-up` and `scroll-page-down` in a section that already exists about "moving withing a buffer";
- inserts `command-docstring-first-sentence` in the section about "moving within  a buffer";
- fixes a small typo with a whitespace between the final "."  after `(code: "reduce-bandwidth-mode)`.
- fixes a small grammar mistake with the definte article "the" in a docstring; and,
- creates a new section about using the structure to navigate along webpages (in between its parts and to interconnected documents). Commands such as `jump-to-heading` move from **miscellaneous** section to this one.
