### PR TITLE
keep scroll position when querying hints

### DIFF
--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -148,7 +148,8 @@ ANNOTATE-VISIBLE-ONLY-P is deprecated and has no influence on the function.
 PROMPT is a text to show while prompting for hinted elements.
 FUNCTION is the action to perform on the selected elements."
   (declare (ignore annotate-visible-only-p))
-  (let* ((buffer (current-buffer)))
+  (let* ((buffer (current-buffer))
+	 (scroll-position (document-scroll-position)))
     (let ((result (prompt
                    :prompt prompt
                    :extra-modes '(element-hint-mode)
@@ -159,7 +160,8 @@ FUNCTION is the action to perform on the selected elements."
                     :multi-selection-p multi-selection-p
                     :constructor (lambda (source)
                                    (declare (ignore source))
-                                   (add-element-hints :selector selector)))
+                                   (add-element-hints :selector selector)
+				   (document-scroll-position scroll-position)))
                    :after-destructor
                    (lambda ()
                      (with-current-buffer buffer


### PR DESCRIPTION
I came up with this patch after being slightly annoyed by the `follow-hint` command scrolling the webpage all the way to top  before showing me the hints. With it applied, it saves the scroll position and re-sets after adding the hints to the webpage.

That said, maybe people like the current behaviour and this should be an user option?

Assuming this new behaviour is welcome, this is my first real (albeit small) contribution and I have no idea if this is the best way to go about fixing it, so do comment :)