### PR TITLE
Workaround spurious "load-failed" events when loading webkit history pages.

### DIFF
--- a/source/renderers/gtk.lisp
+++ b/source/renderers/gtk.lisp
@@ -69,7 +69,11 @@ See https://developer.gnome.org/gobject/stable/gobject-Signals.html#signal-memor
                       :documentation "Directory in which the WebKitGTK
 data-manager will store the data separately for each buffer.")
    (gtk-extensions-path (make-instance 'gtk-extensions-data-path)
-                        :documentation "Directory to store the WebKit-specific extensions in."))
+                        :documentation "Directory to store the WebKit-specific extensions in.")
+   (loading-webkit-history-p nil
+                             :type boolean
+                             :export nil
+                             :documentation "Internal hack, do not use me!"))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
@@ -756,9 +760,6 @@ See `gtk-browser's `modifier-translator' slot."
             (webkit:webkit-policy-decision-ignore response-policy-decision)
             nil)))))
 
-(defvar *loading-webkit-history-p* nil
-  "Internal hack, do not use!")
-
 (define-ffi-method on-signal-load-changed ((buffer gtk-buffer) load-event)
   ;; `url' can be nil if buffer didn't have any URL associated
   ;; to the web view, e.g. the start page, or if the load failed.
@@ -776,7 +777,7 @@ See `gtk-browser's `modifier-translator' slot."
           ((eq load-event :webkit-load-committed)
            (on-signal-load-committed buffer url))
           ((eq load-event :webkit-load-finished)
-           (setf *loading-webkit-history-p* nil)
+           (setf (loading-webkit-history-p buffer) nil)
            (unless (eq (slot-value buffer 'load-status) :failed)
              (setf (slot-value buffer 'load-status) :finished))
            (on-signal-load-finished buffer url)
@@ -987,8 +988,8 @@ See `gtk-browser's `modifier-translator' slot."
     ;; TODO: WebKitGTK sometimes (when?) triggers "load-failed" when loading a
     ;; page from the webkit-history cache.  Upstream bug?  Anyways, we should
     ;; ignore these.
-    (if *loading-webkit-history-p*
-        (setf *loading-webkit-history-p* nil)
+    (if (loading-webkit-history-p buffer)
+        (setf (loading-webkit-history-p buffer) nil)
         (unless (member (slot-value buffer 'load-status) '(:finished :failed))
           (echo "Failed to load URL ~a in buffer ~a." failing-url (id buffer))
           (setf (slot-value buffer 'load-status) :failed)
@@ -1324,7 +1325,7 @@ As a second value, return the current buffer index starting from 0."
     (values history-list current-index)))
 
 (defmethod load-webkit-history-entry ((buffer gtk-buffer) history-entry)
-  (setf *loading-webkit-history-p* t)
+  (setf (loading-webkit-history-p buffer) t)
   (webkit:webkit-web-view-go-to-back-forward-list-item
    (gtk-object buffer)
    (webkit-history-entry-gtk-object history-entry)))

--- a/source/renderers/gtk.lisp
+++ b/source/renderers/gtk.lisp
@@ -1039,7 +1039,7 @@ requested a reload."
          (entry (or (find url history :test #'quri:uri= :key #'webkit-history-entry-url)
                     (find url history :test #'quri:uri= :key #'webkit-history-entry-original-url))))
     ;; Mark buffer as :loading right away so functions like `window-set-buffer'
-    ;; don't try to reload if they are called before the "load-change" signal
+    ;; don't try to reload if they are called before the "load-changed" signal
     ;; is emitted.
     (setf (slot-value buffer 'load-status) :loading)
     (if (and entry (not (quri:uri= url (url buffer))))
@@ -1297,7 +1297,7 @@ As a second value, return the current buffer index starting from 0."
          (current (webkit:webkit-back-forward-list-get-current-item bf-list))
          (history-list nil)
          (current-index 0))
-    ;; The back-forward list is both negatively and positibely indexed.  Seems
+    ;; The back-forward list is both negatively and positively indexed.  Seems
     ;; that we can't easily know the first index nor the last one.  So let's
     ;; iterate over the length backwards and forwards to make sure we get all
     ;; elements in order.


### PR DESCRIPTION
This seems to be an upstream bug.  In the meantime, temporarily disable
load-failed when loading a page from the webkit history cache.

"Fixes" #1739.

@aartaka I can reproduce this "load-failed" bug with the cl-webkit demo.
Any idea why this happens?