### PR TITLE
New mode for disabling search auto-completion

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -154,6 +154,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                (:file "mode/no-image")
                (:file "mode/no-sound")
                (:file "mode/no-script")
+               (:file "mode/no-search-completion")
                (:file "mode/no-webgl")
                (:file "mode/reduce-bandwidth")
                (:file "mode/download")

--- a/source/mode/no-search-completion.lisp
+++ b/source/mode/no-search-completion.lisp
@@ -1,0 +1,16 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package :nyxt/no-search-completion-mode
+    (:use :common-lisp :nyxt)
+  (:documentation "Disable search engine autocompletion."))
+(in-package :nyxt/no-search-completion-mode)
+
+(define-mode no-search-completion-mode ()
+  "Disable search engine autocompletion in current buffer."
+  ((destructor
+    (lambda (mode)
+      (setf (search-always-auto-complete-p (buffer mode)) t)))
+   (constructor
+    (lambda (mode)
+      (setf (search-always-auto-complete-p (buffer mode)) nil)))))


### PR DESCRIPTION
Here is `no-search-completion-mode` which disables suggestions from a search engine. This mode sets already existing `search-always-auto-complete-p` slot in instances of `user-buffer` class.