### PR TITLE
buffer: Allow non-prefixed completion for default search engine.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1325,7 +1325,8 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
               (list (make-instance 'new-url-query
                                    :query       input
                                    :check-dns-p check-dns-p)))
-            (sera:and-let* ((buffer (current-buffer))
+            (sera:and-let* ((completion engine-completion-p)
+                            (buffer (current-buffer))
                             (always (search-always-auto-complete-p buffer))
                             (engine (default-search-engine))
                             (completion (completion-function engine))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1325,33 +1325,33 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
               (list (make-instance 'new-url-query
                                    :query       input
                                    :check-dns-p check-dns-p)))
-            (sera:and-let* ((completion engine-completion-p)
-                            (buffer (current-buffer))
-                            (always (search-always-auto-complete-p buffer))
-                            (engine (default-search-engine))
-                            (completion (completion-function engine))
-                            (all-terms (str:join " " terms)))
-              (mapcar (alex:curry #'make-instance 'new-url-query
-                                  :engine engine :query)
-                      (funcall (completion-function engine) all-terms)))
-            (alex:mappend (lambda (engine)
-                            (append
-                             (list (make-instance 'new-url-query
-                                                  :query       (str:join " " (rest terms))
-                                                  :engine      engine
-                                                  :check-dns-p check-dns-p))
-                             ;; Some engines (I'm looking at you, Wikipedia!)
-                             ;; return garbage in response to an empty request.
-                             (when (and engine-completion-p
-                                        (completion-function engine) (rest terms))
-                               (mapcar (alex:curry #'make-instance 'new-url-query
-                                                   :engine      engine
-                                                   :check-dns-p check-dns-p
-                                                   :query)
-                                       (with-protect ("Error while completing search: ~a" :condition)
-                                         (funcall (completion-function engine)
-                                                  (str:join " " (rest terms))))))))
-                          engines))))
+            (or (alex:mappend (lambda (engine)
+                                (append
+                                 (list (make-instance 'new-url-query
+                                                      :query       (str:join " " (rest terms))
+                                                      :engine      engine
+                                                      :check-dns-p check-dns-p))
+                                 ;; Some engines (I'm looking at you, Wikipedia!)
+                                 ;; return garbage in response to an empty request.
+                                 (when (and engine-completion-p
+                                            (completion-function engine) (rest terms))
+                                   (mapcar (alex:curry #'make-instance 'new-url-query
+                                                       :engine      engine
+                                                       :check-dns-p check-dns-p
+                                                       :query)
+                                           (with-protect ("Error while completing search: ~a" :condition)
+                                             (funcall (completion-function engine)
+                                                      (str:join " " (rest terms))))))))
+                              engines)
+                (sera:and-let* ((completion engine-completion-p)
+                                (buffer (current-buffer))
+                                (always (search-always-auto-complete-p buffer))
+                                (engine (default-search-engine))
+                                (completion (completion-function engine))
+                                (all-terms (str:join " " terms)))
+                  (mapcar (alex:curry #'make-instance 'new-url-query
+                                      :engine engine :query)
+                          (funcall (completion-function engine) all-terms)))))))
 
 (define-class new-url-or-search-source (prompter:source)
   ((prompter:name "New URL or search query")

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -62,7 +62,7 @@ after the mode-specific hook.")
     :type boolean
     :documentation "Whether search suggestions are requested and displayed.")
    (search-always-auto-complete-p
-    nil
+    t
     :type boolean
     :documentation "Whether auto-completion works even for non-prefixed search.
 Auto-completions come from the default search engine.")

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -76,8 +76,9 @@ Auto-completions come from the default search engine.")
                           :base-url "https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=~a"
                           :processing-function
                           #'(lambda (results)
-                              (when results
-                                (second (json:decode-json-from-string results))))))
+                              (alex:when-let* ((results results)
+                                               (results (json:decode-json-from-string results)))
+                                (mapcar #'list (second results) (fourth results))))))
           (make-instance 'search-engine
                          :shortcut "ddg"
                          :search-url "https://duckduckgo.com/?q=~a"
@@ -1239,6 +1240,9 @@ URL is then transformed by BUFFER's `buffer-load-hook'."
 (define-class new-url-query ()
   ((query ""
           :documentation "Either a URL or a string query passed to `engine'.")
+   (label nil
+          :type (or null string)
+          :documentation "The meaningful text for the query, if query is a URL.")
    (engine nil
            :type (or null search-engine)))
   (:export-class-name-p t)
@@ -1303,8 +1307,19 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
      (t (query query)))))
 
 (defmethod prompter:object-attributes ((query new-url-query))
-  `(("URL or new query" ,(query query))
+  `(("URL or new query" ,(or (label query) (query query)))
     ("Search engine?" ,(if (engine query) (shortcut (engine query)) ""))))
+
+(defun make-completion-query (completion &key engine (check-dns-p t))
+  (typecase completion
+    (string (make-instance 'new-url-query
+                           :engine      engine
+                           :check-dns-p check-dns-p
+                           :query completion))
+    (list (make-instance 'new-url-query
+                         :check-dns-p check-dns-p
+                         :query (second completion)
+                         :label (first completion)))))
 
 (defun input->queries (input &key (check-dns-p t)
                                (engine-completion-p))
@@ -1335,10 +1350,9 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
                                  ;; return garbage in response to an empty request.
                                  (when (and engine-completion-p
                                             (completion-function engine) (rest terms))
-                                   (mapcar (alex:curry #'make-instance 'new-url-query
-                                                       :engine      engine
-                                                       :check-dns-p check-dns-p
-                                                       :query)
+                                   (mapcar (alex:rcurry #'make-completion-query
+                                                        :engine      engine
+                                                        :check-dns-p check-dns-p)
                                            (with-protect ("Error while completing search: ~a" :condition)
                                              (funcall (completion-function engine)
                                                       (str:join " " (rest terms))))))))
@@ -1349,8 +1363,9 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
                                 (engine (default-search-engine))
                                 (completion (completion-function engine))
                                 (all-terms (str:join " " terms)))
-                  (mapcar (alex:curry #'make-instance 'new-url-query
-                                      :engine engine :query)
+                  (mapcar (alex:rcurry #'make-completion-query
+                                       :engine      engine
+                                       :check-dns-p check-dns-p)
                           (funcall (completion-function engine) all-terms)))))))
 
 (define-class new-url-or-search-source (prompter:source)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -61,6 +61,11 @@ after the mode-specific hook.")
     t
     :type boolean
     :documentation "Whether search suggestions are requested and displayed.")
+   (search-always-auto-complete-p
+    nil
+    :type boolean
+    :documentation "Whether auto-completion works even for non-prefixed search.
+Auto-completions come from the default search engine.")
    (search-engines
     (list (make-instance 'search-engine
                          :shortcut "wiki"
@@ -1320,6 +1325,14 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
               (list (make-instance 'new-url-query
                                    :query       input
                                    :check-dns-p check-dns-p)))
+            (sera:and-let* ((buffer (current-buffer))
+                            (always (search-always-auto-complete-p buffer))
+                            (engine (default-search-engine))
+                            (completion (completion-function engine))
+                            (all-terms (str:join " " terms)))
+              (mapcar (alex:curry #'make-instance 'new-url-query
+                                  :engine engine :query)
+                      (funcall (completion-function engine) all-terms)))
             (alex:mappend (lambda (engine)
                             (append
                              (list (make-instance 'new-url-query


### PR DESCRIPTION
This addresses #1730 by adding a buffer-based toggle for search auto-completion even if there's no engine prefix.

Tends to be slow, but such are Dexador requests, we can do nothing about it.

Things to discuss: Can we optimize it? Should it be the default behavior?

Closes: #1730.
Closes: #1885.