### PR TITLE
source/global.lisp: fix small grammar mistake

### DIFF
--- a/source/global.lisp
+++ b/source/global.lisp
@@ -32,7 +32,7 @@ The hook takes no argument.
 This hook is run after the `*browser*' is instantiated and before the
 `startup' is run.
 
-Add a handler can be added with:
+A handler can be added with:
 
   (hooks:add-hook *after-init-hook*
     (hooks:make-handler-void #'my-foo-function))")


### PR DESCRIPTION
It is a small typo being fixed. The current phrase is:

> Add a handler can be added with:

It could be changed to "Add a handler with" or "A handler can be added with". I have picked up the latter.