### PR TITLE
Refactor copy placeholder

### DIFF
--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -223,15 +223,13 @@ and to index the top of the page.")
 (define-command go-next ()
   "Navigate to the next element according to the HTML 'rel' attribute."
   (pflet ((go-next ()
-                   (ps:chain document
-                             (query-selector-all "[rel=next]") 0 (click))))
+            (ps:chain document (query-selector-all "[rel=next]") 0 (click))))
     (go-next)))
 
 (define-command go-previous ()
   "Navigate to the previous element according to the HTML 'rel' attribute."
   (pflet ((go-previous ()
-                       (ps:chain document
-                                 (query-selector-all "[rel=prev]") 0 (click))))
+            (ps:chain document (query-selector-all "[rel=prev]") 0 (click))))
     (go-previous)))
 
 (define-command go-to-homepage ()

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -552,16 +552,15 @@ Otherwise go forward to the only child."
     (copy-to-clipboard input)
     (echo "Text copied.")))
 
-(define-parenscript %copy-placeholder ()
-  (ps:chain document active-element placeholder))
-
 (define-command copy-placeholder ()
   "Copy placeholder text to clipboard."
-  (let ((current-value (%copy-placeholder)))
-    (if (eq current-value :undefined)
-        (echo "No active selected placeholder.")
-        (progn (copy-to-clipboard current-value)
-               (echo "Placeholder copied.")))))
+  (pflet ((copy-placeholder ()
+            (ps:chain document active-element placeholder)))
+    (let ((current-value (copy-placeholder)))
+      (if (eq current-value :undefined)
+          (echo "No active selected placeholder.")
+          (progn (copy-to-clipboard current-value)
+                 (echo "Placeholder copied."))))))
 
 (define-class autofill-source (prompter:source)
   ((prompter:name "Autofills")


### PR DESCRIPTION
I am improving the aesthetic of code that I wrote a few weeks/days ago. In the case of `copy-placeholder`, it will make the source code shorter and more reliable, since the auxiliary function will be local to the main function. 