### PR TITLE
help: create a command to print the bindings using the space wisely via a tweak in CSS.

### DIFF
--- a/source/help.lisp
+++ b/source/help.lisp
@@ -383,6 +383,17 @@ CLASS is a class symbol."
                                       (:td keyspec)
                                       (:td (string-downcase bound-value)))))))))))
 
+(define-command print-bindings-cheatsheet ()
+  "Print the buffer with the list of all known bindings for the current buffer
+optimizing the use of space."
+  (nyxt::html-set-style 
+   (cl-css:css '((h3 :font-size "10px" :font-family Helvetica Neue Helvetica
+                     :font-weight 500)
+                 (tr :font-size "7px")
+                 (div :display inline-block)))
+   (nyxt:describe-bindings))
+  (print-buffer))
+
 (defun tls-help (buffer url)
   "This function is invoked upon TLS certificate errors to give users
 help on how to proceed."


### PR DESCRIPTION
This PR **tries** to solve issue #1570. I created a new command: `print-bindings-cheatsheet`. The pdf output is attached [here](https://github.com/atlas-engineer/nyxt/files/7079949/output.pdf).

Honestly, I am **not sure** my approach is a good one.
Limitations:
 - it is a cheatsheet tailor-made to keybindings. Seems like something too specific for a command;
 - it re-writes the string wit CSS code entirely inside the `setf`. I guess I can just append the new stuff to the string, this would save some lines of code;
 - the output achieves the goal of reducing paper use, but is it too small to read?
 
 Alternative:
 - I will submit another PR with an alternative approach. This one uses CSS to shrink the font and change the display of the tables. The other will focus on **HTML** and change the `describe-bindings` code, building a different table with spinneret.