### PR TITLE
gtk.lisp: Web context sharing and separation

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -139,6 +139,11 @@ If nil, renderer-provided dialogs are used.")
     :always-ask
     :documentation "Ask whether to restore the session.
 The possible values are `:always-ask', `:always-restore' and `:never-restore'.")
+   (default-cookie-policy :no-third-party
+                          :type cookie-policy
+                          :documentation "Cookie policy of new buffers.
+Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
+`:no-third-party' (accept cookies for current website only).")
    ;; Hooks follow:
    (before-exit-hook
     (hooks:make-hook-void)
@@ -161,7 +166,6 @@ The handlers take the buffer as argument.")
     (make-hook-buffer)
     :type hook-buffer
     :documentation "Hook run before `buffer-make'.
-This hook is mostly useful to set the `cookies-path'.
 The buffer web view is not allocated, so it's not possible to run any
 parenscript from this hook.  See `buffer-make-hook' for a hook.
 The handlers take the buffer as argument.")

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -309,16 +309,7 @@ inherited from the superclasses."))
           :documentation "Proxy for buffer.")
    (certificate-exceptions '()
                            :type list-of-strings
-                           :documentation "A list of hostnames for which certificate errors shall be ignored.")
-   (cookies-path (make-instance 'cookies-data-path)
-                 :type data-path
-                 :documentation "The path where cookies are stored.  Not all
-renderers might support this.")
-   (default-cookie-policy :no-third-party
-                          :type cookie-policy
-                          :documentation "Cookie policy of new buffers.
-Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
-`:no-third-party' (accept cookies for current website only)."))
+                           :documentation "A list of hostnames for which certificate errors shall be ignored."))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:export-predicate-name-p t)
@@ -328,10 +319,6 @@ Must be one of `:always' (accept all cookies), `:never' (reject all cookies),
 
 (defmethod default-modes append ((buffer web-buffer))
   '(certificate-exception-mode))
-
-(defmethod initialize-instance :after ((buffer web-buffer) &key)
-  (when (expand-path (cookies-path buffer))
-    (ensure-parent-exists (expand-path (cookies-path buffer)))))
 
 (define-class nosave-buffer (user-web-buffer)
   ((data-profile (make-instance 'nosave-data-profile)))

--- a/source/conditions.lisp
+++ b/source/conditions.lisp
@@ -12,5 +12,8 @@
              (format stream "~a" (slot-value c 'message))))
   (:documentation "An error internal to Nyxt. It should abort the ongoing command, but not the whole process."))
 
+(define-condition nyxt-web-context-condition (nyxt-condition)
+  ((context :initarg :context :reader context)))
+
 (define-condition nyxt-prompt-buffer-canceled (error)
   ())

--- a/source/renderers/gtk.lisp
+++ b/source/renderers/gtk.lisp
@@ -94,11 +94,19 @@ See https://developer.gnome.org/gobject/stable/gobject-Signals.html#signal-memor
 
 (defmethod data-directory ((web-context webkit-web-context))
   "Directly returns the CFFI object's `base-data-directory'"
-  (slot-value (slot-value web-context 'webkit::website-data-manager) 'webkit::base-data-directory))
+  (webkit:webkit-website-data-manager-base-data-directory (webkit:webkit-web-context-website-data-manager web-context)))
 
 (defmethod cache-directory ((web-context webkit-web-context))
   "Directly returns the CFFI object's `base-cache-directory'"
-  (slot-value (slot-value web-context 'webkit::website-data-manager) 'webkit::base-cache-directory))
+  (webkit:webkit-website-data-manager-base-cache-directory (webkit:webkit-web-context-website-data-manager web-context)))
+
+(defclass webkit-web-context-ephemeral (webkit-web-context) ()
+  (:metaclass gobject:gobject-class))
+
+(defmethod initialize-instance :after ((web-context webkit-web-context-ephemeral) &key)
+  (unless (webkit:webkit-web-context-is-ephemeral web-context)
+    (error 'nyxt-web-context-condition :context web-context
+                                       :message "Web Contexts of class webkit-web-context-ephemeral must be ephemeral")))
 
 (defclass webkit-website-data-manager (webkit:webkit-website-data-manager) ()
   (:metaclass gobject:gobject-class))
@@ -109,6 +117,14 @@ See https://developer.gnome.org/gobject/stable/gobject-Signals.html#signal-memor
   #+webkit2-tracking
   (webkit:webkit-website-data-manager-set-itp-enabled data-manager t)
   data-manager)
+
+(defclass webkit-website-data-manager-ephemeral (webkit-website-data-manager) ()
+  (:metaclass gobject:gobject-class))
+
+(defmethod initialize-instance :after ((data-manager webkit-website-data-manager-ephemeral) &key)
+  (unless (webkit:webkit-website-data-manager-is-ephemeral data-manager)
+    (error 'nyxt-web-context-condition :context data-manager
+                                       :message "Data Managers of class webkit-website-data-manager-ephemeral must be ephemeral")))
 
 (defvar gtk-running-p nil
   "Non-nil if the GTK main loop is running.
@@ -275,6 +291,14 @@ not return."
                    :dirname (uiop:xdg-data-home +data-root+
                                                  (format nil "~a-web-context" name))))
 
+(defclass webkit-web-view-ephemeral (webkit:webkit-web-view) ()
+  (:metaclass gobject:gobject-class))
+
+(defmethod initialize-instance :after ((web-view webkit-web-view-ephemeral) &key web-context)
+  (unless (webkit:webkit-web-view-is-ephemeral web-view)
+    (error 'nyxt-web-context-condition :context web-context
+                                       :message "Tried to make an ephemeral web-view in a non-ephemeral context")))
+
 (defun make-web-view (&key buffer context-name ephemeral-p)
   "Return a web view instance.
 
@@ -292,7 +316,9 @@ the same naming rules as above."
         (ephemeral-p (or ephemeral-p
                          (typep (current-data-profile) 'nosave-data-profile)
                          (typep buffer 'nosave-buffer))))
-    (make-instance 'webkit:webkit-web-view
+    (make-instance (if ephemeral-p
+                       'webkit-web-view-ephemeral
+                       'webkit:webkit-web-view)
                    :web-context (get-context *browser* (or context-name
                                                            (if internal-p "internal" "default"))
                                              :ephemeral-p ephemeral-p))))
@@ -677,15 +703,17 @@ See `gtk-browser's `modifier-translator' slot."
 (defun construct-web-context (name &key ephemeral-p)
   "Initializes the CFFI object `nyxt:webkit-website-web-context' and its
 `nyxt:webkit-website-data-manager'"
-  (let ((data-manager-data-path (expand-path (data-manager-data-path-for-context name)))
-        (data-manager-cache-path (expand-path (data-manager-cache-path-for-context name))))
-    ;; An ephemeral data-manager cannot be given any directories, even if they are set to nil
-    (let ((data-manager (if ephemeral-p
-                            (make-instance 'webkit-website-data-manager :is-ephemeral t)
-                            (make-instance 'webkit-website-data-manager
-                                           :base-data-directory data-manager-data-path
-                                           :base-cache-directory data-manager-cache-path))))
-      (make-instance 'webkit-web-context :website-data-manager data-manager))))
+  (if ephemeral-p
+      ;; An ephemeral data-manager cannot be given any directories, even if they are set to nil
+      (make-instance 'webkit-web-context-ephemeral
+                     :website-data-manager (make-instance 'webkit-website-data-manager-ephemeral
+                                                          :is-ephemeral t))
+      (let ((data-manager-data-path (expand-path (data-manager-data-path-for-context name)))
+            (data-manager-cache-path (expand-path (data-manager-cache-path-for-context name))))
+        (make-instance 'webkit-web-context
+                       :website-data-manager (make-instance 'webkit-website-data-manager
+                                                            :base-data-directory data-manager-data-path
+                                                            :base-cache-directory data-manager-cache-path)))))
 
 (defun make-context (name &key ephemeral-p)
   (let* ((context (construct-web-context name :ephemeral-p ephemeral-p))


### PR DESCRIPTION
Prior to this commit, nyxt would create a new web-context for each
buffer, but back each non-ephemeral web-context to one of two
locations on disk, ("data-manager" for external buffers, and
"WebKitCache" for internal buffers (as the webkit-data-manager wasn't
being set, so would default)). Since they were backed to the same
location on disk, some session-sharing was possible, but in an
unreliable manner. Furthermore, while the data-directory was set to be
inside of xdg-cache-home the cache-directory wasn't being set, so some
caches were being stored inside of the data-manager-data-path and
others on the system-wide webkit default (hsts-cache-directory and
offline-application-cache-directory).

This patch causes nyxt, by default, to re-use in-memory web-contexts
based on if the buffer is internal or external and whether or not it
is meant to be ephemeral, determined by the make-web-view
function. This function can now also return a web-view in a custom
web-context.

Data-path names are generated based on the name of the context (and
cookies are now stored separately per context). The data-manager's
data-directory is stored inside of xdg-data-home and it's
cache-directory is stored inside of xdg-cache-home.

As buffers are now assigned to a web-context, it doesn't make sense to
store defaults controlling web-contexts in buffer classes. The
default-cookie policy was moved to a setting in the browser and a
per-context cookie data-path is generated

This sets the groundwork to allow user-facing browsing "sessions",
akin to Firefox's "Multi Account Container"s, where users can assign
groups of buffers to share a browsing context.