### PR TITLE
An option not to resolve DNS names when opening an URL

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1198,14 +1198,16 @@ If prefixing with 'https://' results in a valid URL, set `query' to this result
 on instantiation.
 Finally, if nothing else, set the `engine' to the `default-search-engine'."))
 
-(defmethod initialize-instance :after ((query new-url-query) &key)
+(defmethod initialize-instance :after ((query new-url-query)
+                                       &key check-dns-p &allow-other-keys)
   ;; Trim whitespace, in particular to detect URL properly.
   (setf (query query) (str:trim (query query)))
   (cond
     ((engine query)
      ;; First check engine: if set, no need to change anything.
      nil)
-    ((valid-url-p (query query))
+    ((valid-url-p (query query)
+                  :check-dns-p check-dns-p)
      ;; Valid URLs should be passed forward.
      nil)
     ;; Rest is for invalid URLs:
@@ -1216,7 +1218,9 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
             (uiop:native-namestring
              (uiop:ensure-absolute-pathname
               (query query) *default-pathname-defaults*)))))
-    ((valid-url-p (str:concat "https://" (query query)))
+    ((and check-dns-p
+          (valid-url-p (str:concat "https://" (query query))
+                       :check-dns-p check-dns-p))
      (setf (query query)
            (str:concat "https://" (query query))))
     (t
@@ -1246,7 +1250,7 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
   `(("URL or new query" ,(query query))
     ("Search engine?" ,(if (engine query) (shortcut (engine query)) ""))))
 
-(defun input->queries (input)
+(defun input->queries (input &key (check-dns-p t))
   (let* ((terms (sera:tokens input))
          (engines (let ((all-prefixed-engines
                           (remove-if
@@ -1261,17 +1265,22 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
     (append (unless (and engines (member (first terms)
                                          (mapcar #'shortcut engines)
                                          :test #'string=))
-              (list (make-instance 'new-url-query :query input)))
+              (list (make-instance 'new-url-query
+                                   :query       input
+                                   :check-dns-p check-dns-p)))
             (alex:mappend (lambda (engine)
                             (append
                              (list (make-instance 'new-url-query
-                                                  :query (str:join " " (rest terms))
-                                                  :engine engine))
+                                                  :query       (str:join " " (rest terms))
+                                                  :engine      engine
+                                                  :check-dns-p check-dns-p))
                              ;; Some engines (I'm looking at you, Wikipedia!)
                              ;; return garbage in response to an empty request.
                              (when (and (completion-function engine) (rest terms))
                                (mapcar (alex:curry #'make-instance 'new-url-query
-                                                   :engine engine :query)
+                                                   :engine      engine
+                                                   :check-dns-p check-dns-p
+                                                   :query)
                                        (with-protect ("Error while completing search: ~a" :condition)
                                          (funcall (completion-function engine)
                                                   (str:join " " (rest terms))))))))
@@ -1281,9 +1290,13 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
   ((prompter:name "New URL or search query")
    (prompter:filter-preprocessor
     (lambda (suggestions source input)
-      (declare (ignorable suggestions source))
-      (input->queries input)))
+      (declare (ignore suggestions source))
+      (input->queries input :check-dns-p nil)))
    (prompter:filter nil)
+   (prompter:filter-postprocessor
+    (lambda (suggestions source input)
+      (declare (ignore suggestions source))
+      (input->queries input :check-dns-p t)))
    (prompter:actions '(buffer-load)))
   (:export-class-name-p t)
   (:documentation "This prompter source tries to \"do the right thing\" to

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -73,10 +73,10 @@ If the URL contains hexadecimal-encoded characters, return their unicode counter
   (iolib/sockets:lookup-hostname name))
 
 (export-always 'valid-url-p)
-(defun valid-url-p (url &key skip-domain-validation)
+(defun valid-url-p (url &key (check-dns-p t))
   "Return non-nil when URL is a valid URL.
-With SKIP-DOMAIN-VALIDATION, the domain name existence is not verified.
-Domain name validation may take significant time since it looks up the DNS."
+The domain name existence is verified only if CHECK-DNS-P is T. Domain
+name validation may take significant time since it looks up the DNS."
   ;; List of URI schemes: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
   ;; Last updated 2020-08-26.
   (let* ((nyxt-schemes '("lisp" "javascript"))
@@ -111,7 +111,7 @@ Domain name validation may take significant time since it looks up the DNS."
                 ;; A valid URL may have an empty domain, e.g. http://192.168.1.1.
                 (quri:uri-host url)
                 (or
-                 skip-domain-validation
+                 (not check-dns-p)
                  ;; Onion links or not resolved via DNS, just accept them.
                  (string= (quri:uri-tld url) "onion")
                  ;; "http://algo" has the "algo" hostname but it's probably invalid


### PR DESCRIPTION
Here is a commit which makes use of SKIP-DOMAIN-VALIDATION in VALID-URL-P. When domain validation is skipped you do not have to wait a bit after you typed your web address in a prompt buffer. I thought this was done before, but apparently it wasn't.

Here is the rules how URL queries are distinguished from search queries:

* If you type a query with a scheme and this looks like an URL when it is an URL (e.g. `http://localhost` is considered to be URL)
* If you type something like `localhost` when it is considered to be a search query even if it is a host name.
* If you type something with dot which appears to be an URL when it is considered to be URL (e.g. `google.com`)
* Everything else is a search query.