### PR TITLE
mode/auto,urls: Add match-port URL designator predicate

### DIFF
--- a/source/mode/auto.lisp
+++ b/source/mode/auto.lisp
@@ -485,6 +485,8 @@ Auto-mode is re-enabled once the page is reloaded."
 ;; - match-regex works for any address that matches a given regex. You can add these manually,
 ;;   but remember: with great regex comes great responsibility!
 ;;   Example: (match-regex \"https://github\\.com/.*/.*\") will activate only in repos on GitHub.
+;; - match-port matches the port number(s) only.
+;;   Example: (match-port 8000 8080) will work for e.g. localhost:8000, 127.0.0.1:8080, etc.
 ;; - String format matches the exact URL and nothing else
 ;;   Example: \"https://lispcookbook.github.io/cl-cookbook/pattern_matching.html\"
 ;;            will work on the Pattern Matching article of CL Cookbook, and nowhere else.

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -333,6 +333,15 @@ return a boolean.  It defines an equivalence relation induced by EQ-FN-LIST.
         (some (alex:curry #'string= (quri:uri-domain (url url-designator)))
               (cons domain other-domains)))))
 
+(-> match-port (integer &rest integer) (function (quri:uri) boolean))
+(export-always 'match-port)
+(defun match-port (port &rest other-ports)
+  "Return a predicate for URL designators matching one of PORT or OTHER-PORTS."
+  #'(lambda (url-designator)
+      (when url-designator
+        (some (alex:curry #'eq (quri:uri-port (url url-designator)))
+              (cons port other-ports)))))
+
 (-> match-file-extension (string &rest string) (function (quri:uri) boolean))
 (export-always 'match-file-extension)
 (defun match-file-extension (extension &rest other-extensions)


### PR DESCRIPTION
Real simple patch, the only thing that might need changing would be `#'eq` but it appears to work just fine.