### PR TITLE
Refactor visual mode

### DIFF
--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -49,7 +49,9 @@
        "C-a" 'beginning-line
        "C-e" 'end-line
        "M-a" 'backward-sentence
-       "M-e" 'forward-sentence)
+       "M-e" 'forward-sentence
+       "M-}" 'forward-paragraph
+       "M-{" 'backward-paragraph)
       ;; vi keybindings only enable use of vim's plain "visual" mode for now
       scheme:vi-normal
       (list
@@ -241,6 +243,20 @@ marquee, multicol, nobr, s, spacer, strike, tt, u, wbr, code, cite, pre"))
     (caret-move :action (caret-action mode)
                 :direction :backward
                 :scale :sentence)))
+
+(define-command forward-paragraph ()
+  "Move caret forward by a paragraph."
+  (let ((mode (find-submode (current-buffer) 'visual-mode)))
+    (caret-move :action (caret-action mode)
+                :direction :forward
+                :scale :paragraph)))
+
+(define-command backward-paragraph ()
+  "Move caret backward by a paragraph."
+  (let ((mode (find-submode (current-buffer) 'visual-mode)))
+    (caret-move :action (caret-action mode)
+                :direction :backward
+                :scale :paragraph)))
 
 (define-command forward-line-with-selection ()
   "Set mark and move caret forward by a line."

--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -97,8 +97,8 @@
 
 (defmethod caret-action ((mode visual-mode))
   (if (mark-set mode)
-      "extend"
-      "move"))
+      :extend
+      :move))
 
 (define-parenscript block-page-keypresses ()
   (setf (ps:@ window block-keypresses)
@@ -176,71 +176,71 @@ marquee, multicol, nobr, s, spacer, strike, tt, u, wbr, code, cite, pre"))
   "Move caret forward by a character."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "forward"
-                :scale "character")))
+                :direction :forward
+                :scale :character)))
 
 (define-command backward-char ()
   "Move caret backward by a character."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "backward"
-                :scale "character")))
+                :direction :backward
+                :scale :character)))
 
 (define-command forward-word ()
   "Move caret forward by a word."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "forward"
-                :scale "word")))
+                :direction :forward
+                :scale :word)))
 
 (define-command backward-word ()
   "Move caret backward by a word."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "backward"
-                :scale "word")))
+                :direction :backward
+                :scale :word)))
 
 (define-command forward-line ()
   "Move caret forward by a line."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "forward"
-                :scale "line")))
+                :direction :forward
+                :scale :line)))
 
 (define-command backward-line ()
   "Move caret backward by a line."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "backward"
-                :scale "line")))
+                :direction :backward
+                :scale :line)))
 
 (define-command beginning-line ()
   "Move caret to the beginning of the line."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "backward"
-                :scale "lineboundary")))
+                :direction :backward
+                :scale :lineboundary)))
 
 (define-command end-line ()
   "Move caret to the end of the line."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "forward"
-                :scale "lineboundary")))
+                :direction :forward
+                :scale :lineboundary)))
 
 (define-command forward-sentence ()
   "Move caret forward to next end of sentence."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "forward"
-                :scale "sentence")))
+                :direction :forward
+                :scale :sentence)))
 
 (define-command backward-sentence ()
   "Move caret backward to start of sentence."
   (let ((mode (find-submode (current-buffer) 'visual-mode)))
     (caret-move :action (caret-action mode)
-                :direction "backward"
-                :scale "sentence")))
+                :direction :backward
+                :scale :sentence)))
 
 (define-command forward-line-with-selection ()
   "Set mark and move caret forward by a line."

--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -52,7 +52,9 @@
        "M-a" 'backward-sentence
        "M-e" 'forward-sentence
        "M-}" 'forward-paragraph
-       "M-{" 'backward-paragraph)
+       "M-{" 'backward-paragraph
+       "M->" 'forward-document
+       "M-<" 'backward-document)
       ;; vi keybindings only enable use of vim's plain "visual" mode for now
       scheme:vi-normal
       (list
@@ -67,6 +69,8 @@
        "(" 'backward-sentence
        "}" 'forward-paragraph
        "{" 'backward-paragraph
+       "G" 'forward-document
+       "g g" 'backward-document
        "0" 'beginning-line
        "v" 'toggle-mark
        "C-c" 'visual-mode)))

--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -62,6 +62,8 @@
        "w" 'forward-word
        "b" 'backward-word
        "$" 'end-line
+       ")" 'forward-sentence
+       "(" 'backward-sentence
        "0" 'beginning-line
        "v" 'toggle-mark
        "C-c" 'visual-mode)))

--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -7,6 +7,7 @@
   (:import-from #:nyxt/web-mode #:query-hints #:get-nyxt-id)
   (:documentation "Visual mode."))
 (in-package :nyxt/visual-mode)
+(use-nyxt-package-nicknames)
 
 (define-mode visual-mode ()
   "Visual mode. For documentation on commands and keybindings, see the manual."
@@ -262,50 +263,45 @@ marquee, multicol, nobr, s, spacer, strike, tt, u, wbr, code, cite, pre"))
                 :direction :backward
                 :scale :paragraph)))
 
-(define-command forward-line-with-selection ()
+(defmacro define-command-with-selection (name args &body body)
+  (declare (ignore args))
+  (alex:with-gensyms (mode)
+    (multiple-value-bind (body decls doc)
+      (alex:parse-body body :documentation t)
+        `(define-command ,name ()
+           ,@decls ,@(sera:unsplice doc)
+           (let ((,mode (find-submode (current-buffer) 'visual-mode)))
+             (setf (mark-set ,mode) t)
+             ,@body)))))
+
+(define-command-with-selection forward-line-with-selection ()
   "Set mark and move caret forward by a line."
-  (let ((mode (find-submode (current-buffer) 'visual-mode)))
-    (setf (mark-set mode) t)
-    (forward-line)))
+  (forward-line))
 
-(define-command backward-line-with-selection ()
+(define-command-with-selection backward-line-with-selection ()
   "Set mark and move caret backward by a line."
-  (let ((mode (find-submode (current-buffer) 'visual-mode)))
-    (setf (mark-set mode) t)
-    (backward-line)))
+  (backward-line))
 
-(define-command forward-char-with-selection ()
+(define-command-with-selection forward-char-with-selection ()
   "Set mark and move caret forward by a character."
-  (let ((mode (find-submode (current-buffer) 'visual-mode)))
-    (setf (mark-set mode) t)
-    (forward-char)))
+  (forward-char))
 
-(define-command backward-char-with-selection ()
+(define-command-with-selection backward-char-with-selection ()
   "Set mark and move caret backward by a character."
-  (let ((mode (find-submode (current-buffer) 'visual-mode)))
-    (setf (mark-set mode) t)
-    (backward-char)))
+  (backward-char))
 
-(define-command forward-word-with-selection ()
+(define-command-with-selection forward-word-with-selection ()
   "Set mark and move caret forward by a word."
-  (let ((mode (find-submode (current-buffer) 'visual-mode)))
-    (setf (mark-set mode) t)
-    (forward-word)))
+  (forward-word))
 
-(define-command backward-word-with-selection ()
+(define-command-with-selection backward-word-with-selection ()
   "Set mark and move caret backward by a word."
-  (let ((mode (find-submode (current-buffer) 'visual-mode)))
-    (setf (mark-set mode) t)
-    (backward-word)))
+  (backward-word))
 
-(define-command beginning-line-with-selection ()
+(define-command-with-selection beginning-line-with-selection ()
   "Set mark and move caret to the beginning of the line."
-  (let ((mode (find-submode (current-buffer) 'visual-mode)))
-    (setf (mark-set mode) t)
-    (beginning-line)))
+  (beginning-line))
 
-(define-command end-line-with-selection ()
+(define-command-with-selection end-line-with-selection ()
   "Set mark and move caret to the end of line."
-  (let ((mode (find-submode (current-buffer) 'visual-mode)))
-    (setf (mark-set mode) t)
-    (end-line)))
+  (end-line))

--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -263,6 +263,20 @@ marquee, multicol, nobr, s, spacer, strike, tt, u, wbr, code, cite, pre"))
                 :direction :backward
                 :scale :paragraph)))
 
+(define-command forward-document ()
+  "Move caret forward to the end of the document."
+  (let ((mode (find-submode (current-buffer) 'visual-mode)))
+    (caret-move :action (caret-action mode)
+                :direction :forward
+                :scale :documentboundary)))
+
+(define-command backward-document ()
+  "Move caret backward to the beginning of the document."
+  (let ((mode (find-submode (current-buffer) 'visual-mode)))
+    (caret-move :action (caret-action mode)
+                :direction :backward
+                :scale :documentboundary)))
+
 (defmacro define-command-with-selection (name args &body body)
   (declare (ignore args))
   (alex:with-gensyms (mode)

--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -64,6 +64,8 @@
        "$" 'end-line
        ")" 'forward-sentence
        "(" 'backward-sentence
+       "}" 'forward-paragraph
+       "{" 'backward-paragraph
        "0" 'beginning-line
        "v" 'toggle-mark
        "C-c" 'visual-mode)))

--- a/source/types.lisp
+++ b/source/types.lisp
@@ -65,6 +65,22 @@ Example:
        (eql :never)
        (eql :no-third-party)))
 
+;; The following types represent the positional arguments documented at
+;; https://developer.mozilla.org/en-US/docs/Web/API/Selection/modify#parameters
+
+(deftype selection-action ()
+  "The type of change to apply."
+  '(member :move :extend))
+
+(deftype selection-direction ()
+  "The direction in which to adjust the current selection."
+  '(member :forward :backward))
+
+(deftype selection-scale ()
+  "The distance to adjust the current selection or cursor position."
+  '(member :character :word :sentence :line :paragraph :lineboundary
+    :sentenceboundary :paragraphboundary :documentboundary))
+
 (export-always 'html-string-p)
 (defun html-string-p (string)
   (and (stringp string)


### PR DESCRIPTION
I mentioned I had more coming, did I not? :smile:

In addition to adding enum types for the various options for the parameters for the Web Selection API or whatever you'd call it, I added a few new "scales" with their respective commands. That and some refactoring.

The only thing missing is to make the bindings work for the new `forward-document`/`backward-document` commands. I've discussed some with @jmercouris, but he's on vacation and I couldn't figure out the override-map idea he mentioned.