### PR TITLE
Prompter async attrs

### DIFF
--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -171,7 +171,7 @@ compution is not finished.")))
   text)
 
 (export-always 'destroy)
-(defun destroy (prompter)
+(defmethod destroy ((prompter prompter))
   "First call `before-destructor', then call all the source destructors, finally call
 `after-destructor'.
 Signal destruction by sending a value to PROMPTER's `interrupt-channel'."

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -754,7 +754,7 @@ BUFFER's modes."
 (defmethod prompter:object-attributes ((buffer web-buffer))
   `(("URL" ,(render-url (url buffer)))
     ("Title" ,(title buffer))
-    ("Keywords" ,(format nil "~:{~a~^ ~}" (keywords buffer)))))
+    ("Keywords" ,(lambda (buffer) (format nil "~:{~a~^ ~}" (keywords buffer))))))
 
 (-> make-buffer
     (&key (:title string)


### PR DESCRIPTION
Fix #1709 and supersedes https://github.com/atlas-engineer/nyxt/pull/1924.

@jmercouris This does the same as #1924 but at the prompter library level, this way it will now be trivial to make attribute computation asynchronous any time, instead of all the boilerplate from #1924.

Also note that attributes are only computed if displayed.  Were we to not display Keywords by default, they would no be computed.  This way we are fully lazy!

I've also removed the staleness issue.