### PR TITLE
Fix redirections skipping

### DIFF
--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -641,7 +641,8 @@ ELEMENT-SCRIPT is a Parenscript script that is passed to `ps:ps'."
 
 (defmethod nyxt:on-signal-notify-uri ((mode web-mode) url)
   (declare (type quri:uri url))
-  (add-url-to-history url (buffer mode) mode)
+  (when (eq :finished (slot-value (buffer mode) 'nyxt::load-status))
+    (add-url-to-history url (buffer mode) mode))
   url)
 
 (defmethod nyxt:on-signal-notify-title ((mode web-mode) title)
@@ -653,20 +654,6 @@ ELEMENT-SCRIPT is a Parenscript script that is passed to `ps:ps'."
 (defmethod nyxt:on-signal-load-committed ((mode web-mode) url)
   (declare (ignore mode url))
   nil)
-
-(defmethod nyxt:on-signal-load-redirected ((mode web-mode) url)
-  (with-history-access (history (buffer mode))
-    (sera:and-let* ((owner (htree:owner history (id (buffer mode))))
-                    (node (htree:current owner))
-                    (data (htree:data node)))
-      ;; We need to rewrite the previous URL with the data of the URL we get
-      ;; after redirection, thus this entry rewriting.
-      ;;
-      ;; A good alternative would be to delete the previous node and add the new
-      ;; one to history instead, but `htree' is immutable in this regard.
-      (setf (slot-value data 'nyxt:url) url
-            (title data) (title (buffer mode))
-            (nyxt::last-access data) (local-time:now)))))
 
 (defmethod nyxt:on-signal-load-finished ((mode web-mode) url)
   (add-url-to-history url (buffer mode) mode)


### PR DESCRIPTION
This is a fix to my oversight: `:webkit-load-redirected` is actually emitted when the redirection is already resolved. Thus the URL that comes with `:webkit-load-redirected` shouldn't be ignored -- quite the opposite, it should be stored to history, overwriting the URL that it was redirected from (basically the parent URL). That's what this patch does.

Does it make sense?

Closes: #1843.