### PR TITLE
buffer: Fix document-model :around method when DOM elements are NIL.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -616,10 +616,10 @@ Delete it with `ffi-buffer-delete'."
            (count-dom-elements (nyxt/ps:qs document "html"))))
     (with-current-buffer buffer
       (let ((value (call-next-method))
-            (element-count (truncate (%count-dom-elements))))
-        (if (and value
+            (element-count (%count-dom-elements)))
+        (if (and value element-count
                  ;; Check whether the difference in element count is significant.
-                 (< (abs (- (length (clss:select "*" value)) element-count))
+                 (< (abs (- (length (clss:select "*" value)) (truncate element-count)))
                     (document-model-delta-threshold buffer)))
             value
             (update-document-model :buffer buffer))))))

--- a/source/renderers/gtk.lisp
+++ b/source/renderers/gtk.lisp
@@ -1020,7 +1020,8 @@ See `gtk-browser's `modifier-translator' slot."
                                                handler-id))
         (handler-ids buffer))
   (when (slot-value buffer 'gtk-object) ; Not all buffers have their own web view, e.g. prompt buffers.
-    (gtk:gtk-widget-destroy (gtk-object buffer))))
+    (gtk:gtk-widget-destroy (gtk-object buffer))
+    (setf (gtk-object buffer) nil)))
 
 (define-ffi-method ffi-buffer-load ((buffer gtk-buffer) url)
   "Load URL in BUFFER.


### PR DESCRIPTION
Previously reopening a dead buffer would raise a condition, this fixes it.

@jmercouris Any idea why `truncate` was used here? 