### PR TITLE
Add TAGS file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ manual.html
 
 # Ignore flake lockfile
 flake.lock
+
+# Ignore etags/ctags
+TAGS


### PR DESCRIPTION
The TAGS file is created when you use tools like `ctags`/`etags`, which is used for navigating a codebase.