### PR TITLE
Add `pkg-config` to macOS dependencies in developer README

### DIFF
--- a/documents/README.org
+++ b/documents/README.org
@@ -134,6 +134,7 @@ run the following:
 - libfixposix
 - xclip (for clipboard support)
 - enchant (for spellchecking)
+- pkg-config (for web-extensions)
 
 - Debian-based distributions:
   #+begin_src sh
@@ -234,6 +235,7 @@ details about how to install it on your system.
 - libfixposix
 - xclip (for clipboard support)
 - enchant (for spellchecking)
+- pkg-config (for web-extensions)
 
 *** macOS dependencies
 

--- a/documents/README.org
+++ b/documents/README.org
@@ -189,6 +189,7 @@ these fixes.
 - WebKitGTK+
 - XQuartz
 - libfixposix
+- pkg-config
 
 Notes:
 
@@ -239,6 +240,7 @@ details about how to install it on your system.
 - Qt 5.14.0+
 - Qt WebEngine
 - libfixposix
+- pkg-config
 
 ** Fetch the source code
 


### PR DESCRIPTION
After web-extension was added to `master` branch, compiling from source requires `pkg-config`.

The program `pkg-config` is not included in either macOS system or Apple's command line tools, so one needs to install it, like other dependencies, from third-party tools.