### PR TITLE
Commands to duplicate current buffer

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -896,14 +896,6 @@ See `make-buffer' for a description of the arguments."
   (declare (ignorable title modes url))
   (apply #'make-buffer (append (list :buffer-class 'user-background-buffer :no-history-p t) args)))
 
-(define-command duplicate-modes (&key (url (quri:uri "")) parent-buffer)
-  "Duplicate current modes in a new buffer."
-  (let ((buffer (make-buffer :url url
-                             :modes (mapcar #'mode-name (modes (current-buffer)))
-                             :parent-buffer parent-buffer)))
-    (set-current-buffer buffer)
-    buffer))
-
 (define-command duplicate-buffer-with-current-modes (&key (modes nil) parent-buffer)
   "Duplicate current buffer in a new buffer with current modes as well."
   (let* ((curr-buffer (current-buffer))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -898,10 +898,11 @@ See `make-buffer' for a description of the arguments."
 
 (define-command duplicate-buffer-with-current-modes (&key parent-buffer)
   "Duplicate current buffer in a new buffer with current modes as well."
-  (let ((buffer (current-buffer)))
+  (let* ((buffer (current-buffer))
+         (modes (modes buffer)))
     (make-buffer :title (title buffer)
                  :url (url buffer)
-                 :modes (mapcar #'mode-name (modes buffer))
+                 :modes (mapcar #'mode-name modes)
                  :parent-buffer parent-buffer)
     (set-current-buffer buffer)
     buffer))
@@ -912,6 +913,14 @@ See `make-buffer' for a description of the arguments."
     (make-buffer :title (title buffer)
                  :url (url buffer)
                  :parent-buffer parent-buffer)
+    (set-current-buffer buffer)
+    buffer))
+
+(define-command duplicate-modes (&key (url (quri:uri "")) parent-buffer)
+  "Duplicate current modes in a new buffer."
+  (let ((buffer (make-buffer :url url
+                             :modes (mapcar #'mode-name (current-buffer))
+                             :parent-buffer parent-buffer)))
     (set-current-buffer buffer)
     buffer))
 

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -910,7 +910,8 @@ See `make-buffer' for a description of the arguments."
 
 (define-command duplicate-buffer (&key parent-buffer)
   "Duplicate current buffer in a new buffer."
-  (duplicate-buffer-with-current-modes :modes '(web-mode base-mode)))
+  (duplicate-buffer-with-current-modes :modes '(web-mode base-mode)
+                                       :parent-buffer parent-buffer))
 
 (define-command make-internal-buffer (&key (title "") modes no-history-p)
   "Create a new buffer.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -913,7 +913,7 @@ See `make-buffer' for a description of the arguments."
   (duplicate-buffer-with-current-modes :modes '(web-mode base-mode)
                                        :parent-buffer parent-buffer))
 
-(define-command make-internal-buffer (&key (title "") modes no-history-p)
+(define-command make-internal-buffer (&key (url (quri:uri "")) (title "") modes no-history-p)
   "Create a new buffer.
 MODES is a list of mode symbols.
 If URL is `:default', use `default-new-buffer-url'."

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -896,16 +896,29 @@ See `make-buffer' for a description of the arguments."
   (declare (ignorable title modes url))
   (apply #'make-buffer (append (list :buffer-class 'user-background-buffer :no-history-p t) args)))
 
+(define-command duplicate-modes (&key (url (quri:uri "")) parent-buffer)
+  "Duplicate current modes in a new buffer."
+  (let ((modes (mapcar #'mode-name (modes (current-buffer)))))
+    (if-confirm ("Duplicate current modes: ~a?" modes)
+                (progn
+                  (let ((buffer (make-buffer :url url
+                                             :modes modes
+                                             :parent-buffer parent-buffer)))
+                    (set-current-buffer buffer)
+                    buffer)))))
+
 (define-command duplicate-buffer-with-current-modes (&key parent-buffer)
   "Duplicate current buffer in a new buffer with current modes as well."
   (let* ((buffer (current-buffer))
-         (modes (modes buffer)))
-    (make-buffer :title (title buffer)
-                 :url (url buffer)
-                 :modes (mapcar #'mode-name modes)
-                 :parent-buffer parent-buffer)
-    (set-current-buffer buffer)
-    buffer))
+         (modes (mapcar #'mode-name (modes buffer))))
+    (if-confirm ("Duplicate current modes: ~a?" modes)
+                (progn
+                  (make-buffer :title (title buffer)
+                               :url (url buffer)
+                               :modes modes
+                               :parent-buffer parent-buffer)
+                  (set-current-buffer buffer)
+                  buffer))))
 
 (define-command duplicate-buffer (&key parent-buffer)
   "Duplicate current buffer in a new buffer."
@@ -913,14 +926,6 @@ See `make-buffer' for a description of the arguments."
     (make-buffer :title (title buffer)
                  :url (url buffer)
                  :parent-buffer parent-buffer)
-    (set-current-buffer buffer)
-    buffer))
-
-(define-command duplicate-modes (&key (url (quri:uri "")) parent-buffer)
-  "Duplicate current modes in a new buffer."
-  (let ((buffer (make-buffer :url url
-                             :modes (mapcar #'mode-name (current-buffer))
-                             :parent-buffer parent-buffer)))
     (set-current-buffer buffer)
     buffer))
 

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -898,27 +898,21 @@ See `make-buffer' for a description of the arguments."
 
 (define-command duplicate-modes (&key (url (quri:uri "")) parent-buffer)
   "Duplicate current modes in a new buffer."
-  (let ((modes (mapcar #'mode-name (modes (current-buffer)))))
-    (if-confirm ("Duplicate current modes: ~a?" modes)
-                (progn
-                  (let ((buffer (make-buffer :url url
-                                             :modes modes
-                                             :parent-buffer parent-buffer)))
-                    (set-current-buffer buffer)
-                    buffer)))))
+  (let ((buffer (make-buffer :url url
+                             :modes (mapcar #'mode-name (modes (current-buffer)))
+                             :parent-buffer parent-buffer)))
+    (set-current-buffer buffer)
+    buffer))
 
 (define-command duplicate-buffer-with-current-modes (&key parent-buffer)
   "Duplicate current buffer in a new buffer with current modes as well."
-  (let* ((buffer (current-buffer))
-         (modes (mapcar #'mode-name (modes buffer))))
-    (if-confirm ("Duplicate current modes: ~a?" modes)
-                (progn
-                  (make-buffer :title (title buffer)
-                               :url (url buffer)
-                               :modes modes
-                               :parent-buffer parent-buffer)
-                  (set-current-buffer buffer)
-                  buffer))))
+  (let* ((buffer (current-buffer)))
+    (make-buffer :title (title buffer)
+                 :url (url buffer)
+                 :modes (mapcar #'mode-name (modes buffer))
+                 :parent-buffer parent-buffer)
+    (set-current-buffer buffer)
+    buffer))
 
 (define-command duplicate-buffer (&key parent-buffer)
   "Duplicate current buffer in a new buffer."

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -904,24 +904,21 @@ See `make-buffer' for a description of the arguments."
     (set-current-buffer buffer)
     buffer))
 
-(define-command duplicate-buffer-with-current-modes (&key parent-buffer)
+(define-command duplicate-buffer-with-current-modes (&key (modes nil) parent-buffer)
   "Duplicate current buffer in a new buffer with current modes as well."
-  (let* ((buffer (current-buffer)))
-    (make-buffer :title (title buffer)
-                 :url (url buffer)
-                 :modes (mapcar #'mode-name (modes buffer))
-                 :parent-buffer parent-buffer)
+  (let* ((curr-buffer (current-buffer))
+         (buffer (make-buffer :title (title curr-buffer)
+                              :url (url curr-buffer)
+                              :modes (or modes
+                                         (mapcar #'mode-name
+                                                 (modes curr-buffer)))
+                              :parent-buffer parent-buffer)))
     (set-current-buffer buffer)
     buffer))
 
 (define-command duplicate-buffer (&key parent-buffer)
   "Duplicate current buffer in a new buffer."
-  (let ((buffer (current-buffer)))
-    (make-buffer :title (title buffer)
-                 :url (url buffer)
-                 :parent-buffer parent-buffer)
-    (set-current-buffer buffer)
-    buffer))
+  (duplicate-buffer-with-current-modes :modes '(web-mode base-mode)))
 
 (define-command make-internal-buffer (&key (title "") modes no-history-p)
   "Create a new buffer.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -896,6 +896,25 @@ See `make-buffer' for a description of the arguments."
   (declare (ignorable title modes url))
   (apply #'make-buffer (append (list :buffer-class 'user-background-buffer :no-history-p t) args)))
 
+(define-command duplicate-buffer-with-current-modes (&key parent-buffer)
+  "Duplicate current buffer in a new buffer with current modes as well."
+  (let ((buffer (current-buffer)))
+    (make-buffer :title (title buffer)
+                 :url (url buffer)
+                 :modes (mapcar #'mode-name (modes buffer))
+                 :parent-buffer parent-buffer)
+    (set-current-buffer buffer)
+    buffer))
+
+(define-command duplicate-buffer (&key parent-buffer)
+  "Duplicate current buffer in a new buffer."
+  (let ((buffer (current-buffer)))
+    (make-buffer :title (title buffer)
+                 :url (url buffer)
+                 :parent-buffer parent-buffer)
+    (set-current-buffer buffer)
+    buffer))
+
 (define-command make-internal-buffer (&key (title "") modes no-history-p)
   "Create a new buffer.
 MODES is a list of mode symbols.

--- a/source/mode/element-hint.lisp
+++ b/source/mode/element-hint.lisp
@@ -288,6 +288,15 @@ FUNCTION is the action to perform on the selected elements."
 (defmethod %follow-hint-nosave-buffer ((element plump:element))
   (echo "Unsupported operation for hint: can't open in new buffer."))
 
+(defmethod %follow-hint-with-current-modes-new-buffer ((a nyxt/dom:a-element) &optional parent-buffer)
+  (make-buffer :url (url a)
+               :modes (mapcar #'mode-name (modes (current-buffer)))
+               :parent-buffer parent-buffer))
+
+(defmethod %follow-hint-with-current-modes-new-buffer ((element plump:element) &optional parent-buffer)
+  (declare (ignore parent-buffer))
+  (echo "Unsupported operation for hint: can't open in new buffer."))
+
 (defmethod %copy-hint-url ((a nyxt/dom:a-element))
   (trivial-clipboard:text (render-url (url a))))
 
@@ -362,6 +371,15 @@ visible nosave active buffer."
                  (%follow-hint-nosave-buffer-focus (first result))
                  (mapcar #'%follow-hint-nosave-buffer (rest result)))
                :multi-selection-p t))
+
+(define-command follow-hint-with-current-modes-new-buffer ()
+  "Follow hint and open link in a new buffer with current modes."
+  (let ((buffer (current-buffer)))
+    (query-hints "Open element with current modes in new buffer"
+                 (lambda (result)
+                   (mapcar (alex:rcurry #'%follow-hint-with-current-modes-new-buffer buffer)
+                           result))
+                 :multi-selection-p t)))
 
 (define-command copy-hint-url ()
   "Show a set of element hints, and copy the URL of the user inputted one."


### PR DESCRIPTION
This PR intends to help solve #1557.

The two functions are pretty similar, the only difference is line 904:
`:modes (mapcar #'mode-name (modes buffer))`