### PR TITLE
Insert "Create init file" button in the manual

### DIFF
--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -41,7 +41,8 @@ below to create said file, if it's not created yet.")
                    :href (lisp-url `(echo "Init file exists"))
                    "Init file exists")
                (:a :class "button"
-                   :href (lisp-url `(with-open-file (_ ,init-file-path
+                   :href (lisp-url `(ensure-directories-exist ,init-file-path)
+                                   `(with-open-file (_ ,init-file-path
                                                        :direction :output
                                                        :if-exists nil
                                                        :if-does-not-exist :create)

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -36,13 +36,13 @@ similar programming language.")
          ", and the parent folders if necessary. You can also press the button
 below to create said file, if it's not created yet.")
      (let ((init-file-path (expand-path *init-file-path*)))
+       (ensure-directories-exist init-file-path)
        (:p (if (uiop:file-exists-p init-file-path)
                (:a :class "button"
                    :href (lisp-url `(echo "Init file exists"))
                    "Init file exists")
                (:a :class "button"
-                   :href (lisp-url `(ensure-directories-exist ,init-file-path)
-                                   `(with-open-file (_ ,init-file-path
+                   :href (lisp-url `(with-open-file (_ ,init-file-path
                                                        :direction :output
                                                        :if-exists nil
                                                        :if-does-not-exist :create)

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -11,27 +11,27 @@
 of Nyxt."))
    (tutorial-content)
    (spinneret:with-html-string (:h2 "Configuration")
-     (:p "Nyxt is written in the Common Lisp programming language which offers a
+    (:p "Nyxt is written in the Common Lisp programming language which offers a
 great perk: everything in the browser can be customized by the user, even while
 it's running!")
-     (:p "To get started with Common Lisp, we recommend checking out
+    (:p "To get started with Common Lisp, we recommend checking out
     our web page: "
-         (:a :href "https://nyxt.atlas.engineer/learn-lisp" "Learn Lisp")
-         ". It contains numerous pointers to other resources, including
+        (:a :href "https://nyxt.atlas.engineer/learn-lisp" "Learn Lisp")
+        ". It contains numerous pointers to other resources, including
         free books both for beginners and seasoned programmers.")
-     (:p "Nyxt provides a mechanism for new users unfamiliar with Lisp to
+    (:p "Nyxt provides a mechanism for new users unfamiliar with Lisp to
 customize Nyxt. Start by invoking the commands " (:code "describe-class") "
 or " (:code "describe-slot") ".  You can press the button marked 'Configure' to
 change the value of a setting. The settings will be applied immediately and
 saved for future sessions. Please note that these settings will not alter
 existing object instances.")
-     (:p "Settings created by Nyxt are stored in "
-         (:code (expand-path *auto-config-file-path*)) ".")
-     (:p "Any settings can be overridden manually by "
-         (:code (expand-path *init-file-path*)) ".")
-     (:p "The following section assumes knowledge of basic Common Lisp or a
+    (:p "Settings created by Nyxt are stored in "
+        (:code (expand-path *auto-config-file-path*)) ".")
+    (:p "Any settings can be overridden manually by "
+        (:code (expand-path *init-file-path*)) ".")
+    (:p "The following section assumes knowledge of basic Common Lisp or a
 similar programming language.")
-     (:p "The user needs to manually create the Nyxt configuration file "
+    (:p "The user needs to manually create the Nyxt configuration file "
          (:code (expand-path *init-file-path*))
          ", and the parent folders if necessary. You can also press the button
 below to create said file, if it's not created yet.")
@@ -48,62 +48,62 @@ below to create said file, if it's not created yet.")
                                       (echo "Init file created at ~a."
                                             ,init-file-path)))
                    "Create init file"))))
-     (:p "Example:")
-     (:pre (:code "
+    (:p "Example:")
+    (:pre (:code "
 \(define-configuration buffer
   ((default-modes (append '(no-script-mode) %slot-default%))))"))
-     (:p "The above turns on the 'no-script-mode' (disables JavaScript) by default for
+    (:p "The above turns on the 'no-script-mode' (disables JavaScript) by default for
 every buffer.")
-     (:p "The " (:code "define-configuration") " macro can be used to customize
+    (:p "The " (:code "define-configuration") " macro can be used to customize
 the slots of classes like the browser, buffers, windows, etc.  Refer to the
 class and slot documentation for the individual details.")
-     (:p "To find out about all modes known to Nyxt,
+    (:p "To find out about all modes known to Nyxt,
 run " (:code "describe-command") " and type 'mode'.")
 
-     (:h3 "Slot configuration")
-     (:p "Slots store values that can be either accessed (get) or changed
+    (:h3 "Slot configuration")
+    (:p "Slots store values that can be either accessed (get) or changed
 (set). Setting new values for slots allows many possibilities of customization.
 For instance, keyboard layouts vary across the world. The slot " (:code
-                                                                  "hints-alphabet") " has the default value of " (:code
-                                                                  "ABCDEFGHIJKLMNOPQRSTUVWXYZ" ) ". If the user has an American keyboard, they can
+"hints-alphabet") " has the default value of " (:code
+"ABCDEFGHIJKLMNOPQRSTUVWXYZ" ) ". If the user has an American keyboard, they can
 do:")
-     (:ol
-      (:li "Execute command " (command-markup 'describe-slot) ";")
-      (:li "Type " (:code 'hints-alphabet)";")
-      (:li "Select " (:code "hints-alphabet") " (" (:code "user-web-mode") " class option);")
-      (:li "Press the button " (:code "Configure") ", and;")
-      (:li "Insert the string \"asfdghjkl\"") ".")
-     (:p "This will make link-hinting more comfortable for this user. In
+    (:ol
+     (:li "Execute command " (command-markup 'describe-slot) ";")
+     (:li "Type " (:code 'hints-alphabet)";")
+     (:li "Select " (:code "hints-alphabet") " (" (:code "user-web-mode") " class option);")
+     (:li "Press the button " (:code "Configure") ", and;")
+     (:li "Insert the string \"asfdghjkl\"") ".")
+    (:p "This will make link-hinting more comfortable for this user. In
 addition, other similar approaches of customization can be applied to slots
 such as " (:code "spell-check-language") ", which can be expanded to do the
 spelling-check of other languages besides English.")
-     (:h3 "Web buffers and internal buffers")
-     (:p "A `internal-buffer' is used for Nyxt-specific, internal pages such as the
+    (:h3 "Web buffers and internal buffers")
+    (:p "A `internal-buffer' is used for Nyxt-specific, internal pages such as the
 tutorial and the description pages.  A `web-buffer' is used for web pages.  Both
 the `web-buffer' and the `internal-buffer' classes inherit from the `buffer'
 class.")
-     (:p "You can configure a `buffer' slot and it will cascade down as a new
+    (:p "You can configure a `buffer' slot and it will cascade down as a new
 default for both the `internal-buffer' and `web-buffer' classes- unless this slot
 is specialized by these child classes.")
 
-     (:h3 "Keybinding configuration")
-     (:p "Nyxt supports multiple " (:i "bindings schemes") " such as CUA (the
+    (:h3 "Keybinding configuration")
+    (:p "Nyxt supports multiple " (:i "bindings schemes") " such as CUA (the
     default), Emacs or vi.  Changing scheme is as simple as running the
     corresponding mode, e.g. "
-         (:code "emacs-mode") ".  To make the change persistent across sessions,
+        (:code "emacs-mode") ".  To make the change persistent across sessions,
 add the following to your configuration:")
-     (:ul
-      (:li "vi bindings:"
-           (:pre (:code "
+    (:ul
+     (:li "vi bindings:"
+      (:pre (:code "
 \(define-configuration buffer
   ((default-modes (append '(vi-normal-mode) %slot-default%))))")))
-      (:li "Emacs bindings:"
-           (:pre (:code "
+     (:li "Emacs bindings:"
+      (:pre (:code "
 \(define-configuration buffer
   ((default-modes (append '(emacs-mode) %slot-default%))))"))))
-     (:p "You can create new scheme names with " (:code "keymap:make-scheme-name")
-         ".  Also see the " (:code "scheme-name") " class and the "
-         (:code "define-scheme") " macro.")
+    (:p "You can create new scheme names with " (:code "keymap:make-scheme-name")
+        ".  Also see the " (:code "scheme-name") " class and the "
+        (:code "define-scheme") " macro.")
      (:p "To extend the bindings of a specific mode, you can extend the mode with "
          (:code "define-configuration") " and extend its binding scheme with "
          (:code "define-scheme") ". For example:")
@@ -117,22 +117,22 @@ add the following to your configuration:")
      (:p "The " (:code "override-map") " is a keymap that has priority over
 all other keymaps.  By default, it has few bindings like the one
 for " (:code "execute-command") ".  You can use it to set keys globally:")
-     (:pre (:code "
+    (:pre (:code "
 \(define-configuration buffer
   ((override-map (let ((map (make-keymap \"override-map\")))
                    (define-key map
                      \"M-x\" 'execute-command
                      \"C-space\" 'nothing)))))"))
-     (:p "The " (:code "nothing") " command is useful to override bindings to do
+    (:p "The " (:code "nothing") " command is useful to override bindings to do
 nothing. Note that it's possible to bind any command, including those of
 disabled modes that are not listed in " (:code "execute-command") ".")
-     (:p "In addition, a more flexible approach is to create your own mode with
+    (:p "In addition, a more flexible approach is to create your own mode with
 your custom keybindings.  When this mode is added first to the buffer mode list,
 its keybindings have priorities over the other modes.
 Note that this kind of global keymaps also have priority over regular character
 insertion, so you should probably not bind anything without modifiers in such a
 keymap.")
-     (:pre (:code "
+    (:pre (:code "
 \(defvar *my-keymap* (make-keymap \"my-map\"))
 \(define-key *my-keymap*
   \"C-f\" 'nyxt/web-mode:history-forwards
@@ -148,27 +148,27 @@ keymap.")
 \(define-configuration (buffer web-buffer)
   ((default-modes (append '(my-mode) %slot-default%))))"))
 
-     (:p "Bindings are subject to various translations as per "
+    (:p "Bindings are subject to various translations as per "
          (:code "keymap:*translator*") ". "
          "By default if it fails to find a binding it tries again with inverted
 shifts.  For instance if " (:code "C-x C-F") " fails to match anything " (:code "C-x C-f")
-         " is tried."
-         "See the default value of " (:code "keymap:*translator*") " to learn how to
+" is tried."
+"See the default value of " (:code "keymap:*translator*") " to learn how to
          custsomize it or set it to " (:code "nil") " to disable all forms of
          translation.")
 
-     (:h3 "Search engines")
-     (:p "See the " (:code "search-engines") " buffer slot documentation.
+    (:h3 "Search engines")
+    (:p "See the " (:code "search-engines") " buffer slot documentation.
 Bookmarks can also be used as search engines, see the corresponding section.")
-     (:p "Nyxt comes with some default search engines for "
-         (:code (format nil "~{~a~^, ~}"
-                        (mapcar (lambda (engine)
-                                  (quri:uri-host (quri:uri (getf engine :search-url))))
-                                (rest (getf (mopu:slot-properties 'buffer 'search-engines)
-                                            :initform)))))
-         ". "
-         "The following example shows one way to add new search engines.")
-     (:pre (:code "
+    (:p "Nyxt comes with some default search engines for "
+        (:code (format nil "~{~a~^, ~}"
+                       (mapcar (lambda (engine)
+                                 (quri:uri-host (quri:uri (getf engine :search-url))))
+                               (rest (getf (mopu:slot-properties 'buffer 'search-engines)
+                                           :initform)))))
+        ". "
+        "The following example shows one way to add new search engines.")
+    (:pre (:code "
 \(defvar *my-search-engines*
   (list
    '(\"python3\" \"https://docs.python.org/3/search.html?q=~a\" \"https://docs.python.org/3\")\
@@ -179,10 +179,10 @@ Bookmarks can also be used as search engines, see the corresponding section.")
   ((search-engines (append (mapcar (lambda (engine) (apply 'make-search-engine engine))
                                    *my-search-engines*)
                            %slot-default%))))"))
-     (:p "Note that the last search engine is the default one. For example, in
+    (:p "Note that the last search engine is the default one. For example, in
 order to make python3 the default, the above code can be slightly modified as
 follows.")
-     (:pre (:code "
+        (:pre (:code "
 \(defvar *my-search-engines*
   (list
    '(\"doi\" \"https://dx.doi.org/~a\" \"https://dx.doi.org/\")
@@ -193,57 +193,57 @@ follows.")
                            (mapcar (lambda (engine) (apply 'make-search-engine engine))
                                    *my-search-engines*)))))"))
 
-     (:h3 "URL-dispatchers")
-     (:p "You can configure which actions to take depending on the URL to be
+    (:h3 "URL-dispatchers")
+    (:p "You can configure which actions to take depending on the URL to be
 loaded.  For instance, you can configure which Torrent program to start to load
 magnet links.  See the" (:code "url-dispatching-handler") " function
 documentation.")
 
-     (:h3 "Downloads")
-     (:p "See the " (:code "list-downloads") " command and the "
-         (:code "download-path") " buffer slot documentation.")
+    (:h3 "Downloads")
+    (:p "See the " (:code "list-downloads") " command and the "
+        (:code "download-path") " buffer slot documentation.")
 
-     (:h3 "Proxy and Tor")
-     (:p "See the " (:code "proxy-mode") " documentation.")
+    (:h3 "Proxy and Tor")
+    (:p "See the " (:code "proxy-mode") " documentation.")
 
-     (:h3 "Custom commands")
-     (:p "Creating your own invokable commands is similar to creating a Common
+    (:h3 "Custom commands")
+    (:p "Creating your own invokable commands is similar to creating a Common
 Lisp function, except the form is " (:code "define-command") " instead of "
-(:code "defun") ". If you want this command to be invokable outside of
+        (:code "defun") ". If you want this command to be invokable outside of
         the context of a mode, use " (:code "define-command-global") ".")
-     (:p "Example:")
-     (:pre (:code
-            "(define-command-global bookmark-url ()
+    (:p "Example:")
+    (:pre (:code
+           "(define-command-global bookmark-url ()
   \"Query the user which URL to bookmark.\"
   (let ((url (prompt
               :prompt \"Bookmark URL\"
               :sources (make-instance 'prompter:raw-source))))
     (bookmark-add url)))"))
-     (:p "See the " (:code "prompt-buffer") " class documentation for how to write
+    (:p "See the " (:code "prompt-buffer") " class documentation for how to write
 write custom prompt-buffers.")
 
-     (:h3 "Hooks")
-     (:p "Hooks provide a powerful mechanism to tweak the behaviour of various
+    (:h3 "Hooks")
+    (:p "Hooks provide a powerful mechanism to tweak the behaviour of various
 events that occur in the context of windows, buffers, modes, etc.")
-     (:p "A hook holds a list of " (:i "handlers") ".  Handlers are named and
+    (:p "A hook holds a list of " (:i "handlers") ".  Handlers are named and
 typed functions.  Each hook has a dedicated handler constructor.")
-     (:p
-      "Hooks can be 'run', that is, their handlers are run according to
+    (:p
+     "Hooks can be 'run', that is, their handlers are run according to
 the " (:code "combination") " slot of the hook.  This combination is a function
 of the handlers.  Depending on the combination, a hook can run the handlers
 either in parallel, or in order until one fails, or even " (:i "compose")
-      " them (pass the result of one as the input of the next).  The handler types
+     " them (pass the result of one as the input of the next).  The handler types
 specify which input and output values are expected.")
-     (:p "Many hooks are executed at different points in Nyxt, among others:
+    (:p "Many hooks are executed at different points in Nyxt, among others:
 ")
-     (:ul
-      (:li "Global hooks, such as " (:code "*after-init-hook*") ".")
-      (:li "Window- or buffer-related hooks.")
-      (:li "Commands 'before' and 'after' hooks.")
-      (:li "Modes 'enable' and 'disable' hooks."))
-     (:p "For instance, if you want to force 'old.reddit.com' over 'www.reddit.com', you
+    (:ul
+     (:li "Global hooks, such as " (:code "*after-init-hook*") ".")
+     (:li "Window- or buffer-related hooks.")
+     (:li "Commands 'before' and 'after' hooks.")
+     (:li "Modes 'enable' and 'disable' hooks."))
+    (:p "For instance, if you want to force 'old.reddit.com' over 'www.reddit.com', you
 can set a hook like the following in your configuration file:")
-     (:pre (:code "
+    (:pre (:code "
 \(defun old-reddit-handler (request-data)
   (let ((url (url request-data)))
     (setf (url request-data)
@@ -258,48 +258,48 @@ can set a hook like the following in your configuration file:")
 \(define-configuration web-buffer
   ((request-resource-hook
     (hooks:add-hook %slot-default% (make-handler-resource #'old-reddit-handler)))))"))
-     (:p "(See " (:code "url-dispatching-handler")
-         " for a simpler way to achieve the same result.)")
-     (:p "Or, if you want to set multiple handlers at once,")
-     (:pre (:code "
+    (:p "(See " (:code "url-dispatching-handler")
+        " for a simpler way to achieve the same result.)")
+    (:p "Or, if you want to set multiple handlers at once,")
+    (:pre (:code "
 \(define-configuration web-buffer
   ((request-resource-hook
     (reduce #'hooks:add-hook
             (mapcar #'make-handler-resource (list #'old-reddit-handler
                                                   #'my-other-handler))
             :initial-value %slot-default%))))"))
-     (:p "Some hooks like the above example expect a return value, so it's
+    (:p "Some hooks like the above example expect a return value, so it's
 important to make sure we return " (:code "request-data") " here.  See the
 documentation of the respective hooks for more details.")
 
-     (:h3 "Data paths and data profiles")
-     (:p "Nyxt provides a uniform configuration interface for all data files
+    (:h3 "Data paths and data profiles")
+    (:p "Nyxt provides a uniform configuration interface for all data files
 persisted to disk (bookmarks, cookies, etc.).  To each file corresponds
 a " (:code "data-path") " object. A " (:code "data-profile") " is a unique but
 customizable object that helps define general rules for data storage.  Both
 data-paths and data-profiles compose, so it's possible to define general rules
 for all data-paths (even for those not known in advance) while it's also
 possible to specialize some data-paths given a data-profile.")
-     (:p "The data-profile can be set from command line and from the configuration file."
-         "You can list all known data profiles (including the user-defined
+    (:p "The data-profile can be set from command line and from the configuration file."
+        "You can list all known data profiles (including the user-defined
         profiles) with the " (:code "--list-data-profiles") " command-line option.")
-     (:p "The data-paths can be passed a hint from the "
-         (:code "--with-path") " command line option, but each data-path and
+    (:p "The data-paths can be passed a hint from the "
+        (:code "--with-path") " command line option, but each data-path and
 data-profile rules are free to ignore it. The " (:code "expand-default-path") "
 helper function uses the --with-path value first, then fallback to a default.
 See its documentation for more details.")
-     (:p "When the data path ends with the " (:code ".gpg") " extension, your
+    (:p "When the data path ends with the " (:code ".gpg") " extension, your
 GnuPG key is used to decrypt and encrypt the file transparently.  Refer to the
 GnuPG documentation for how to set it up.")
-     (:p "Note that the socket and the initialization data-paths cannot be set in
+    (:p "Note that the socket and the initialization data-paths cannot be set in
 your configuration (the socket is used before the initialization file is
 loaded).  Instead you can specify these paths from their respective command-line
 option.  You can instantiate a unique, separate Nyxt instance when you provide a
 new socket path.  This is particularly useful in combination with data profiles,
 e.g. to develop Nyxt or extensions.")
-     (:p "Example to create a development data-profile that stores all data in "
-         (:code "/tmp/nyxt") " and stores bookmark in an encrypted file:")
-     (:pre (:code "
+    (:p "Example to create a development data-profile that stores all data in "
+        (:code "/tmp/nyxt") " and stores bookmark in an encrypted file:")
+    (:pre (:code "
 \(define-class dev-data-profile (data-profile)
    ((name :initform \"dev\"))
    (:documentation \"Development profile.\"))
@@ -320,106 +320,106 @@ e.g. to develop Nyxt or extensions.")
                                     'dev-data-profile)))
    (bookmarks-path (make-instance 'bookmarks-data-path
                                   :basename \"~/personal/bookmarks/bookmarks.lisp.gpg\"))))"))
-     (:p "Then you can start a separate instance of Nyxt using this profile
+    (:p "Then you can start a separate instance of Nyxt using this profile
 with " (:code "nyxt --data-profile dev --socket /tmp/nyxt.socket") ".")
 
-     (:h3 "Password management")
-     (:p "Nyxt provides a uniform interface to some password managers including "
-         (:a :href "https://keepassxc.org/" "KeepassXC")
-         " and " (:a :href "https://www.passwordstore.org/" "Password Store") ". "
-         "The supported installed password manager is automatically detected."
-         "See the " (:code "password-interface") " buffer slot for customization.")
-     (:p "You may use the " (:code "define-configuration") " macro with
+    (:h3 "Password management")
+    (:p "Nyxt provides a uniform interface to some password managers including "
+        (:a :href "https://keepassxc.org/" "KeepassXC")
+        " and " (:a :href "https://www.passwordstore.org/" "Password Store") ". "
+        "The supported installed password manager is automatically detected."
+        "See the " (:code "password-interface") " buffer slot for customization.")
+    (:p "You may use the " (:code "define-configuration") " macro with
 any of the password interfaces to configure them. Please make sure to
 use the package prefixed class name/slot designators within
 the " (:code "define-configuration") " macro.")
-     (:ul
-      (:li (command-markup 'save-new-password) ": Query for name and new password to persist in the database.")
-      (:li (command-markup 'copy-password) ": " (command-docstring-first-sentence 'copy-password)))
+    (:ul
+     (:li (command-markup 'save-new-password) ": Query for name and new password to persist in the database.")
+     (:li (command-markup 'copy-password) ": " (command-docstring-first-sentence 'copy-password)))
 
-     (:h3 "Appearance")
-     (:p "Much of the visual style can be configured by the user.  Search the
+    (:h3 "Appearance")
+    (:p "Much of the visual style can be configured by the user.  Search the
 class slots for 'style'.  To customize the status area, see
 the " (:code "status-formatter") " window slot.")
 
-     (:h3 "Scripting")
-     (:p "You can evaluate code from the command line with "
-         (:code "--eval") " and " (:code "--load") ".  From a shell:")
-     (:pre (:code "$ nyxt --no-init --eval '+version+' \
+    (:h3 "Scripting")
+    (:p "You can evaluate code from the command line with "
+        (:code "--eval") " and " (:code "--load") ".  From a shell:")
+    (:pre (:code "$ nyxt --no-init --eval '+version+' \
   --load my-lib.lisp --eval '(format t \"Hello ~a!~&\" (my-lib:my-world))'"))
-     (:p "You can evaluate multiple --eval and --load in a row, they are
+    (:p "You can evaluate multiple --eval and --load in a row, they are
 executed in the order they appear.")
-     (:p "You can also evaluate a Lisp file from the Nyxt interface with
+    (:p "You can also evaluate a Lisp file from the Nyxt interface with
 the " (:code "load-file") " command.  For
 convenience, " (:code "load-init-file") " (re)loads your initialization file.")
-     (:p "You can even make scripts.  Here is an example foo.lisp:")
-     (:pre (:code "#!nyxt --script
+    (:p "You can even make scripts.  Here is an example foo.lisp:")
+    (:pre (:code "#!nyxt --script
 \(format t \"~a~&\" +version+)"))
-     (:p "--eval and --load can be commanded to operate over an
+    (:p "--eval and --load can be commanded to operate over an
 existing instance instead of a separate instance that exits immediately.")
-     (:p "The `remote-execution-p' slot of the `browser' class of the remote
+    (:p "The `remote-execution-p' slot of the `browser' class of the remote
 instance must be non-nil.")
-     (:p "To let know a private instance of Nyxt to load a foo.lisp script and run its
+    (:p "To let know a private instance of Nyxt to load a foo.lisp script and run its
 `foo' function:")
-     (:pre (:code "nyxt --data-profile nosave --remote --load foo.lisp --eval '(foo)'"))
+    (:pre (:code "nyxt --data-profile nosave --remote --load foo.lisp --eval '(foo)'"))
 
-     (:h2 "Extensions")
-     (:p "To install an extension, copy inside the "
-         (:code "*extensions-path*") " (default to "
-         (:code "~/.local/share/nyxt/extensions")").")
-     (:p "Extensions are regular Common Lisp systems.")
-     (:p "A catalogue of extensions is available in the "
-         (:code "document/EXTENSIONS.org") " file in the source repository.")
+    (:h2 "Extensions")
+    (:p "To install an extension, copy inside the "
+        (:code "*extensions-path*") " (default to "
+        (:code "~/.local/share/nyxt/extensions")").")
+    (:p "Extensions are regular Common Lisp systems.")
+    (:p "A catalogue of extensions is available in the "
+        (:code "document/EXTENSIONS.org") " file in the source repository.")
 
-     (:h2 "Troubleshooting")
-     (:h3 "Playing videos")
-     (:p "Nyxt delegates video support to third-party plugins.")
-     (:p "When using the WebKitGTK backends, GStreamer and its plugins are
+    (:h2 "Troubleshooting")
+    (:h3 "Playing videos")
+    (:p "Nyxt delegates video support to third-party plugins.")
+    (:p "When using the WebKitGTK backends, GStreamer and its plugins are
 leveraged.  Depending on the video, you will need to install some of the
 following packages:")
-     (:ul
-      (:li "gst-libav")
-      (:li "gst-plugins-bad")
-      (:li "gst-plugins-base")
-      (:li "gst-plugins-good")
-      (:li "gst-plugins-ugly"))
-     (:p "On Debian-based systems, you might be looking for (adapt the version numbers):")
-     (:ul
-      (:li "libgstreamer1.0-0")
-      (:li "gir1.2-gst-plugins-base-1.0"))
-     (:p "For systems from the Fedora family:")
-     (:ul
-      (:li "gstreamer1-devel")
-      (:li "gstreamer1-plugins-base-devel"))
-     (:p "After the desired plugins have been installed, clear the GStreamer cache at "
-         (:code "~/.cache/gstreamer-1.0") " and restart Nyxt.")
-     (:h3 "Input method support (CJK, etc.)")
-     (:p "Depending on your setup, you might have to set some environment
+    (:ul
+     (:li "gst-libav")
+     (:li "gst-plugins-bad")
+     (:li "gst-plugins-base")
+     (:li "gst-plugins-good")
+     (:li "gst-plugins-ugly"))
+    (:p "On Debian-based systems, you might be looking for (adapt the version numbers):")
+    (:ul
+     (:li "libgstreamer1.0-0")
+     (:li "gir1.2-gst-plugins-base-1.0"))
+    (:p "For systems from the Fedora family:")
+    (:ul
+     (:li "gstreamer1-devel")
+     (:li "gstreamer1-plugins-base-devel"))
+    (:p "After the desired plugins have been installed, clear the GStreamer cache at "
+        (:code "~/.cache/gstreamer-1.0") " and restart Nyxt.")
+    (:h3 "Input method support (CJK, etc.)")
+    (:p "Depending on your setup, you might have to set some environment
 variables or run some commands before starting Nyxt, for instance")
-     (:pre (:code "
+    (:pre (:code "
 GTK_IM_MODULE=xim
 XMODIFIERS=@im=ibus
 ibus --daemonize --replace --xim"))
-     (:p "You can persist this change by saving the commands in
+    (:p "You can persist this change by saving the commands in
 your " (:code ".xprofile") " or similar.")
-     (:h3 "Font size on HiDPI displays")
-     (:p "On HiDPI displays, the font size used for displaying web and Nyxt's
+    (:h3 "Font size on HiDPI displays")
+    (:p "On HiDPI displays, the font size used for displaying web and Nyxt's
 prompt-buffer content might be too tiny.")
-     (:p "To fix this issue when using the WebKitGTK render, export the following
+    (:p "To fix this issue when using the WebKitGTK render, export the following
 environment variable before starting Nyxt:")
-     (:pre (:code "
+    (:pre (:code "
 export GDK_SCALE=2
 export GDK_DPI_SCALE=0.5
 nyxt
 "))
-     (:h3 "StumpWM mouse scroll")
-     (:p "If the mouse scroll does not work for you, see the "
-         (:a
-          :href "https://github.com/stumpwm/stumpwm/wiki/FAQ#my-mouse-wheel-doesnt-work-with-gtk3-applications-add-the-following-to"
-          "StumpWM FAQ")
-         " for a fix.")
-     (:h3 "Blank WebKit web-views")
-     (:p "If you are experiencing problems with blank web-views on some sites you
+    (:h3 "StumpWM mouse scroll")
+    (:p "If the mouse scroll does not work for you, see the "
+        (:a
+         :href "https://github.com/stumpwm/stumpwm/wiki/FAQ#my-mouse-wheel-doesnt-work-with-gtk3-applications-add-the-following-to"
+         "StumpWM FAQ")
+        " for a fix.")
+    (:h3 "Blank WebKit web-views")
+    (:p "If you are experiencing problems with blank web-views on some sites you
     can try to disable compositing. To disable compositing from your
     initialization file, you can do the following: ")
-     (:code "(setf (uiop:getenv \"WEBKIT_DISABLE_COMPOSITING_MODE\") \"1\")"))))
+    (:code "(setf (uiop:getenv \"WEBKIT_DISABLE_COMPOSITING_MODE\") \"1\")"))))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -11,85 +11,85 @@
 of Nyxt."))
    (tutorial-content)
    (spinneret:with-html-string (:h2 "Configuration")
-    (:p "Nyxt is written in the Common Lisp programming language which offers a
+     (:p "Nyxt is written in the Common Lisp programming language which offers a
 great perk: everything in the browser can be customized by the user, even while
 it's running!")
-    (:p "To get started with Common Lisp, we recommend checking out
+     (:p "To get started with Common Lisp, we recommend checking out
     our web page: "
-        (:a :href "https://nyxt.atlas.engineer/learn-lisp" "Learn Lisp")
-        ". It contains numerous pointers to other resources, including
+         (:a :href "https://nyxt.atlas.engineer/learn-lisp" "Learn Lisp")
+         ". It contains numerous pointers to other resources, including
         free books both for beginners and seasoned programmers.")
-    (:p "Nyxt provides a mechanism for new users unfamiliar with Lisp to
+     (:p "Nyxt provides a mechanism for new users unfamiliar with Lisp to
 customize Nyxt. Start by invoking the commands " (:code "describe-class") "
 or " (:code "describe-slot") ".  You can press the button marked 'Configure' to
 change the value of a setting. The settings will be applied immediately and
 saved for future sessions. Please note that these settings will not alter
 existing object instances.")
-    (:p "Settings created by Nyxt are stored in "
-        (:code (expand-path *auto-config-file-path*)) ".")
-    (:p "Any settings can be overridden manually by "
-        (:code (expand-path *init-file-path*)) ".")
-    (:p "The following section assumes knowledge of basic Common Lisp or a
+     (:p "Settings created by Nyxt are stored in "
+         (:code (expand-path *auto-config-file-path*)) ".")
+     (:p "Any settings can be overridden manually by "
+         (:code (expand-path *init-file-path*)) ".")
+     (:p "The following section assumes knowledge of basic Common Lisp or a
 similar programming language.")
-    (:p "Nyxt configuration can be persisted in the user
-file " (:code (expand-path *init-file-path*)) " (create the parent folders if
-necessary).")
-    (:p "Example:")
-    (:pre (:code "
+     (:p "The user needs to manually create the Nyxt configuration file "
+         (:code (expand-path *init-file-path*))
+         ", and the parent folders if necessary.")
+     (:p "Example:")
+     (:pre (:code "
 \(define-configuration buffer
   ((default-modes (append '(no-script-mode) %slot-default%))))"))
-    (:p "The above turns on the 'no-script-mode' (disables JavaScript) by default for
+     (:p "The above turns on the 'no-script-mode' (disables JavaScript) by default for
 every buffer.")
-    (:p "The " (:code "define-configuration") " macro can be used to customize
+     (:p "The " (:code "define-configuration") " macro can be used to customize
 the slots of classes like the browser, buffers, windows, etc.  Refer to the
 class and slot documentation for the individual details.")
-    (:p "To find out about all modes known to Nyxt,
+     (:p "To find out about all modes known to Nyxt,
 run " (:code "describe-command") " and type 'mode'.")
 
-    (:h3 "Slot configuration")
-    (:p "Slots store values that can be either accessed (get) or changed
+     (:h3 "Slot configuration")
+     (:p "Slots store values that can be either accessed (get) or changed
 (set). Setting new values for slots allows many possibilities of customization.
 For instance, keyboard layouts vary across the world. The slot " (:code
-"hints-alphabet") " has the default value of " (:code
-"ABCDEFGHIJKLMNOPQRSTUVWXYZ" ) ". If the user has an American keyboard, they can
+                                                                  "hints-alphabet") " has the default value of " (:code
+                                                                  "ABCDEFGHIJKLMNOPQRSTUVWXYZ" ) ". If the user has an American keyboard, they can
 do:")
-    (:ol
-     (:li "Execute command " (command-markup 'describe-slot) ";")
-     (:li "Type " (:code 'hints-alphabet)";")
-     (:li "Select " (:code "hints-alphabet") " (" (:code "user-web-mode") " class option);")
-     (:li "Press the button " (:code "Configure") ", and;")
-     (:li "Insert the string \"asfdghjkl\"") ".")
-    (:p "This will make link-hinting more comfortable for this user. In
+     (:ol
+      (:li "Execute command " (command-markup 'describe-slot) ";")
+      (:li "Type " (:code 'hints-alphabet)";")
+      (:li "Select " (:code "hints-alphabet") " (" (:code "user-web-mode") " class option);")
+      (:li "Press the button " (:code "Configure") ", and;")
+      (:li "Insert the string \"asfdghjkl\"") ".")
+     (:p "This will make link-hinting more comfortable for this user. In
 addition, other similar approaches of customization can be applied to slots
 such as " (:code "spell-check-language") ", which can be expanded to do the
 spelling-check of other languages besides English.")
-    (:h3 "Web buffers and internal buffers")
-    (:p "A `internal-buffer' is used for Nyxt-specific, internal pages such as the
+     (:h3 "Web buffers and internal buffers")
+     (:p "A `internal-buffer' is used for Nyxt-specific, internal pages such as the
 tutorial and the description pages.  A `web-buffer' is used for web pages.  Both
 the `web-buffer' and the `internal-buffer' classes inherit from the `buffer'
 class.")
-    (:p "You can configure a `buffer' slot and it will cascade down as a new
+     (:p "You can configure a `buffer' slot and it will cascade down as a new
 default for both the `internal-buffer' and `web-buffer' classes- unless this slot
 is specialized by these child classes.")
 
-    (:h3 "Keybinding configuration")
-    (:p "Nyxt supports multiple " (:i "bindings schemes") " such as CUA (the
+     (:h3 "Keybinding configuration")
+     (:p "Nyxt supports multiple " (:i "bindings schemes") " such as CUA (the
     default), Emacs or vi.  Changing scheme is as simple as running the
     corresponding mode, e.g. "
-        (:code "emacs-mode") ".  To make the change persistent across sessions,
+         (:code "emacs-mode") ".  To make the change persistent across sessions,
 add the following to your configuration:")
-    (:ul
-     (:li "vi bindings:"
-      (:pre (:code "
+     (:ul
+      (:li "vi bindings:"
+           (:pre (:code "
 \(define-configuration buffer
   ((default-modes (append '(vi-normal-mode) %slot-default%))))")))
-     (:li "Emacs bindings:"
-      (:pre (:code "
+      (:li "Emacs bindings:"
+           (:pre (:code "
 \(define-configuration buffer
   ((default-modes (append '(emacs-mode) %slot-default%))))"))))
-    (:p "You can create new scheme names with " (:code "keymap:make-scheme-name")
-        ".  Also see the " (:code "scheme-name") " class and the "
-        (:code "define-scheme") " macro.")
+     (:p "You can create new scheme names with " (:code "keymap:make-scheme-name")
+         ".  Also see the " (:code "scheme-name") " class and the "
+         (:code "define-scheme") " macro.")
      (:p "To extend the bindings of a specific mode, you can extend the mode with "
          (:code "define-configuration") " and extend its binding scheme with "
          (:code "define-scheme") ". For example:")
@@ -103,22 +103,22 @@ add the following to your configuration:")
      (:p "The " (:code "override-map") " is a keymap that has priority over
 all other keymaps.  By default, it has few bindings like the one
 for " (:code "execute-command") ".  You can use it to set keys globally:")
-    (:pre (:code "
+     (:pre (:code "
 \(define-configuration buffer
   ((override-map (let ((map (make-keymap \"override-map\")))
                    (define-key map
                      \"M-x\" 'execute-command
                      \"C-space\" 'nothing)))))"))
-    (:p "The " (:code "nothing") " command is useful to override bindings to do
+     (:p "The " (:code "nothing") " command is useful to override bindings to do
 nothing. Note that it's possible to bind any command, including those of
 disabled modes that are not listed in " (:code "execute-command") ".")
-    (:p "In addition, a more flexible approach is to create your own mode with
+     (:p "In addition, a more flexible approach is to create your own mode with
 your custom keybindings.  When this mode is added first to the buffer mode list,
 its keybindings have priorities over the other modes.
 Note that this kind of global keymaps also have priority over regular character
 insertion, so you should probably not bind anything without modifiers in such a
 keymap.")
-    (:pre (:code "
+     (:pre (:code "
 \(defvar *my-keymap* (make-keymap \"my-map\"))
 \(define-key *my-keymap*
   \"C-f\" 'nyxt/web-mode:history-forwards
@@ -134,27 +134,27 @@ keymap.")
 \(define-configuration (buffer web-buffer)
   ((default-modes (append '(my-mode) %slot-default%))))"))
 
-    (:p "Bindings are subject to various translations as per "
+     (:p "Bindings are subject to various translations as per "
          (:code "keymap:*translator*") ". "
          "By default if it fails to find a binding it tries again with inverted
 shifts.  For instance if " (:code "C-x C-F") " fails to match anything " (:code "C-x C-f")
-" is tried."
-"See the default value of " (:code "keymap:*translator*") " to learn how to
+         " is tried."
+         "See the default value of " (:code "keymap:*translator*") " to learn how to
          custsomize it or set it to " (:code "nil") " to disable all forms of
          translation.")
 
-    (:h3 "Search engines")
-    (:p "See the " (:code "search-engines") " buffer slot documentation.
+     (:h3 "Search engines")
+     (:p "See the " (:code "search-engines") " buffer slot documentation.
 Bookmarks can also be used as search engines, see the corresponding section.")
-    (:p "Nyxt comes with some default search engines for "
-        (:code (format nil "~{~a~^, ~}"
-                       (mapcar (lambda (engine)
-                                 (quri:uri-host (quri:uri (getf engine :search-url))))
-                               (rest (getf (mopu:slot-properties 'buffer 'search-engines)
-                                           :initform)))))
-        ". "
-        "The following example shows one way to add new search engines.")
-    (:pre (:code "
+     (:p "Nyxt comes with some default search engines for "
+         (:code (format nil "~{~a~^, ~}"
+                        (mapcar (lambda (engine)
+                                  (quri:uri-host (quri:uri (getf engine :search-url))))
+                                (rest (getf (mopu:slot-properties 'buffer 'search-engines)
+                                            :initform)))))
+         ". "
+         "The following example shows one way to add new search engines.")
+     (:pre (:code "
 \(defvar *my-search-engines*
   (list
    '(\"python3\" \"https://docs.python.org/3/search.html?q=~a\" \"https://docs.python.org/3\")\
@@ -165,10 +165,10 @@ Bookmarks can also be used as search engines, see the corresponding section.")
   ((search-engines (append (mapcar (lambda (engine) (apply 'make-search-engine engine))
                                    *my-search-engines*)
                            %slot-default%))))"))
-    (:p "Note that the last search engine is the default one. For example, in
+     (:p "Note that the last search engine is the default one. For example, in
 order to make python3 the default, the above code can be slightly modified as
 follows.")
-        (:pre (:code "
+     (:pre (:code "
 \(defvar *my-search-engines*
   (list
    '(\"doi\" \"https://dx.doi.org/~a\" \"https://dx.doi.org/\")
@@ -179,57 +179,57 @@ follows.")
                            (mapcar (lambda (engine) (apply 'make-search-engine engine))
                                    *my-search-engines*)))))"))
 
-    (:h3 "URL-dispatchers")
-    (:p "You can configure which actions to take depending on the URL to be
+     (:h3 "URL-dispatchers")
+     (:p "You can configure which actions to take depending on the URL to be
 loaded.  For instance, you can configure which Torrent program to start to load
 magnet links.  See the" (:code "url-dispatching-handler") " function
 documentation.")
 
-    (:h3 "Downloads")
-    (:p "See the " (:code "list-downloads") " command and the "
-        (:code "download-path") " buffer slot documentation.")
+     (:h3 "Downloads")
+     (:p "See the " (:code "list-downloads") " command and the "
+         (:code "download-path") " buffer slot documentation.")
 
-    (:h3 "Proxy and Tor")
-    (:p "See the " (:code "proxy-mode") " documentation.")
+     (:h3 "Proxy and Tor")
+     (:p "See the " (:code "proxy-mode") " documentation.")
 
-    (:h3 "Custom commands")
-    (:p "Creating your own invokable commands is similar to creating a Common
+     (:h3 "Custom commands")
+     (:p "Creating your own invokable commands is similar to creating a Common
 Lisp function, except the form is " (:code "define-command") " instead of "
-        (:code "defun") ". If you want this command to be invokable outside of
+(:code "defun") ". If you want this command to be invokable outside of
         the context of a mode, use " (:code "define-command-global") ".")
-    (:p "Example:")
-    (:pre (:code
-           "(define-command-global bookmark-url ()
+     (:p "Example:")
+     (:pre (:code
+            "(define-command-global bookmark-url ()
   \"Query the user which URL to bookmark.\"
   (let ((url (prompt
               :prompt \"Bookmark URL\"
               :sources (make-instance 'prompter:raw-source))))
     (bookmark-add url)))"))
-    (:p "See the " (:code "prompt-buffer") " class documentation for how to write
+     (:p "See the " (:code "prompt-buffer") " class documentation for how to write
 write custom prompt-buffers.")
 
-    (:h3 "Hooks")
-    (:p "Hooks provide a powerful mechanism to tweak the behaviour of various
+     (:h3 "Hooks")
+     (:p "Hooks provide a powerful mechanism to tweak the behaviour of various
 events that occur in the context of windows, buffers, modes, etc.")
-    (:p "A hook holds a list of " (:i "handlers") ".  Handlers are named and
+     (:p "A hook holds a list of " (:i "handlers") ".  Handlers are named and
 typed functions.  Each hook has a dedicated handler constructor.")
-    (:p
-     "Hooks can be 'run', that is, their handlers are run according to
+     (:p
+      "Hooks can be 'run', that is, their handlers are run according to
 the " (:code "combination") " slot of the hook.  This combination is a function
 of the handlers.  Depending on the combination, a hook can run the handlers
 either in parallel, or in order until one fails, or even " (:i "compose")
-     " them (pass the result of one as the input of the next).  The handler types
+      " them (pass the result of one as the input of the next).  The handler types
 specify which input and output values are expected.")
-    (:p "Many hooks are executed at different points in Nyxt, among others:
+     (:p "Many hooks are executed at different points in Nyxt, among others:
 ")
-    (:ul
-     (:li "Global hooks, such as " (:code "*after-init-hook*") ".")
-     (:li "Window- or buffer-related hooks.")
-     (:li "Commands 'before' and 'after' hooks.")
-     (:li "Modes 'enable' and 'disable' hooks."))
-    (:p "For instance, if you want to force 'old.reddit.com' over 'www.reddit.com', you
+     (:ul
+      (:li "Global hooks, such as " (:code "*after-init-hook*") ".")
+      (:li "Window- or buffer-related hooks.")
+      (:li "Commands 'before' and 'after' hooks.")
+      (:li "Modes 'enable' and 'disable' hooks."))
+     (:p "For instance, if you want to force 'old.reddit.com' over 'www.reddit.com', you
 can set a hook like the following in your configuration file:")
-    (:pre (:code "
+     (:pre (:code "
 \(defun old-reddit-handler (request-data)
   (let ((url (url request-data)))
     (setf (url request-data)
@@ -244,48 +244,48 @@ can set a hook like the following in your configuration file:")
 \(define-configuration web-buffer
   ((request-resource-hook
     (hooks:add-hook %slot-default% (make-handler-resource #'old-reddit-handler)))))"))
-    (:p "(See " (:code "url-dispatching-handler")
-        " for a simpler way to achieve the same result.)")
-    (:p "Or, if you want to set multiple handlers at once,")
-    (:pre (:code "
+     (:p "(See " (:code "url-dispatching-handler")
+         " for a simpler way to achieve the same result.)")
+     (:p "Or, if you want to set multiple handlers at once,")
+     (:pre (:code "
 \(define-configuration web-buffer
   ((request-resource-hook
     (reduce #'hooks:add-hook
             (mapcar #'make-handler-resource (list #'old-reddit-handler
                                                   #'my-other-handler))
             :initial-value %slot-default%))))"))
-    (:p "Some hooks like the above example expect a return value, so it's
+     (:p "Some hooks like the above example expect a return value, so it's
 important to make sure we return " (:code "request-data") " here.  See the
 documentation of the respective hooks for more details.")
 
-    (:h3 "Data paths and data profiles")
-    (:p "Nyxt provides a uniform configuration interface for all data files
+     (:h3 "Data paths and data profiles")
+     (:p "Nyxt provides a uniform configuration interface for all data files
 persisted to disk (bookmarks, cookies, etc.).  To each file corresponds
 a " (:code "data-path") " object. A " (:code "data-profile") " is a unique but
 customizable object that helps define general rules for data storage.  Both
 data-paths and data-profiles compose, so it's possible to define general rules
 for all data-paths (even for those not known in advance) while it's also
 possible to specialize some data-paths given a data-profile.")
-    (:p "The data-profile can be set from command line and from the configuration file."
-        "You can list all known data profiles (including the user-defined
+     (:p "The data-profile can be set from command line and from the configuration file."
+         "You can list all known data profiles (including the user-defined
         profiles) with the " (:code "--list-data-profiles") " command-line option.")
-    (:p "The data-paths can be passed a hint from the "
-        (:code "--with-path") " command line option, but each data-path and
+     (:p "The data-paths can be passed a hint from the "
+         (:code "--with-path") " command line option, but each data-path and
 data-profile rules are free to ignore it. The " (:code "expand-default-path") "
 helper function uses the --with-path value first, then fallback to a default.
 See its documentation for more details.")
-    (:p "When the data path ends with the " (:code ".gpg") " extension, your
+     (:p "When the data path ends with the " (:code ".gpg") " extension, your
 GnuPG key is used to decrypt and encrypt the file transparently.  Refer to the
 GnuPG documentation for how to set it up.")
-    (:p "Note that the socket and the initialization data-paths cannot be set in
+     (:p "Note that the socket and the initialization data-paths cannot be set in
 your configuration (the socket is used before the initialization file is
 loaded).  Instead you can specify these paths from their respective command-line
 option.  You can instantiate a unique, separate Nyxt instance when you provide a
 new socket path.  This is particularly useful in combination with data profiles,
 e.g. to develop Nyxt or extensions.")
-    (:p "Example to create a development data-profile that stores all data in "
-        (:code "/tmp/nyxt") " and stores bookmark in an encrypted file:")
-    (:pre (:code "
+     (:p "Example to create a development data-profile that stores all data in "
+         (:code "/tmp/nyxt") " and stores bookmark in an encrypted file:")
+     (:pre (:code "
 \(define-class dev-data-profile (data-profile)
    ((name :initform \"dev\"))
    (:documentation \"Development profile.\"))
@@ -306,106 +306,106 @@ e.g. to develop Nyxt or extensions.")
                                     'dev-data-profile)))
    (bookmarks-path (make-instance 'bookmarks-data-path
                                   :basename \"~/personal/bookmarks/bookmarks.lisp.gpg\"))))"))
-    (:p "Then you can start a separate instance of Nyxt using this profile
+     (:p "Then you can start a separate instance of Nyxt using this profile
 with " (:code "nyxt --data-profile dev --socket /tmp/nyxt.socket") ".")
 
-    (:h3 "Password management")
-    (:p "Nyxt provides a uniform interface to some password managers including "
-        (:a :href "https://keepassxc.org/" "KeepassXC")
-        " and " (:a :href "https://www.passwordstore.org/" "Password Store") ". "
-        "The supported installed password manager is automatically detected."
-        "See the " (:code "password-interface") " buffer slot for customization.")
-    (:p "You may use the " (:code "define-configuration") " macro with
+     (:h3 "Password management")
+     (:p "Nyxt provides a uniform interface to some password managers including "
+         (:a :href "https://keepassxc.org/" "KeepassXC")
+         " and " (:a :href "https://www.passwordstore.org/" "Password Store") ". "
+         "The supported installed password manager is automatically detected."
+         "See the " (:code "password-interface") " buffer slot for customization.")
+     (:p "You may use the " (:code "define-configuration") " macro with
 any of the password interfaces to configure them. Please make sure to
 use the package prefixed class name/slot designators within
 the " (:code "define-configuration") " macro.")
-    (:ul
-     (:li (command-markup 'save-new-password) ": Query for name and new password to persist in the database.")
-     (:li (command-markup 'copy-password) ": " (command-docstring-first-sentence 'copy-password)))
+     (:ul
+      (:li (command-markup 'save-new-password) ": Query for name and new password to persist in the database.")
+      (:li (command-markup 'copy-password) ": " (command-docstring-first-sentence 'copy-password)))
 
-    (:h3 "Appearance")
-    (:p "Much of the visual style can be configured by the user.  Search the
+     (:h3 "Appearance")
+     (:p "Much of the visual style can be configured by the user.  Search the
 class slots for 'style'.  To customize the status area, see
 the " (:code "status-formatter") " window slot.")
 
-    (:h3 "Scripting")
-    (:p "You can evaluate code from the command line with "
-        (:code "--eval") " and " (:code "--load") ".  From a shell:")
-    (:pre (:code "$ nyxt --no-init --eval '+version+' \
+     (:h3 "Scripting")
+     (:p "You can evaluate code from the command line with "
+         (:code "--eval") " and " (:code "--load") ".  From a shell:")
+     (:pre (:code "$ nyxt --no-init --eval '+version+' \
   --load my-lib.lisp --eval '(format t \"Hello ~a!~&\" (my-lib:my-world))'"))
-    (:p "You can evaluate multiple --eval and --load in a row, they are
+     (:p "You can evaluate multiple --eval and --load in a row, they are
 executed in the order they appear.")
-    (:p "You can also evaluate a Lisp file from the Nyxt interface with
+     (:p "You can also evaluate a Lisp file from the Nyxt interface with
 the " (:code "load-file") " command.  For
 convenience, " (:code "load-init-file") " (re)loads your initialization file.")
-    (:p "You can even make scripts.  Here is an example foo.lisp:")
-    (:pre (:code "#!nyxt --script
+     (:p "You can even make scripts.  Here is an example foo.lisp:")
+     (:pre (:code "#!nyxt --script
 \(format t \"~a~&\" +version+)"))
-    (:p "--eval and --load can be commanded to operate over an
+     (:p "--eval and --load can be commanded to operate over an
 existing instance instead of a separate instance that exits immediately.")
-    (:p "The `remote-execution-p' slot of the `browser' class of the remote
+     (:p "The `remote-execution-p' slot of the `browser' class of the remote
 instance must be non-nil.")
-    (:p "To let know a private instance of Nyxt to load a foo.lisp script and run its
+     (:p "To let know a private instance of Nyxt to load a foo.lisp script and run its
 `foo' function:")
-    (:pre (:code "nyxt --data-profile nosave --remote --load foo.lisp --eval '(foo)'"))
+     (:pre (:code "nyxt --data-profile nosave --remote --load foo.lisp --eval '(foo)'"))
 
-    (:h2 "Extensions")
-    (:p "To install an extension, copy inside the "
-        (:code "*extensions-path*") " (default to "
-        (:code "~/.local/share/nyxt/extensions")").")
-    (:p "Extensions are regular Common Lisp systems.")
-    (:p "A catalogue of extensions is available in the "
-        (:code "document/EXTENSIONS.org") " file in the source repository.")
+     (:h2 "Extensions")
+     (:p "To install an extension, copy inside the "
+         (:code "*extensions-path*") " (default to "
+         (:code "~/.local/share/nyxt/extensions")").")
+     (:p "Extensions are regular Common Lisp systems.")
+     (:p "A catalogue of extensions is available in the "
+         (:code "document/EXTENSIONS.org") " file in the source repository.")
 
-    (:h2 "Troubleshooting")
-    (:h3 "Playing videos")
-    (:p "Nyxt delegates video support to third-party plugins.")
-    (:p "When using the WebKitGTK backends, GStreamer and its plugins are
+     (:h2 "Troubleshooting")
+     (:h3 "Playing videos")
+     (:p "Nyxt delegates video support to third-party plugins.")
+     (:p "When using the WebKitGTK backends, GStreamer and its plugins are
 leveraged.  Depending on the video, you will need to install some of the
 following packages:")
-    (:ul
-     (:li "gst-libav")
-     (:li "gst-plugins-bad")
-     (:li "gst-plugins-base")
-     (:li "gst-plugins-good")
-     (:li "gst-plugins-ugly"))
-    (:p "On Debian-based systems, you might be looking for (adapt the version numbers):")
-    (:ul
-     (:li "libgstreamer1.0-0")
-     (:li "gir1.2-gst-plugins-base-1.0"))
-    (:p "For systems from the Fedora family:")
-    (:ul
-     (:li "gstreamer1-devel")
-     (:li "gstreamer1-plugins-base-devel"))
-    (:p "After the desired plugins have been installed, clear the GStreamer cache at "
-        (:code "~/.cache/gstreamer-1.0") " and restart Nyxt.")
-    (:h3 "Input method support (CJK, etc.)")
-    (:p "Depending on your setup, you might have to set some environment
+     (:ul
+      (:li "gst-libav")
+      (:li "gst-plugins-bad")
+      (:li "gst-plugins-base")
+      (:li "gst-plugins-good")
+      (:li "gst-plugins-ugly"))
+     (:p "On Debian-based systems, you might be looking for (adapt the version numbers):")
+     (:ul
+      (:li "libgstreamer1.0-0")
+      (:li "gir1.2-gst-plugins-base-1.0"))
+     (:p "For systems from the Fedora family:")
+     (:ul
+      (:li "gstreamer1-devel")
+      (:li "gstreamer1-plugins-base-devel"))
+     (:p "After the desired plugins have been installed, clear the GStreamer cache at "
+         (:code "~/.cache/gstreamer-1.0") " and restart Nyxt.")
+     (:h3 "Input method support (CJK, etc.)")
+     (:p "Depending on your setup, you might have to set some environment
 variables or run some commands before starting Nyxt, for instance")
-    (:pre (:code "
+     (:pre (:code "
 GTK_IM_MODULE=xim
 XMODIFIERS=@im=ibus
 ibus --daemonize --replace --xim"))
-    (:p "You can persist this change by saving the commands in
+     (:p "You can persist this change by saving the commands in
 your " (:code ".xprofile") " or similar.")
-    (:h3 "Font size on HiDPI displays")
-    (:p "On HiDPI displays, the font size used for displaying web and Nyxt's
+     (:h3 "Font size on HiDPI displays")
+     (:p "On HiDPI displays, the font size used for displaying web and Nyxt's
 prompt-buffer content might be too tiny.")
-    (:p "To fix this issue when using the WebKitGTK render, export the following
+     (:p "To fix this issue when using the WebKitGTK render, export the following
 environment variable before starting Nyxt:")
-    (:pre (:code "
+     (:pre (:code "
 export GDK_SCALE=2
 export GDK_DPI_SCALE=0.5
 nyxt
 "))
-    (:h3 "StumpWM mouse scroll")
-    (:p "If the mouse scroll does not work for you, see the "
-        (:a
-         :href "https://github.com/stumpwm/stumpwm/wiki/FAQ#my-mouse-wheel-doesnt-work-with-gtk3-applications-add-the-following-to"
-         "StumpWM FAQ")
-        " for a fix.")
-    (:h3 "Blank WebKit web-views")
-    (:p "If you are experiencing problems with blank web-views on some sites you
+     (:h3 "StumpWM mouse scroll")
+     (:p "If the mouse scroll does not work for you, see the "
+         (:a
+          :href "https://github.com/stumpwm/stumpwm/wiki/FAQ#my-mouse-wheel-doesnt-work-with-gtk3-applications-add-the-following-to"
+          "StumpWM FAQ")
+         " for a fix.")
+     (:h3 "Blank WebKit web-views")
+     (:p "If you are experiencing problems with blank web-views on some sites you
     can try to disable compositing. To disable compositing from your
     initialization file, you can do the following: ")
-    (:code "(setf (uiop:getenv \"WEBKIT_DISABLE_COMPOSITING_MODE\") \"1\")"))))
+     (:code "(setf (uiop:getenv \"WEBKIT_DISABLE_COMPOSITING_MODE\") \"1\")"))))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -37,14 +37,15 @@ similar programming language.")
 below to create said file, if it's not created yet.")
      (let ((init-file-path (expand-path *init-file-path*)))
        (if (uiop:file-exists-p init-file-path)
-           (:a :class "button" :onclick (echo "Init file exists") "Init file exists")
            (:a :class "button"
-               :onclick (progn
-                          (with-open-file (_ init-file-path
-                                             :direction :output
-                                             :if-does-not-exist :create)
-                            (echo "Init file created at ~a."
-                                  init-file-path)))
+               :href (lisp-url '(echo "Init file exists"))
+               "Init file exists")
+           (:a :class "button"
+               :herf (lisp-url `(with-open-file (_ init-file-path
+                                                   :direction :output
+                                                   :if-does-not-exist :create)
+                                  (echo "Init file created at ~a."
+                                        init-file-path)))
                "Create init file")))
      ;; (:a :class "button" :href (lisp-url `(nyxt::describe-bindings)) "List bindings")
      (:p "Example:")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -36,18 +36,18 @@ similar programming language.")
          ", and the parent folders if necessary. You can also press the button
 below to create said file, if it's not created yet.")
      (let ((init-file-path (expand-path *init-file-path*)))
-       (if (uiop:file-exists-p init-file-path)
-           (:a :class "button"
-               :href (lisp-url '(echo "Init file exists"))
-               "Init file exists")
-           (:a :class "button"
-               :herf (lisp-url `(with-open-file (_ init-file-path
-                                                   :direction :output
-                                                   :if-does-not-exist :create)
-                                  (echo "Init file created at ~a."
-                                        init-file-path)))
-               "Create init file")))
-     ;; (:a :class "button" :href (lisp-url `(nyxt::describe-bindings)) "List bindings")
+       (:p (if (uiop:file-exists-p init-file-path)
+               (:a :class "button"
+                   :href (lisp-url `(echo "Init file exists"))
+                   "Init file exists")
+               (:a :class "button"
+                   :href (lisp-url `(with-open-file (_ ,init-file-path
+                                                       :direction :output
+                                                       :if-exists nil
+                                                       :if-does-not-exist :create)
+                                      (echo "Init file created at ~a."
+                                            ,init-file-path)))
+                   "Create init file"))))
      (:p "Example:")
      (:pre (:code "
 \(define-configuration buffer

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -33,7 +33,20 @@ existing object instances.")
 similar programming language.")
      (:p "The user needs to manually create the Nyxt configuration file "
          (:code (expand-path *init-file-path*))
-         ", and the parent folders if necessary.")
+         ", and the parent folders if necessary. You can also press the button
+below to create said file, if it's not created yet.")
+     (let ((init-file-path (expand-path *init-file-path*)))
+       (if (uiop:file-exists-p init-file-path)
+           (:a :class "button" :onclick (echo "Init file exists") "Init file exists")
+           (:a :class "button"
+               :onclick (progn
+                          (with-open-file (_ init-file-path
+                                             :direction :output
+                                             :if-does-not-exist :create)
+                            (echo "Init file created at ~a."
+                                  init-file-path)))
+               "Create init file")))
+     ;; (:a :class "button" :href (lisp-url `(nyxt::describe-bindings)) "List bindings")
      (:p "Example:")
      (:pre (:code "
 \(define-configuration buffer


### PR DESCRIPTION
This PR intends to resolve the issue #1923.

The real change happens **from line 34 to line 50.** I use Lispy for strucutural editing, so when I press "Return" key to enter a new line, it seems to indent everywhere else in the source file. I could not find a way to pass around that.

My idea is to dynamically create the button based on whether `init.lisp` is already created: If so, then do nothing. Otherwise, create the real button.