### PR TITLE
Process "decide-policy" asynchronously.

### DIFF
--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -239,7 +239,7 @@ Such contexts are not needed for internal buffers."
     ;; decision on error, lest we load a web page in an internal buffer for
     ;; instance.
     (g:g-object-ref (g:pointer response-policy-decision))
-    (run-thread
+    (run-thread "asynchronous decide-policy processing"
       (handler-bind ((error (lambda (c)
                               (echo-warning "decide policy error: ~a" c)
                               ;; TODO: Don't automatically call the restart when from the REPL?

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -238,15 +238,18 @@ Such contexts are not needed for internal buffers."
     ;; Even if errors are caught with `with-protect', we must ignore the policy
     ;; decision on error, lest we load a web page in an internal buffer for
     ;; instance.
-    (handler-bind ((error (lambda (c)
-                            (echo-warning "decide policy error: ~a" c)
-                            ;; TODO: Don't automatically call the restart when from the REPL?
-                            ;; (unless *run-from-repl-p*
-                            ;;   (invoke-restart 'ignore-policy-decision))
-                            (invoke-restart 'ignore-policy-decision))))
-      (restart-case (on-signal-decide-policy buffer response-policy-decision policy-decision-type-response)
-        (ignore-policy-decision ()
-          (webkit:webkit-policy-decision-ignore response-policy-decision))))))
+    (g:g-object-ref (g:pointer response-policy-decision))
+    (run-thread
+      (handler-bind ((error (lambda (c)
+                              (echo-warning "decide policy error: ~a" c)
+                              ;; TODO: Don't automatically call the restart when from the REPL?
+                              ;; (unless *run-from-repl-p*
+                              ;;   (invoke-restart 'ignore-policy-decision))
+                              (invoke-restart 'ignore-policy-decision))))
+        (restart-case (on-signal-decide-policy buffer response-policy-decision policy-decision-type-response)
+          (ignore-policy-decision ()
+            (webkit:webkit-policy-decision-ignore response-policy-decision)))))
+    t))
 
 
 (defmacro connect-signal-function (object signal fn)
@@ -737,8 +740,7 @@ See `gtk-browser's `modifier-translator' slot."
               (progn
                 (log:debug "Forward to ~s's renderer (no request-resource-hook handlers)."
                            buffer)
-                (webkit:webkit-policy-decision-use response-policy-decision)
-                nil)
+                (webkit:webkit-policy-decision-use response-policy-decision))
               (let ((request-data
                       (hooks:run-hook
                        (request-resource-hook buffer)
@@ -748,13 +750,11 @@ See `gtk-browser's `modifier-translator' slot."
                   ((not (typep request-data 'request-data))
                    (log:debug "Don't forward to ~s's renderer (non request data)."
                               buffer)
-                   (webkit:webkit-policy-decision-ignore response-policy-decision)
-                   nil)
+                   (webkit:webkit-policy-decision-ignore response-policy-decision))
                   ((quri:uri= url (url request-data))
                    (log:debug "Forward to ~s's renderer (unchanged URL)."
                               buffer)
-                   (webkit:webkit-policy-decision-use response-policy-decision)
-                   nil)
+                   (webkit:webkit-policy-decision-use response-policy-decision))
                   (t
                    ;; Low-level URL string, we must not render the puni codes so use
                    ;; `quri:render-uri'.
@@ -766,13 +766,11 @@ See `gtk-browser's `modifier-translator' slot."
                    ;; start the new load request, or else WebKit will be
                    ;; confused about which URL to load.
                    (webkit:webkit-policy-decision-ignore response-policy-decision)
-                   (webkit:webkit-web-view-load-request (gtk-object buffer) request)
-                   nil))))
+                   (webkit:webkit-web-view-load-request (gtk-object buffer) request)))))
           (progn
             (log:debug "Don't forward to ~s's renderer (non request data)."
                        buffer)
-            (webkit:webkit-policy-decision-ignore response-policy-decision)
-            nil)))))
+            (webkit:webkit-policy-decision-ignore response-policy-decision))))))
 
 (define-ffi-method on-signal-load-changed ((buffer gtk-buffer) load-event)
   ;; `url' can be nil if buffer didn't have any URL associated


### PR DESCRIPTION
This should fix the issue we had with the WebKit 2.34.1 update crashing Nyxt.

**Summary:** the issue was in the fact that we processed the `"decide-policy"` synchronously and were not fast enough to process it, thus the requests were never resolved and WebKit was cutting us off, hanging the whole browser.

# Investigation

It all started with #1840 and #1845, with Arch and Void getting the 2.34.1 WebKit update, and Nyxt started crashing _on every page load_. 

> NB: In my case, it wasn't crashing, it was hanging, so I may have fixed a different issue there. Testing is welcome!

@dtw-waleee (thanks!) have narrowed the problem down to `make-decide-policy-handler`, where the `"decide-policy"` signal was processed. 

@jmercouris supposed it was the `handler-bind` and `restart-case` to blame, with the omnipresent issues of WebKit main thread segfaulting when you try to move computations inside/outside of it. Removing the `handler-bind` didn't solve the problem for me, though.

Then, @dtw-waleee (thanks again!) have reported that disabling `blocker-mode` made crashes to effectively disappear. At the same time, I discovered that I can sometimes use Nyxt, but then it breaks terribly when I try to load some _big_ website, like YouTube. The remark of Kabouik that `blocker-mode` is slow and is a performance bottleneck led me to thinking that it's actually about the performance and time...

The problem was:
- We are trying to process the request synchronously.
- We are too slow at it (especially if the `blocker-mode` is there wasting precious time on hostlist fetching).
- WebKit is unable to get the final result of the synchronous computation.
- WebKit simply hangs without it.

To fix it, this patch offloads the request processing to a separate thread and tells WebKit we will eventually process the request _asynchronously_. Once we actually process it, we send the decision to Webkit and it loads the website. See the [`"decide-policy"` docs](https://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#WebKitWebView-decide-policy) for how it's working.

However, why does Nyxt 2.2.0 works? Why it's only WebKit 2.34.1 that have broken the fragile mechanism for policy decisions that we had? I have no answer to these questions :/

# Things to Discuss

- This patch returns TRUE from the decide policy handler, thus disabling all the other handlers attached to this signal. Were we actually using them? Can this patch possibly break Nyxt somewher else? Why returning FALSE in the first place? Docs say that there's only a default handler that always accepts the request, so no need in making it fire.
- Why this `handler-bind` in `make-decide-policy-handler` if a simpler `handler-case` would do just fine?
- We need to revisit other signal handlers and ensure we process them asynchronously whenever possible.

@Ambrevar, @dtw-waleee, @khinsen, @sivark, @OlMon, @fade, @rimio, @WilliamBehrens, @fbmnds, @guojing0, if you have time, can you please test it and tell whether it solves your problem? I'm still unsure whether it's the proper fix for your crashes, so I need your confirmation to merge.