### PR TITLE
auto.lisp: Amends format directive and tweaks arguments display

### DIFF
--- a/source/mode/auto.lisp
+++ b/source/mode/auto.lisp
@@ -421,15 +421,15 @@ Auto-mode is re-enabled once the page is reloaded."
 (defmethod serialize-object ((rule auto-mode-rule) stream)
   (flet ((write-if-present (slot &key modes-p)
            (when (funcall slot rule)
-             (format t " :~a ~a"
+             (format t " :~a ~s"
                      slot
                      (let ((value (funcall slot rule)))
                        (if modes-p
                            (mapcar
                             #'(lambda (mode-invocation)
                                 (if (arguments mode-invocation)
-                                    (list (name mode-invocation)
-                                          (arguments mode-invocation))
+                                    `(,(name mode-invocation)
+                                      ,@(arguments mode-invocation))
                                     (name mode-invocation)))
                             value)
                            value))))))


### PR DESCRIPTION
When attempting to add programmatic `auto-mode` rules via `add-modes-to-auto-mode-rules`, I encountered an odd behavior where if I passed a list of mode invocations with `:initarg`'s like the following.

```lisp
(nyxt/auto-mode::add-modes-to-auto-mode-rules 
(list (match-domain "fsf.org"))
:include (nyxt/auto-mode::mode-invocations
(list (nyxt/style-mode::dark-mode :visible-in-status-p nil))))
```

I would get the following rule in the `auto-mode-rules-data-path`.

```lisp
((match-domain "fsf.org")  :included ((nyxt/style-mode:dark-mode
                                        (visible-in-status-p nil))))
```

I therefore tried to navigate to `https://fsf.org` and was prompted with an error that said no valid `&key` arguments were provided.

I've slightly tweaked the `auto-mode` serialization method to account for this, so that now one would get the following rule in their `auto-mode-rules-data-path`.

```lisp
((match-domain "fsf.org")  :included ((nyxt/style-mode:dark-mode
                                        :visible-in-status-p nil)))
```

Which leaves out any errors, appropriately instantiates the mode with the respective  `:initarg`'s and fills any necessary package specifiers on the symbols being provided.