### PR TITLE
Set User Agent to a more generic one in reduce-tracking-mode.

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -711,7 +711,7 @@ sometimes yields the wrong result."
 (define-ffi-generic ffi-buffer-enable-webgl (buffer value))
 (define-ffi-generic ffi-buffer-auto-load-image (buffer value))
 (define-ffi-generic ffi-buffer-enable-sound (buffer value))
-(define-ffi-generic ffi-buffer-user-agent (buffer value))
+(define-ffi-generic ffi-buffer-user-agent (buffer &optional value))
 (define-ffi-generic ffi-buffer-set-proxy (buffer &optional proxy-url ignore-hosts))
 (define-ffi-generic ffi-buffer-get-proxy (buffer))
 (define-ffi-generic ffi-buffer-download (buffer url))

--- a/source/mode/reduce-tracking.lisp
+++ b/source/mode/reduce-tracking.lisp
@@ -8,7 +8,7 @@
 
 (define-mode reduce-tracking-mode ()
   "Set specific settings in the web view in order to mitigate fingerprinting,
-(how third-party trackers attempt to indentify you.
+(how third-party trackers attempt to indentify you).
 
 Fingerprinting can be tested with https://panopticlick.eff.org/."
   ((preferred-languages
@@ -16,8 +16,23 @@ Fingerprinting can be tested with https://panopticlick.eff.org/."
     :type list-of-strings
     :documentation "The list of languages that will be sent as part of the
 Accept-Language HTTP header.")
+   (preferred-user-agent
+    ;; Check https://techblog.willshouse.com/2012/01/03/most-common-user-agents
+    ;; occasionally and refresh when necessary.
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
+    :type string
+    :documentation "The user agent to set when enabling `reduce-tracking-mode'.
+It's Safari on macOS by default, because this way we break fewer websites while
+still being less noticeable in the crowd.")
+   (old-user-agent
+    nil
+    :type (or null string)
+    :export nil
+    :documentation "The User Agent the browser had before enabling this mode.")
    (destructor
     (lambda (mode)
+      (setf (old-user-agent mode) (ffi-buffer-user-agent (buffer mode)))
+      (ffi-buffer-user-agent (buffer mode) (preferred-user-agent mode))
       (ffi-set-preferred-languages (buffer mode)
                                    (list (first
                                           (str:split
@@ -26,6 +41,7 @@ Accept-Language HTTP header.")
       (ffi-set-tracking-prevention (buffer mode) nil)))
    (constructor
     (lambda (mode)
+      (ffi-buffer-user-agent (buffer mode) (old-user-agent mode))
       (ffi-set-preferred-languages (buffer mode)
                                    (preferred-languages mode))
       (ffi-set-tracking-prevention (buffer mode) t)))))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1210,10 +1210,13 @@ requested a reload."
         ;; If download was too small, it may not have been updated.
         (setf (completion-percentage download) 100)))))
 
-(define-ffi-method ffi-buffer-user-agent ((buffer gtk-buffer) value)
-  (setf (webkit:webkit-settings-user-agent
-         (webkit:webkit-web-view-get-settings (gtk-object buffer)))
-        value))
+(define-ffi-method ffi-buffer-user-agent ((buffer gtk-buffer) &optional value)
+  (if value
+      (setf (webkit:webkit-settings-user-agent
+             (webkit:webkit-web-view-get-settings (gtk-object buffer)))
+            value)
+      (webkit:webkit-settings-user-agent
+       (webkit:webkit-web-view-get-settings (gtk-object buffer)))))
 
 (define-ffi-method ffi-buffer-webgl-enabled-p ((buffer gtk-buffer))
   (webkit:webkit-settings-enable-webgl


### PR DESCRIPTION
This adds User Agent customization to `reduce-tracking-mode`. As a fun exercise, I was able to open Jitsi when setting `nyxt/reduce-tracking-mode:preferred-user-agent` to `"Mozilla/5.0 (X11; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0"` (Firefox on Linux).

# What's new:
- `old-user-agent` and `preferred-user-agent` slots in `reduce-tracking-mode`.
  - It uses them to store the old User Agent and set new, a bit more generic User Agent, respectively.
- `ffi-buffer-user-agent`'s second argument is optional now.
  - When it's there, `ffi-buffer-user-agent` behaves like a setter.
  - When it's not there, `ffi-buffer-user-agent` behaves like getter.

# Why Safari?
Well, MacOS is pretty close to GNU/Linux and BSD, while Safari uses the same rendering engine. Thus, the website breakage should be minimal, while we will still be able to disappear in the Safari users crowd (however small it is).

# How to Test 
- Run Nyxt with this patch.
- Enable `reduce-tracking-mode`.
- Navigate to https://techblog.willshouse.com/2012/01/03/most-common-user-agents.
- It should identify you as a MacOS Safari User.

How does it look?