### PR TITLE
Build on FreeBSD is broken again.

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -611,6 +611,7 @@ See `asdf::*immutable-systems*'."
 
 (defsystem "nyxt/web-extensions"
   :pathname "libraries/web-extensions/"
+  :depends-on (:cffi-toolchain)
   :components ((:static-file "alarms.c")
                (:static-file "bookmarks.c")
                (:static-file "browser.c")
@@ -634,8 +635,8 @@ See `asdf::*immutable-systems*'."
                                     t))
   :perform (compile-op
             (o c)
-            (let ((c-compiler (or (uiop:getenv "CC")
-                                  "gcc"))
+            (let ((c-compiler (symbol-value
+                               (uiop:find-symbol* :*cc* :cffi-toolchain)))
                   (c-flags (uiop:split-string
                             (uiop:run-program
                              '("pkg-config" "gobject-2.0" "webkit2gtk-web-extension-4.0" "--cflags")


### PR DESCRIPTION
FreeBSD and maybe some other BSD variants do not have GCC installed by default, the compiler name must be simply `cc` (which is a symlink to clang). `cc` is OK on most linuxes too, but, unfortunately, guix does not have `cc` symlink.

I do not know guix and have no idea how to fix it properly, but there is a dirty solution if you cannot do something better.

BTW, `libnyxt` seems to be unused. What is it for? (I suggest it's for upcoming browser extensions, but I think I can remove it for now. Is that correct?)