### PR TITLE
gtk.lisp: create outside-renderer-thread

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -721,7 +721,7 @@ BUFFER's modes."
 (export-always 'on-signal-load-finished)
 (defmethod on-signal-load-finished ((buffer buffer) url)
   ;; Need to force document-model re-parsing.
-  (setf (document-model buffer) nil)
+  (update-document-model :buffer buffer)
   (dolist (mode (modes buffer))
     (on-signal-load-finished mode url))
   (run-thread (hooks:run-hook (buffer-loaded-hook buffer) buffer)))


### PR DESCRIPTION
To run javascript and return its value successfully it has to be run on a
thread outside of the main thread. Why? Because of this code:

```
(defmethod ffi-buffer-evaluate-javascript ((buffer gtk-buffer) javascript &optional world-name)
  (within-renderer-thread
   (lambda (&optional channel)
     (webkit2:webkit-web-view-evaluate-javascript
      (gtk-object buffer)
      javascript
      (if channel
          (lambda (result jsc-result)
            (declare (ignore jsc-result))
            (calispel:! channel result))
          (lambda (result jsc-result)
            (declare (ignore jsc-result))
            result))
      (lambda (condition)
        (javascript-error-handler condition)
        ;; Notify the listener that we are done.
        (when channel
          (calispel:! channel nil)))
      world-name))))
```

note the line that says `if channel`. Looking at the definition for `within-renderer-thread` we see the problem:

```
(defun within-renderer-thread (thunk)
  "If the current thread is the renderer thread, execute THUNK with `funcall'.
Otherwise run the THUNK on the renderer thread by passing it a channel and wait on the channel's result."
  (if (renderer-thread-p)
      (funcall thunk)
      (let ((channel (make-channel 1)))
        (within-gtk-thread
          (funcall thunk channel))
        (calispel:? channel))))
```

a channel is only created and blocking IFF we are running on a non-renderer thread. If we try to make a channel regardless of whether we are on a renderer thread we find ourselves in a starvation state.

Consider:

Thread 1 says "Hello, I am running some code `within-renderer-thread`". It is running our `webkit:webkit-web-view-evaluate-javascript` function. This function accepts a callback. This callback also runs on the renderer thread. Therefore in order for Thread 1 to complete its `within-renderer-thread` call, it must have the callback update the channel which is also waiting for the same `renderer` thread.

It is for this reason that `on-signal-load-finished` is now executed outside of the renderer thread. Otherwise it would not be able to return any values from JS.