### PR TITLE
Refer to "guix shell" rather than "guix environment"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
       run: test -z "$(guix --version 2>&1 >/dev/null)"
     - name: Build Guix package
       run: |
-          guix environment --container --user=dummy-user --load=build-scripts/nyxt.scm --ad-hoc guix -- make all NYXT_SUBMODULES=false
+          guix shell --container -D -f build-scripts/nyxt.scm --user=dummy-user --ad-hoc guix -- make all NYXT_SUBMODULES=false
 
     - name: Generate version file
       shell: bash

--- a/build-scripts/nyxt-quicklisp.scm
+++ b/build-scripts/nyxt-quicklisp.scm
@@ -3,7 +3,7 @@
 
 ;; Test with
 ;;
-;;  guix environment -l build-scripts/nyxt-quicklisp.scm --pure --ad-hoc openssl -- bash -c 'make all && make install DESTDIR=/tmp/nyxt-output/'
+;;  guix shell --pure -D -f build-scripts/nyxt-quicklisp.scm openssl -- bash -c 'make all && make install DESTDIR=/tmp/nyxt-output/'
 
 ;; Notes: openssl is required for cl-cookie, etc.  For some reason, it's not
 ;; dragged into the environment when added as propagated-input.

--- a/build-scripts/nyxt.scm
+++ b/build-scripts/nyxt.scm
@@ -10,18 +10,18 @@
 ;;
 ;; To use as the basis for a development environment, run:
 ;;
-;;   guix environment --container --load=build-scripts/nyxt.scm --ad-hoc glib glib-networking gsettings-desktop-schemas
+;;   guix shell --container -D -f build-scripts/nyxt.scm glib glib-networking gsettings-desktop-schemas
 ;;
 ;; Replace --container by --pure if you still want ASDF to see external
 ;; libraries in ~/common-lisp, etc.
 ;; To build a local executable and then run it:
 ;;
-;;   guix environment --container --load=build-scripts/nyxt.scm -- make all NYXT_SUBMODULES=false
-;;   guix environment --pure --load=build-scripts/nyxt.scm -- ./nyxt
+;;   guix shell --container -D -f build-scripts/nyxt.scm -- make all NYXT_SUBMODULES=false
+;;   guix shell --pure -D -f build-scripts/nyxt.scm -- ./nyxt
 ;;
 ;; To start in a container, run:
 ;;
-;;   guix environment --load=build-scripts/nyxt.scm --container --network --share=/PATH/TO/YOUR/NYXT/CHECKOUT=/nyxt --preserve='^DISPLAY$' --expose=/etc/ssl/certs --ad-hoc nss-certs glib glib-networking gsettings-desktop-schemas
+;;   guix shell -f build-scripts/nyxt.scm --container --network --share=/PATH/TO/YOUR/NYXT/CHECKOUT=/nyxt --preserve='^DISPLAY$' --expose=/etc/ssl/certs --ad-hoc nss-certs glib glib-networking gsettings-desktop-schemas
 ;;
 ;; Replace '/PATH/TO/YOUR/NYXT/CHECKOUT' as appropriate.
 ;; Then in the container environment:

--- a/documents/README.org
+++ b/documents/README.org
@@ -305,13 +305,13 @@ a container on GNU/Linux.
 
 - With Guix:
   #+begin_src sh
-    guix environment --container --network --preserve='^DISPLAY$' --expose=/etc/ssl/certs --ad-hoc nss-certs nyxt -- nyxt
+    guix shell --container --network --preserve='^DISPLAY$' --expose=/etc/ssl/certs nss-certs nyxt -- nyxt
   #+end_src
 
   If you want to load your configuration and use the data files:
 
   #+begin_src sh
-    guix environment --container --network --preserve='^DISPLAY$' --expose=/etc/ssl/certs --expose="$HOME/.config/nyxt/" --share="$HOME/.local/share/nyxt"="$HOME/.local/share/nyxt/" --ad-hoc nss-certs nyxt -- nyxt
+    guix shell --container --network --preserve='^DISPLAY$' --expose=/etc/ssl/certs --expose="$HOME/.config/nyxt/" --share="$HOME/.local/share/nyxt"="$HOME/.local/share/nyxt/" nss-certs nyxt -- nyxt
   #+end_src
 
   If you get the following error:


### PR DESCRIPTION
Guix is transitioning away from "guix environment" to the new
"guix shell" command.