### PR TITLE
Documentation: add a section about the four spelling check commands

### DIFF
--- a/source/spell-check.lisp
+++ b/source/spell-check.lisp
@@ -31,7 +31,7 @@ suggestions."
                (spell-check-suggest-word :word word))))
 
 (define-command spell-check-word-at-cursor ()
-  "Spell check the word at cursor."
+  "Spell check the word at the cursor."
   (let* ((contents (nyxt/input-edit-mode::active-input-area-content))
          (cursor-position (truncate (nyxt/input-edit-mode::active-input-area-cursor))))
     (let ((text-buffer (make-instance 'text-buffer:text-buffer))

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -213,6 +213,14 @@ buffer.")
                                 nyxt/web-mode:go-previous
                                 nyxt/web-mode:go-up
                                 nyxt/web-mode:go-to-homepage)))
+   (:h3 "Spelling check")
+   (:p "Several commands are provided to spell check words. The default is
+English but it is possible to change the slot for other languages:")
+   (:ul
+    (list-command-information '(nyxt/web-mode:spell-check-word
+                                nyxt/web-mode:spell-check-word-at-cursor
+                                nyxt/web-mode:spell-check-suggest-word
+                                nyxt/web-mode:spell-check-highlighted-word)))
    (:h3 "Visual mode")
    (:p "Select text without a mouse. Nyxt's "
        (:code "visual-mode") " imitates Vim's visual mode (and comes with the


### PR DESCRIPTION
The app **Grammarly** also suggested inserting the article *the* in one of the docstring, so I did.