### PR TITLE
window.lisp: Add `delete-all-panel-buffers` command

### DIFF
--- a/source/window.lisp
+++ b/source/window.lisp
@@ -110,6 +110,13 @@ The handlers take the window as argument."))
                                              :window window)))))
     (mapc (lambda (i) (window-delete-panel-buffer window i)) panels)))
 
+(define-command-global delete-all-panel-buffers (&key (window (current-window)))
+  "Delete all panel buffers, with confirmation."
+  (if-confirm ("Delete all current panel buffers?")
+              (mapcar (lambda (panel)
+                        (window-delete-panel-buffer window panel))
+                      (panel-buffers window))))
+
 (defmacro define-panel (name (buffer-variable) &body body)
   (let ((panel-name (format nil "*~a Panel*" name))
         (docstring-show (format nil "Show ~a panel." name))


### PR DESCRIPTION
I found it really helpful when implementing panel buffer-related functionality. It should be helpful to users when we have more kinds of panels in the future.