### PR TITLE
Handle onbeforeunload prompts.

### DIFF
--- a/build-scripts/nyxt.scm
+++ b/build-scripts/nyxt.scm
@@ -45,6 +45,7 @@
   #:use-module (guix licenses)
   #:use-module (guix git-download)
   #:use-module (guix build-system asdf) ; TODO: Remove sbcl-cl-webkit once Guix has 3.3.0.
+  #:use-module (guix build-system asdf) ; TODO: Remove sbcl-cl-webkit once Guix has 3.4.0.
   #:use-module (guix build-system gnu)
   #:use-module (guix build-system glib-or-gtk)
   #:use-module (gnu packages)
@@ -61,11 +62,11 @@
   #:use-module (gnu packages version-control)
   #:use-module (gnu packages webkit))
 
-;; TODO: Remove sbcl-cl-webkit once Guix has 3.3.0.
+;; TODO: Remove sbcl-cl-webkit once Guix has 3.4.0.
 (define-public sbcl-cl-webkit
   (package
     (name "sbcl-cl-webkit")
-    (version "3.3.0")
+    (version "3.4.0")
     (source
      (origin
        (method git-fetch)
@@ -75,7 +76,7 @@
        (file-name (git-file-name "cl-webkit" version))
        (sha256
         (base32
-         "00y02nzskvvgxj9r3ypqswxp932f5nvyriafcxfp5kr9b33j93x0"))))
+         "0l6ml7g0r0kzbgf49bsgj2yxhgralh8fc0h9vpc79fvw20qgsd56"))))
     (build-system asdf-build-system/sbcl)
     (inputs
      `(("cffi" ,sbcl-cffi)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -913,19 +913,25 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
 (defun buffer-delete (buffer)
   "For dummy buffers, use `ffi-buffer-delete' instead."
   (hooks:run-hook (buffer-delete-hook buffer) buffer)
+  (with-data-access (history (history-path buffer))
+    (sera:and-let* ((owner (htree:owner history (id buffer)))
+                    (current (htree:current owner))
+                    (data (htree:data current)))
+      (setf (nyxt::scroll-position data) (nyxt:document-scroll-position buffer))))
+  (ffi-buffer-delete buffer))
+
+(defun buffer-hide (buffer)
+  "Stop showing the buffer in Nyxt.
+Should be called from/instead of `ffi-buffer-delete' when the renderer view
+associated to the buffer is already killed."
   (let ((parent-window (find buffer (window-list) :key 'active-buffer)))
     (with-data-access (history (history-path buffer))
-      (sera:and-let* ((owner (htree:owner history (id buffer)))
-                      (current (htree:current owner))
-                      (data (htree:data current)))
-        (setf (nyxt::scroll-position data) (nyxt:document-scroll-position buffer)))
       (htree:delete-owner history (id buffer)))
     (when parent-window
       (let ((replacement-buffer (or (first (get-inactive-buffers))
                                     (make-buffer :load-url-p nil
                                                  :url (quri:uri "about:blank")))))
         (window-set-buffer parent-window replacement-buffer)))
-    (ffi-buffer-delete buffer)
     (buffers-delete (id buffer))
     ;; (setf (id buffer) "") ; TODO: Reset ID?
     (add-to-recent-buffers buffer)))


### PR DESCRIPTION
This enables the "Do you want to leave this page"-like prompts for the buffers with the unfinished input or otherwise `onbeforeunload`-invoking code. This way, one has much less chances to lose their input/progress when doing something in Nyxt.

@Ambrevar, this it the buffer killing prompt I've been talking about in #1681.

# Caveats
- What used to be `buffer-delete` is now effectively two functions: `buffer-delete` and `buffer-hide`, the latter of which should be called from `ffi-buffer-delete`. This is not a perfect design, but I had no idea of how to do it better, given the overall WebKit brittleness there -- it does not provide us with async processing, callbacks, anything. You simply call `webkit_web_view_try_close` and process it elsewhere.
- `webkit_web_view_try_close`. It's there as a binding in `cl-webkit`, and this patch requires the lates `cl-webkit`. On a related note: is it alright when I bump up the `cl-webkit` version every week? :) I feel like I shouldn't, but we need to depend on some version of `cl-webkit` in Nyxt, thus the version bumping.

# Hot To Tests
Open one of the examples on https://www.w3schools.com/jsref/event_onbeforeunload.asp and try to close the buffer/click any link.