### PR TITLE
Fix "can't open-code test" SBCL warnings

### DIFF
--- a/libraries/history-tree/history-tree.lisp
+++ b/libraries/history-tree/history-tree.lisp
@@ -142,24 +142,6 @@ If the node has no owner, return Epoch."
                      (alex:hash-table-values (bindings node))))
       (local-time:unix-to-timestamp 0)))
 
-(export-always 'data-last-access)
-(declaim (ftype (function (history-tree t) local-time:timestamp) data-last-access))
-(defun data-last-access (history data)
-  "Return data last access across all its nodes, regardless of the owner.
-Return Epoch if DATA is not found or if entry has no timestamp."
-  (let* ((entry (find-entry history data))
-         (nodes (when entry (nodes entry))))
-    (the (values local-time:timestamp &optional)
-         (if nodes
-             (let ((new-last-access
-                     (apply #'local-time:timestamp-maximum
-                            (mapcar #'last-access nodes))))
-               (setf (last-access entry) new-last-access)
-               new-last-access)
-             (if entry
-                 (last-access entry)
-                 (local-time:unix-to-timestamp 0))))))
-
 (define-class owner ()
   ;; REVIEW: Add slot pointing to history an owner belongs to?  As long as the
   ;; owner has at least one node, the history can be accessed via the entry.
@@ -352,6 +334,24 @@ if if were a function."))
       (setf (gethash owner (htree:owners history))
             (make-instance 'htree:owner)))
     history))
+
+(export-always 'data-last-access)
+(declaim (ftype (function (history-tree t) local-time:timestamp) data-last-access))
+(defun data-last-access (history data)
+  "Return data last access across all its nodes, regardless of the owner.
+Return Epoch if DATA is not found or if entry has no timestamp."
+  (let* ((entry (find-entry history data))
+         (nodes (when entry (nodes entry))))
+    (the (values local-time:timestamp &optional)
+         (if nodes
+             (let ((new-last-access
+                     (apply #'local-time:timestamp-maximum
+                            (mapcar #'last-access nodes))))
+               (setf (last-access entry) new-last-access)
+               new-last-access)
+             (if entry
+                 (last-access entry)
+                 (local-time:unix-to-timestamp 0))))))
 
 (export-always 'owner)
 (defun owner (history owner-spec)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -164,17 +164,21 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                (:file "diff-mode")
                (:file "expedition-mode")
                ;; Web-mode commands
-               (:file "bookmarklets")
-               (:file "input-edit")
-               (:file "element-hint")
-               (:file "element-hint-mode")
-               (:file "element-frame")
-               (:file "jump-heading")
-               (:file "summarize")
-               (:file "scroll")
-               (:file "search-buffer")
-               (:file "spell-check")
-               (:file "zoom")
+               (:module "web-mode-commands"
+                :pathname ""
+                :serial nil
+                :components
+                ((:file "bookmarklets")
+                 (:file "input-edit")
+                 (:file "element-hint" :depends-on ("search-buffer"))
+                 (:file "element-hint-mode")
+                 (:file "element-frame")
+                 (:file "jump-heading")
+                 (:file "summarize")
+                 (:file "scroll")
+                 (:file "search-buffer")
+                 (:file "spell-check")
+                 (:file "zoom")))
                ;; Needs web-mode
                (:file "help")
                (:file "macro-edit-mode")

--- a/source/auto-mode.lisp
+++ b/source/auto-mode.lisp
@@ -164,38 +164,6 @@ non-new-page requests, buffer URL is not altered."
     (setf (previous-url auto-mode) (url request-data)))
   request-data)
 
-(-> mode-covered-by-auto-mode-p
-    (root-mode auto-mode boolean)
-    (values (or list boolean) &optional))
-(defun mode-covered-by-auto-mode-p (mode auto-mode enable-p)
-  "Says whether AUTO-MODE already knows what to do with MODE.
-ENABLE-P is whether mode is being enabled (non-nil) or disabled (nil).
-Mode is covered if:
-- It's not rememberable (has `rememberable-p' set to nil).
-- There is a rule it matches and:
-  - when mode is ENABLED-P and part of `included' modes in the rule, or
-  - when mode is not ENABLED-P and part of `excluded' modes in the rule.
-- If there's no matching rule but it's part of `last-active-modes' and needs to be ENABLED-P.
-- If it's getting disabled (not ENABLED-P) after being enabled by a rule on the previous page."
-  (let ((invocation (mode-invocation mode)))
-    (flet ((invocation-member (list)
-             (member invocation list :test #'equals)))
-      (or (not (rememberable-p mode))
-          (alex:when-let ((matching-rule (matching-auto-mode-rule (url (buffer auto-mode))
-                                                                  (buffer auto-mode))))
-            (or (and enable-p (invocation-member (included matching-rule)))
-                (and (not enable-p) (invocation-member (excluded matching-rule)))))
-          ;; Mode is covered by auto-mode only if it is both in
-          ;; last-active-modes and gets enabled.  If it gets disabled, user
-          ;; should be prompted, because they may want to persist it.
-          (and enable-p (invocation-member (last-active-modes auto-mode)))
-          (and (not enable-p)
-               (invocation-member
-                (alex:when-let* ((previous-url (previous-url auto-mode))
-                                 (matching-rule (matching-auto-mode-rule previous-url
-                                                                         (buffer auto-mode))))
-                  (included matching-rule))))))))
-
 (-> url-infer-match (string) list)
 (defun url-infer-match (url)
   "Infer the best `test' for `auto-mode-rule', based on the form of URL.
@@ -304,6 +272,39 @@ modes that were in place before the nyxt.atlas.engineer rule was applied are
 restored.")
    (destructor #'clean-up-auto-mode)
    (constructor #'initialize-auto-mode)))
+
+
+(-> mode-covered-by-auto-mode-p
+    (root-mode auto-mode boolean)
+    (values (or list boolean) &optional))
+(defun mode-covered-by-auto-mode-p (mode auto-mode enable-p)
+  "Says whether AUTO-MODE already knows what to do with MODE.
+ENABLE-P is whether mode is being enabled (non-nil) or disabled (nil).
+Mode is covered if:
+- It's not rememberable (has `rememberable-p' set to nil).
+- There is a rule it matches and:
+  - when mode is ENABLED-P and part of `included' modes in the rule, or
+  - when mode is not ENABLED-P and part of `excluded' modes in the rule.
+- If there's no matching rule but it's part of `last-active-modes' and needs to be ENABLED-P.
+- If it's getting disabled (not ENABLED-P) after being enabled by a rule on the previous page."
+  (let ((invocation (mode-invocation mode)))
+    (flet ((invocation-member (list)
+             (member invocation list :test #'equals)))
+      (or (not (rememberable-p mode))
+          (alex:when-let ((matching-rule (matching-auto-mode-rule (url (buffer auto-mode))
+                                                                  (buffer auto-mode))))
+            (or (and enable-p (invocation-member (included matching-rule)))
+                (and (not enable-p) (invocation-member (excluded matching-rule)))))
+          ;; Mode is covered by auto-mode only if it is both in
+          ;; last-active-modes and gets enabled.  If it gets disabled, user
+          ;; should be prompted, because they may want to persist it.
+          (and enable-p (invocation-member (last-active-modes auto-mode)))
+          (and (not enable-p)
+               (invocation-member
+                (alex:when-let* ((previous-url (previous-url auto-mode))
+                                 (matching-rule (matching-auto-mode-rule previous-url
+                                                                         (buffer auto-mode))))
+                  (included matching-rule))))))))
 
 (define-command save-non-default-modes-for-future-visits ()
   "Save the modes present in `default-modes' and not present in current modes as :excluded,

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -51,6 +51,69 @@ See `*default-hostlist*' for an example."))
 See the `hostlist' class documentation."
   (apply #'make-instance 'hostlist args))
 
+
+(serapeum:export-always '*default-hostlist*)
+(defparameter *default-hostlist*
+  (make-instance 'hostlist
+                 :url (quri:uri "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts")
+                 :basename "hostlist-stevenblack.txt")
+  "Default hostlist for `blocker-mode'.")
+
+(define-mode blocker-mode ()
+  "Enable blocking of listed hosts.
+To customize the list of blocked hosts, set the `hostlists' slot.
+See the `hostlist' class documentation.
+
+Example:
+
+\(defvar *my-blocked-hosts*
+  (nyxt/blocker-mode:make-hostlist
+   :hosts '(\"platform.twitter.com\"
+            \"syndication.twitter.com\"
+            \"m.media-amazon.com\")))
+
+\(define-mode my-blocker-mode (nyxt/blocker-mode:blocker-mode)
+  \"Blocker mode with custom hosts from `*my-blocked-hosts*'.\"
+  ((nyxt/blocker-mode:hostlists (list *my-blocked-hosts* nyxt/blocker-mode:*default-hostlist*))))
+
+\(define-configuration buffer
+  ((default-modes (append '(my-blocker-mode) %slot-default%))))"
+  ((hostlists (list *default-hostlist*))
+   (thread
+    nil
+    :type (or bt:thread null)
+    :export nil
+    :documentation "This thread is used to update the hostlists in the background.")
+   (worker-channel
+    nil
+    :type (or calispel:channel null)
+    :export nil
+    :documentation "Communication channel between `thread' and `blocker-mode'.")
+   (blocked-hosts
+    (make-hash-table :test 'equal)
+    :export nil
+    :documentation "The set of domain names to block.")
+   (destructor
+    (lambda (mode)
+      (bt:destroy-thread (thread mode))
+      (when (web-buffer-p (buffer mode))
+        (hooks:remove-hook (request-resource-hook (buffer mode))
+                           'request-resource-block))))
+   (constructor
+    (lambda (mode)
+      (setf (worker-channel mode) (nyxt::make-channel))
+      (setf (thread mode)
+            (run-thread "blocker-mode hostlist update worker"
+              (worker mode)))
+      (load-hostlists mode)
+      (when (web-buffer-p (buffer mode))
+        (if (request-resource-hook (buffer mode))
+            (hooks:add-hook (request-resource-hook (buffer mode))
+                            (make-handler-resource #'request-resource-block))
+            (make-hook-resource
+             :combination #'combine-composed-hook-until-nil
+             :handlers (list #'request-resource-block))))))))
+
 (defmethod store ((profile data-profile) (path hostlist) &key &allow-other-keys)
   (with-data-file (file path :direction :output)
     (write-string (get-data path) file)))
@@ -140,68 +203,6 @@ Return NIL on failure, T on success."
   (do () (nil)
     (alex:when-let ((hostlist (calispel:? (worker-channel mode))))
       (load-hostlist hostlist mode))))
-
-(serapeum:export-always '*default-hostlist*)
-(defparameter *default-hostlist*
-  (make-instance 'hostlist
-                 :url (quri:uri "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts")
-                 :basename "hostlist-stevenblack.txt")
-  "Default hostlist for `blocker-mode'.")
-
-(define-mode blocker-mode ()
-  "Enable blocking of listed hosts.
-To customize the list of blocked hosts, set the `hostlists' slot.
-See the `hostlist' class documentation.
-
-Example:
-
-\(defvar *my-blocked-hosts*
-  (nyxt/blocker-mode:make-hostlist
-   :hosts '(\"platform.twitter.com\"
-            \"syndication.twitter.com\"
-            \"m.media-amazon.com\")))
-
-\(define-mode my-blocker-mode (nyxt/blocker-mode:blocker-mode)
-  \"Blocker mode with custom hosts from `*my-blocked-hosts*'.\"
-  ((nyxt/blocker-mode:hostlists (list *my-blocked-hosts* nyxt/blocker-mode:*default-hostlist*))))
-
-\(define-configuration buffer
-  ((default-modes (append '(my-blocker-mode) %slot-default%))))"
-  ((hostlists (list *default-hostlist*))
-   (thread
-    nil
-    :type (or bt:thread null)
-    :export nil
-    :documentation "This thread is used to update the hostlists in the background.")
-   (worker-channel
-    nil
-    :type (or calispel:channel null)
-    :export nil
-    :documentation "Communication channel between `thread' and `blocker-mode'.")
-   (blocked-hosts
-    (make-hash-table :test 'equal)
-    :export nil
-    :documentation "The set of domain names to block.")
-   (destructor
-    (lambda (mode)
-      (bt:destroy-thread (thread mode))
-      (when (web-buffer-p (buffer mode))
-        (hooks:remove-hook (request-resource-hook (buffer mode))
-                           'request-resource-block))))
-   (constructor
-    (lambda (mode)
-      (setf (worker-channel mode) (nyxt::make-channel))
-      (setf (thread mode)
-            (run-thread "blocker-mode hostlist update worker"
-              (worker mode)))
-      (load-hostlists mode)
-      (when (web-buffer-p (buffer mode))
-        (if (request-resource-hook (buffer mode))
-            (hooks:add-hook (request-resource-hook (buffer mode))
-                            (make-handler-resource #'request-resource-block))
-            (make-hook-resource
-             :combination #'combine-composed-hook-until-nil
-             :handlers (list #'request-resource-block))))))))
 
 (defmethod blocklisted-host-p ((mode blocker-mode) host)
   "Return non-nil of HOST if found in the hostlists of MODE.

--- a/source/prompt-buffer-mode.lisp
+++ b/source/prompt-buffer-mode.lisp
@@ -209,6 +209,12 @@ If STEPS is negative, go to next pages instead."
                  :value attribute
                  :attributes `(("Attribute key" ,attribute))))
 
+(define-class attribute-source (prompter:source)
+  ((prompter:name "List of prompter attributes")
+   (prompter:multi-selection-p t)
+   (prompter:suggestion-maker 'make-attribute-suggestion)
+   (prompter:actions '(return-marks-only))))
+
 (defun return-marks-only (suggestion-values)
   "Return marked suggestions only.
 They are returned untouched.
@@ -221,12 +227,6 @@ current unmarked selection."
         (remove (prompter:value suggestion) suggestion-values
                 :test #'equal)
         suggestion-values)))
-
-(define-class attribute-source (prompter:source)
-  ((prompter:name "List of prompter attributes")
-   (prompter:multi-selection-p t)
-   (prompter:suggestion-maker 'make-attribute-suggestion)
-   (prompter:actions '(return-marks-only))))
 
 (define-command-prompt toggle-attributes-display (prompt-buffer)
   "Prompt for which prompter attributes to display."


### PR DESCRIPTION
This should finally rid us of the warnings in the line of

```log
source/buffer.lisp:856:1:
  note:
    can't open-code test of unknown type BROWSER
```

that started occurring with SBCL 2.1.9 at least.
You can trigger these warnings by force-compiling Nyxt or simply by changing branch (between `master` and `2-series` for instance).

I like the new `:module` in the .asd: it structures the list and make us less prone to break the load order by introducing new files and re-ordering files.

The only "fix" that I'm a bit skeptical about is the class forward declaration in f97d8fc612f059295b87de2106a47088bb6edb22.  What do you think?