### PR TITLE
Fix to not remove highlighting of search terms

### DIFF
--- a/source/mode/element-hint.lisp
+++ b/source/mode/element-hint.lisp
@@ -80,7 +80,7 @@
 (define-parenscript remove-element-hints ()
   (defun hints-remove-all ()
     "Removes all the elements"
-    (ps:dolist (element (nyxt/ps:qsa document ".nyxt-hint"))
+    (ps:dolist (element (nyxt/ps:qsa document ":not(.nyxt-search-node) > .nyxt-hint"))
       (ps:chain element (remove))))
   (hints-remove-all))
 


### PR DESCRIPTION
Hi,

I found what I thought was a bug and fixed it.

# Steps to Reproduce

1. Open https://nyxt.atlas.engineer/ in Nyxt.
2. Execute the `search-buffer` command to search for "nyxt".
3. Execute `visual-mode` command.

# Expected behavior

Able to use visual-mode, including search terms.

# Actual behavior

Search terms are removed when switching to visual-mode.

If we use visual mode after searching in a document, you may want to select a string of search terms, so it would be inconvenient if it is removed.

Therefore, I changed the CSS selector expression so that search term highlights are not targeted for removal by `remove-element-hints`.

Nyxt is a great browser and I really like it. Thanks again.
