### PR TITLE
Fix upload of files whose names contain wildcard characters

### DIFF
--- a/source/renderers/gtk.lisp
+++ b/source/renderers/gtk.lisp
@@ -877,7 +877,7 @@ See `gtk-browser's `modifier-translator' slot."
       (gobject:g-object-ref (gobject:pointer file-chooser-request))
       (run-thread
         (let ((files (mapcar
-                      #'namestring
+                      #'uiop:native-namestring
                       (handler-case
                           (prompt :prompt (format
                                            nil "File~@[s~*~] to input"


### PR DESCRIPTION
Hello. This patch fixes upload of files with names like `[foo]bar.baz`.