### PR TITLE
Password Manager Bridge (KeepassXC): Bug Fix

### DIFF
--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -18,7 +18,7 @@
   (let* ((st (make-string-input-stream (master-password password-interface)))
          (output (execute password-interface (list "ls" (password-file password-interface))
                           :input st :output '(:string :stripped t))))
-    (remove "Recycle Bin/" (rest (cl-ppcre:split "\\n" output)) :test #'equal)))
+    (remove "Recycle Bin/" (sera:lines output) :test #'equal)))
 
 (defmethod clip-password ((password-interface keepassxc-interface) &key password-name service)
   (declare (ignore service))


### PR DESCRIPTION
Fixed a bug (#1821) in the KeepassXC bridge that caused one of the entries
be missing when listed by Nyxt commands such as `copy-password` or
`copy-username`.