### PR TITLE
FAQ section added in the developer README

### DIFF
--- a/README.org
+++ b/README.org
@@ -77,7 +77,7 @@ systems provide packages for Nyxt:
 
 - Alpine.
 - Debian and derivatives such as Ubuntu and Linux Mint.
-- [[https://source.atlas.engineer/view/repository/macports-port][MacPorts]].
+- [[https://github.com/atlas-engineer/ports][MacPorts]].
 - [[https://aur.archlinux.org/packages/nyxt][Arch Linux AUR]] and the [[https://aur.archlinux.org/packages/nyxt-browser-git/][-git PKGBUILD]].  See also the [[https://e-v.srht.site/nyxt-aur-builds.html][unofficial binary
   packages]], courtesy of @edgar-vincent.
 - [[https://nixos.org/nix/][Nix]]: Install with =nix-env --install nyxt=.

--- a/documents/README.org
+++ b/documents/README.org
@@ -33,7 +33,6 @@
   - [[#interacting-with-a-compiled-version-of-nyxt][Interacting with a compiled version of Nyxt]]
     - [[#slime][SLIME]]
     - [[#sly][SLY]]
-- [[#faq][FAQ]]
 - [[#help--community][Help & Community]]
   - [[#issue-tracker][Issue tracker]]
   - [[#learning-common-lisp][Learning Common Lisp]]
@@ -187,6 +186,21 @@ these fixes.
 - WebKitGTK+
 - XQuartz
 - libfixposix
+
+Notes:
+
+1. If you install dependencies via MacPorts and your Lisp is SBCL, please try
+   putting the following into your =~/.sbclrc=:
+
+   #+begin_src lisp
+     (ql:quickload :cffi)
+     (pushnew "/opt/local/lib" cffi:*foreign-library-directories* :test #'equal)
+   #+end_src
+
+2. To install the WebKitGTK+ dependency, you may want to install
+   `webkit2-gtk(-devel)` instead of `webkit-gtk3` via your favorite
+   package manager.
+
 
 ** Qt dependencies
 
@@ -385,21 +399,6 @@ Follow the following steps:
 
 Then proceed as in the previous SLIME section by relacing
 ~slime-connect~ with ~sly-connect~.
-
-* FAQ
-
-This section aims to collect questions and answers that have helped users and
-developers in the past:
-
-1. If you install dependencies via MacPorts and your Lisp is SBCL, please try
-   putting the following into your =~/.sbclrc=:
-   #+begin_src lisp
-     (ql:quickload :cffi)
-     (pushnew "/opt/local/lib" cffi:*foreign-library-directories* :test #'equal)
-   #+end_src
-
-2. If you are on a Mac, you may want to install "webkit2-gtk(-devel)" instead
-   of "webkit-gtk3" via your package manager.
 
 
 * Help & Community

--- a/documents/README.org
+++ b/documents/README.org
@@ -199,7 +199,8 @@ Notes:
 
 2. To install the WebKitGTK+ dependency, you may want to install
    `webkit2-gtk(-devel)` instead of `webkit-gtk3` via your favorite
-   package manager.
+   package manager. If you are on a legacy version of macOS which is not
+   supported by HomeBrew, you may want to try install these via MacPorts.
 
 
 ** Qt dependencies

--- a/documents/README.org
+++ b/documents/README.org
@@ -33,6 +33,7 @@
   - [[#interacting-with-a-compiled-version-of-nyxt][Interacting with a compiled version of Nyxt]]
     - [[#slime][SLIME]]
     - [[#sly][SLY]]
+- [[#faq][FAQ]]
 - [[#help--community][Help & Community]]
   - [[#issue-tracker][Issue tracker]]
   - [[#learning-common-lisp][Learning Common Lisp]]

--- a/documents/README.org
+++ b/documents/README.org
@@ -385,6 +385,22 @@ Follow the following steps:
 Then proceed as in the previous SLIME section by relacing
 ~slime-connect~ with ~sly-connect~.
 
+* FAQ
+
+This section aims to collect questions and answers that have helped users and
+developers in the past:
+
+1. If you install dependencies via MacPorts and your Lisp is SBCL, please try
+   putting the following into your =~/.sbclrc=:
+   #+begin_src lisp
+     (ql:quickload :cffi)
+     (pushnew "/opt/local/lib" cffi:*foreign-library-directories* :test #'equal)
+   #+end_src
+
+2. If you are on a Mac, you may want to install "webkit2-gtk(-devel)" instead
+   of "webkit-gtk3" via your package manager.
+
+
 * Help & Community
 
 There are several ways to ask for help from the community.


### PR DESCRIPTION
A simple FAQ section is now added in the developmer README per @Ambrevar's suggestion in https://github.com/atlas-engineer/nyxt/issues/1857. We can extend it as we go.