### PR TITLE
Gemini support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -538,3 +538,7 @@
 	path = _build/cl-gopher
 	url = https://github.com/knusbaum/cl-gopher
     shallow = true
+[submodule "_build/phos"]
+	path = _build/phos
+	url = https://github.com/omar-polo/phos
+    shallow = true

--- a/build-scripts/nyxt.scm
+++ b/build-scripts/nyxt.scm
@@ -238,6 +238,7 @@ WebKit browsing engine.")
        ("named-readtables" ,cl-named-readtables)
        ;; ("osicat" ,cl-osicat) ; Not needed for SBCL.
        ("parenscript" ,cl-parenscript)
+       ("phos" ,cl-phos)
        ("plump" ,cl-plump)
        ("clss" ,cl-clss)
        ("quri" ,cl-quri)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -67,6 +67,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                quri
                serapeum
                str
+               phos
                plump
                clss
                spinneret

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -145,7 +145,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                (:file "mode/list-history")
                (:file "mode/bookmark-frequent-visits")
                (:file "mode/web")
-               (:file "mode/gopher")
+               (:file "mode/small-web")
                (:file "mode/reading-line")
                (:file "mode/style")
                (:file "mode/certificate-exception")

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -350,9 +350,8 @@ Second return value should be the MIME-type of the content."))
 (defun gemini-render (body &optional (mode (current-mode 'small-web)))
   (let ((elements (phos/gemtext:parse-string body))
         (spinneret::*html-style* :tree))
-    (unwind-protect
-         (spinneret:with-html-string
-           (:style (style (buffer mode)))
-           (:style (style mode))
-           (loop for element in elements
-                 collect (:raw (line->html element)))))))
+    (spinneret:with-html-string
+      (:style (style (buffer mode)))
+      (:style (style mode))
+      (loop for element in elements
+            collect (:raw (line->html element))))))

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -328,7 +328,7 @@ Second return value should be the MIME-type of the content."))
   (spinneret:with-html-string
     (let* ((url (render-url (gemtext:url element)))
            (path (quri:uri-path (gemtext:url element)))
-           (mime (when (pathnamep path)
+           (mime (unless (uiop:emptyp path)
                    (mimes:mime-lookup path)))
            (text (cond
                    ((not (uiop:emptyp (gemtext:text element)))

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -15,7 +15,8 @@
     (run-thread "small-web-mode update thread"
       (setf (url mode) url
             (model mode) (str:string-case (quri:uri-scheme url)
-                           ("gopher" (cl-gopher:get-line-contents (cl-gopher:parse-gopher-uri url)))
+                           ("gopher" (cl-gopher:get-line-contents
+                                      (cl-gopher:parse-gopher-uri (render-url url))))
                            ("gemini" (multiple-value-bind (status meta body)
                                          (gemini:request url)
                                        (if (and (eq :success status)

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -345,13 +345,3 @@ Second return value should be the MIME-type of the content."))
          (:video :src url :controls t))
         (t (:a :class "button" :href url text))))
     (:br)))
-
-(export-always 'gemini-render)
-(defun gemini-render (body &optional (mode (current-mode 'small-web)))
-  (let ((elements (phos/gemtext:parse-string body))
-        (spinneret::*html-style* :tree))
-    (spinneret:with-html-string
-      (:style (style (buffer mode)))
-      (:style (style mode))
-      (loop for element in elements
-            collect (:raw (line->html element))))))

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -53,6 +53,7 @@ Gemini support is a bit more chaotic, but you can override `line->html' for
   ((rememberable-p nil)
    (url :documentation "The URL being opened.")
    (model :documentation "The contents of the current page.")
+   (redirections nil :documentation "The list of redirection Gemini URLs.")
    (search-engines
     '()
     :type list

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -715,23 +715,23 @@ See `gtk-browser's `modifier-translator' slot."
   (sera:mvlet* ((url (webkit:webkit-uri-scheme-request-get-uri request))
                 (buffer (find (webkit:webkit-uri-scheme-request-get-web-view request)
                               (buffer-list) :key #'gtk-object))
-                (status body (phos/gemini:request url)))
+                (status meta body (phos/gemini:request url)))
     (flet ((make-gemini-error-page (title)
              (spinneret:with-html-string
                (:h1 title)
-               (:pre (second status)))))
-      (case (first status)
+               (:pre meta))))
+      (case status
         ((:input :sensitive-input)
          (let ((text (quri:url-encode
                       (handler-case
-                          (prompt1 :prompt (second status)
+                          (prompt1 :prompt meta
                             :sources (list (make-instance 'prompter:raw-source))
-                            :invisible-input-p (eq (first status) :sensitive-input))
+                            :invisible-input-p (eq status :sensitive-input))
                         (nyxt-prompt-buffer-canceled () "")))))
            (buffer-load (str:concat url "?" text) :buffer buffer)))
-        (:success (if (str:starts-with-p "text/gemini" (second status))
+        (:success (if (str:starts-with-p "text/gemini" meta)
                       (gemini-render body)
-                      (values body (second status))))
+                      (values body meta)))
         ((:temporary-failure :server-unavailable :cgi-error :proxy-error :slow-down
                              :permanent-failure :not-found :gone :proxy-request-refused :bad-request)
          (make-gemini-error-page

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -692,7 +692,14 @@ See `gtk-browser's `modifier-translator' slot."
            (buffer-load (str:concat url "?" text) :buffer buffer)))
         (:success
          (if (str:starts-with-p "text/gemini" meta)
-             (nyxt/small-web-mode:gemini-render body)
+             (let ((mode (current-mode 'small-web))
+                   (elements (phos/gemtext:parse-string body))
+                   (spinneret::*html-style* :tree))
+               (spinneret:with-html-string
+                (:style (style buffer))
+                (:style (style mode))
+                (loop for element in elements
+                      collect (:raw (nyxt/small-web-mode:line->html element)))))
              (values body meta)))
         ((:redirect :permanent-redirect)
          (push url (nyxt/small-web-mode:redirections (current-mode 'small-web)))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -674,7 +674,6 @@ See `gtk-browser's `modifier-translator' slot."
                                           (make-gemini-error-page
                                            "Malformed response"
                                            (format nil "The response for the URL you're requesting (~s) is malformed.
-Make sure you have typed it right.
 
 ~a"
                                                    url e)))))))
@@ -697,11 +696,13 @@ Make sure you have typed it right.
              (values body meta)))
         ((:redirect :permanent-redirect)
          (push url (nyxt/small-web-mode:redirections (current-mode 'small-web)))
-         (if (< (length (nyxt/small-web-mode:redirections (current-mode 'small-web))) 5)
+         (if (< (length (nyxt/small-web-mode:redirections (current-mode 'small-web)))
+                (nyxt/small-web-mode:allowed-redirections-count (current-mode 'small-web)))
              (buffer-load (quri:merge-uris (quri:uri meta) (quri:uri url)) :buffer buffer)
              (make-gemini-error-page
               "Error"
-              (format nil "The server has caused too much (5+) redirections.~& ~a~{ -> ~a~}"
+              (format nil "The server has caused too much (~a+) redirections.~& ~a~{ -> ~a~}"
+                      (nyxt/small-web-mode:allowed-redirections-count (current-mode 'small-web))
                       (alex:lastcar (nyxt/small-web-mode:redirections (current-mode 'small-web)))
                       (butlast (nyxt/small-web-mode:redirections (current-mode 'small-web)))))))
         ((:temporary-failure :server-unavailable :cgi-error :proxy-error

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -716,18 +716,29 @@ See `gtk-browser's `modifier-translator' slot."
                 (buffer (find (webkit:webkit-uri-scheme-request-get-web-view request)
                               (buffer-list) :key #'gtk-object))
                 (status body (phos/gemini:request url)))
-    (case (first status)
-      (:success (if (str:starts-with-p "text/gemini" (second status))
-                    (gemini-render body)
-                    (values body (second status))))
-      ((:input :sensitive-input)
-       (let ((text (quri:url-encode
-                    (handler-case
-                        (prompt1 :prompt (second status)
-                          :sources (list (make-instance 'prompter:raw-source))
-                          :invisible-input-p (eq (first status) :sensitive-input))
-                      (nyxt-prompt-buffer-canceled () "")))))
-         (buffer-load (str:concat url "?" text) :buffer buffer))))))
+    (flet ((make-gemini-error-page (title)
+             (spinneret:with-html-string
+               (:h1 title)
+               (:pre (second status)))))
+      (case (first status)
+        ((:input :sensitive-input)
+         (let ((text (quri:url-encode
+                      (handler-case
+                          (prompt1 :prompt (second status)
+                            :sources (list (make-instance 'prompter:raw-source))
+                            :invisible-input-p (eq (first status) :sensitive-input))
+                        (nyxt-prompt-buffer-canceled () "")))))
+           (buffer-load (str:concat url "?" text) :buffer buffer)))
+        (:success (if (str:starts-with-p "text/gemini" (second status))
+                      (gemini-render body)
+                      (values body (second status))))
+        ((:temporary-failure :server-unavailable :cgi-error :proxy-error :slow-down
+                             :permanent-failure :not-found :gone :proxy-request-refused :bad-request)
+         (make-gemini-error-page
+          "Error"))
+        ((:client-certificate-required :certificate-not-authorised :certificate-not-valid)
+         (make-gemini-error-page
+          "Certificate error"))))))
 
 (defun sequence-p (object)
   "Return true if OBJECT is a sequence that's not a string."

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -656,51 +656,51 @@ See `gtk-browser's `modifier-translator' slot."
                         :key #'gtk-object))
     (nyxt/gopher-mode:render line)))
 
-(defmethod element->html ((element phos/gemtext:element) (elements-after list) previous-element)
+(defmethod element->html ((element gemtext:element) (elements-after list) previous-element)
   (declare (ignore elements-after previous-element))
   (spinneret:with-html-string
-    (:pre (slot-value element 'phos/gemtext:text))))
+    (:pre (gemtext:text element))))
 
-(defmethod element->html ((element phos/gemtext:paragraph) (elements-after list) previous-element)
+(defmethod element->html ((element gemtext:paragraph) (elements-after list) previous-element)
   (declare (ignore elements-after previous-element))
   (spinneret:with-html-string
-    (:p (slot-value element 'phos/gemtext:text))))
+    (:p (gemtext:text element))))
 
-(defmethod element->html ((element phos/gemtext:title) (elements-after list) previous-element)
+(defmethod element->html ((element gemtext:title) (elements-after list) previous-element)
   (declare (ignore elements-after previous-element))
   (spinneret:with-html-string
-    (case (slot-value element 'phos/gemtext:level)
-      (1 (:h1 (slot-value element 'phos/gemtext:text)))
-      (2 (:h2 (slot-value element 'phos/gemtext:text)))
-      (3 (:h3 (slot-value element 'phos/gemtext:text))))))
+    (case (gemtext:level element)
+      (1 (:h1 (gemtext:text element)))
+      (2 (:h2 (gemtext:text element)))
+      (3 (:h3 (gemtext:text element))))))
 
-(defmethod element->html ((element phos/gemtext:item) (elements-after list) previous-element)
+(defmethod element->html ((element gemtext:item) (elements-after list) previous-element)
   (spinneret:with-html-string
-    (unless (typep previous-element 'phos/gemtext:item)
+    (unless (gemtext:item-p previous-element)
       (:ul (loop for elt in (cons element elements-after)
-                 until (not (typep elt 'phos/gemtext:item))
-                 collect (:li (slot-value elt 'phos/gemtext:text)))))))
+                 until (not (gemtext:item-p elt))
+                 collect (:li (gemtext:text elt)))))))
 
-(defmethod element->html ((element phos/gemtext:link) (elements-after list) previous-element)
+(defmethod element->html ((element gemtext:link) (elements-after list) previous-element)
   (declare (ignore elements-after previous-element))
   (spinneret:with-html-string
-    (let* ((path (quri:uri-path (quri:uri (slot-value element 'phos/gemtext:url))))
+    (let* ((path (quri:uri-path (gemtext:url element)))
            (mime (mimes:mime-lookup path)))
       (cond
         ((str:starts-with-p "image/" mime)
-         (:a :href (slot-value element 'phos/gemtext:url)
-             (:img :src (slot-value element 'phos/gemtext:url)
-                   :alt (slot-value element 'phos/gemtext:text))))
+         (:a :href (render-url (gemtext:url element))
+             (:img :src (render-url (gemtext:url element))
+                   :alt (gemtext:text element))))
         ((str:starts-with-p "audio/" mime)
-         (:audio :src (slot-value element 'phos/gemtext:url)
+         (:audio :src (render-url (gemtext:url element))
                  :controls t
-                 (slot-value element 'phos/gemtext:text)))
+                 (gemtext:text element)))
         ((str:starts-with-p "video/" mime)
-         (:video :src (slot-value element 'phos/gemtext:url)
+         (:video :src (render-url (gemtext:url element))
                  :controls t))
         (t (:a :class "button"
-               :href (slot-value element 'phos/gemtext:url)
-               (slot-value element 'phos/gemtext:text)))))
+               :href (render-url (gemtext:url element))
+               (gemtext:text element)))))
     (:br)))
 
 (defun gemini-render (body)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -656,6 +656,67 @@ See `gtk-browser's `modifier-translator' slot."
                         :key #'gtk-object))
     (nyxt/gopher-mode:render line)))
 
+(defun gemini-render (body)
+  (let ((elements (phos/gemtext:parse-string body)))
+    (spinneret:with-html-string
+      (loop for elements-tail on elements
+            and element = (first elements-tail)
+            and prev = nil then element
+            collect (typecase element
+                      (phos/gemtext:paragraph
+                       (:p (slot-value element 'phos/gemtext:text)))
+                      (phos/gemtext:title
+                       (case (slot-value element 'phos/gemtext:level)
+                         (1 (:h1 (slot-value element 'phos/gemtext:text)))
+                         (2 (:h2 (slot-value element 'phos/gemtext:text)))
+                         (3 (:h3 (slot-value element 'phos/gemtext:text)))))
+                      (phos/gemtext:item
+                       (unless (typep prev 'phos/gemtext:item)
+                         (:ul (loop for elt in elements-tail
+                                    until (not (typep elt 'phos/gemtext:item))
+                                    collect (:li (slot-value elt 'phos/gemtext:text))))))
+                      (phos/gemtext:link
+                       (let* ((path (quri:uri-path (quri:uri (slot-value element 'phos/gemtext:url))))
+                              (mime (mimes:mime-lookup path)))
+                         (cond
+                           ((str:starts-with-p "image/" mime)
+                            (:a :href (slot-value element 'phos/gemtext:url)
+                                (:img :src (slot-value element 'phos/gemtext:url)
+                                      :alt (slot-value element 'phos/gemtext:text))))
+                           ((str:starts-with-p "audio/" mime)
+                            (:audio :src (slot-value element 'phos/gemtext:url)
+                                    :controls t
+                                    (slot-value element 'phos/gemtext:text)))
+                           ((str:starts-with-p "video/" mime)
+                            (:video :src (slot-value element 'phos/gemtext:url)
+                                    :controls t))
+                           (t (:a :class "button"
+                                  :href (slot-value element 'phos/gemtext:url)
+                                  (slot-value element 'phos/gemtext:text)))))
+                       (:br))
+                      (phos/gemtext:verbatim
+                       (:pre (slot-value element 'phos/gemtext:text)))
+                      (phos/gemtext:blockquote
+                       (:pre (slot-value element 'phos/gemtext:text))))))))
+
+(defun process-gemini-scheme (request)
+  (sera:mvlet* ((url (webkit:webkit-uri-scheme-request-get-uri request))
+                (buffer (find (webkit:webkit-uri-scheme-request-get-web-view request)
+                              (buffer-list) :key #'gtk-object))
+                (status body (phos/gemini:request url)))
+    (case (first status)
+      (:success (if (str:starts-with-p "text/gemini" (second status))
+                    (gemini-render body)
+                    (values body (second status))))
+      ((:input :sensitive-input)
+       (let ((text (quri:url-encode
+                    (handler-case
+                        (prompt1 :prompt (second status)
+                          :sources (list (make-instance 'prompter:raw-source))
+                          :invisible-input-p (eq (first status) :sensitive-input))
+                      (nyxt-prompt-buffer-canceled () "")))))
+         (buffer-load (str:concat url "?" text) :buffer buffer))))))
+
 (defun sequence-p (object)
   "Return true if OBJECT is a sequence that's not a string."
   (typep object '(and sequence (not string))))
@@ -783,6 +844,11 @@ See `gtk-browser's `modifier-translator' slot."
        #'process-gopher-scheme
        (lambda (condition)
          (echo-warning "Error while routing \"gopher:\" URL: ~a" condition)))
+      (webkit:webkit-web-context-register-uri-scheme-callback
+       context "gemini"
+       #'process-gemini-scheme
+       (lambda (condition)
+         (echo-warning "Error while routing \"gemini:\" URL: ~a" condition)))
       (webkit:webkit-security-manager-register-uri-scheme-as-local
        (webkit:webkit-web-context-get-security-manager context) "nyxt")
       (webkit:webkit-security-manager-register-uri-scheme-as-cors-enabled

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -703,11 +703,6 @@ See `gtk-browser's `modifier-translator' slot."
                (slot-value element 'phos/gemtext:text)))))
     (:br)))
 
-(defmethod element->html ((element phos/gemtext:verbatim) (elements-after list) previous-element)
-  (declare (ignore elements-after previous-element))
-  (spinneret:with-html-string
-    (:pre (slot-value element 'phos/gemtext:text))))
-
 (defun gemini-render (body)
   (let ((elements (phos/gemtext:parse-string body)))
     (spinneret:with-html-string

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -83,7 +83,7 @@ The domain name existence is verified only if CHECK-DNS-P is T. Domain
 name validation may take significant time since it looks up the DNS."
   ;; List of URI schemes: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
   ;; Last updated 2020-08-26.
-  (let* ((nyxt-schemes '("nyxt" "lisp" "web-extension" "javascript"))
+  (let* ((nyxt-schemes '("nyxt" "lisp" "web-extension" "javascript" "gemini"))
          (iana-schemes
            '("aaa" "aaas" "about" "acap" "acct" "cap" "cid" "coap" "coap+tcp" "coap+ws"
              "coaps" "coaps+tcp" "coaps+ws" "crid" "data" "dav" "dict" "dns" "example" "file"


### PR DESCRIPTION
This allows us to browse pretty-formatted Gemini pages, see images/videos, listen to audio and interact with Gemini input pages. It's most probably 90% of what proper Gemini client should do.

# What's new
- WebKit-friendly support for `gemini:` scheme.
- Dependency on `phos` for gemini requests.

# To do:
- [x] Support redirections.
- [x] Control number of redirections (should it happen on the phos side?)
- [ ] Allow self-signed certs (phos too?)
- [x] Process `phos`, `usocket` &c. conditions & errors.
- [x] Make error pages for all the Gemini error codes (4x-6x) there are.
- [x] Unite Gopher and Gemini support into `small-web-mode` (a different name?), as they share a lot of rendering and interaction code.

How does it look?