### PR TITLE
Refactor file management into a separate mode.

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -125,13 +125,13 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                (:file "history")
                (:file "autofill")
                (:file "external-editor")
-               (:file "file-manager")
                #+quicklisp
                (:file "lisp-system")
                ;; Core Modes
                (:file "mode/auto")
                (:file "mode/input-edit")
                (:file "mode/prompt-buffer")
+               (:file "mode/file-manager")
                (:file "mode/editor")
                (:file "mode/plaintext-editor")
                (:file "mode/buffer-listing")

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -119,8 +119,6 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                (:file "prompt-buffer")
                (:file "command-commands")
                (:file "recent-buffers")
-               (:file "password")
-               (:file "bookmark")
                (:file "annotate")
                (:file "history")
                (:file "autofill")
@@ -132,6 +130,9 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                (:file "mode/input-edit")
                (:file "mode/prompt-buffer")
                (:file "mode/file-manager")
+               ;; Not modes, but depend on file-manager-mode.
+               (:file "password")
+               (:file "bookmark")
                (:file "mode/editor")
                (:file "mode/plaintext-editor")
                (:file "mode/buffer-listing")

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -357,11 +357,12 @@ rest in background buffers."
                        (prompt1
                          ;; TODO: Is there a more intuitive directory for bookmarks?
                          :input (uiop:native-namestring (uiop:getcwd))
+                         :extra-modes '(nyxt/file-manager-mode:file-manager-mode)
                          :sources (make-instance
-                                   'user-file-source
+                                   'nyxt/file-manager-mode:user-file-source
                                    :filter-preprocessor
-                                   (make-file-source-preprocessor
-                                    (alex:disjoin (match-extension "html")
+                                   (nyxt/file-manager-mode::make-file-source-preprocessor
+                                    (alex:disjoin (nyxt/file-manager-mode::match-extension "html")
                                                   #'uiop:directory-pathname-p)))))))
     (if (and (uiop:file-exists-p html-file)
              (equal (pathname-type html-file) "html"))

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -360,10 +360,7 @@ rest in background buffers."
                          :extra-modes '(nyxt/file-manager-mode:file-manager-mode)
                          :sources (make-instance
                                    'nyxt/file-manager-mode:user-file-source
-                                   :filter-preprocessor
-                                   (nyxt/file-manager-mode::make-file-source-preprocessor
-                                    (alex:disjoin (nyxt/file-manager-mode::match-extension "html")
-                                                  #'uiop:directory-pathname-p)))))))
+                                   :extensions '("html"))))))
     (if (and (uiop:file-exists-p html-file)
              (equal (pathname-type html-file) "html"))
         (with-open-file (in-html html-file :external-format :utf-8)

--- a/source/mode/base.lisp
+++ b/source/mode/base.lisp
@@ -62,7 +62,7 @@ This mode is a good candidate to be passed to `make-buffer'."
        "C-shift-t" 'reopen-buffer
        "C-T" 'reopen-buffer
        "C-p" 'print-buffer
-       "C-o" 'open-file)
+       "C-o" 'nyxt/file-manager-mode:open-file)
 
       scheme:emacs
       (list
@@ -97,7 +97,7 @@ This mode is a good candidate to be passed to `make-buffer'."
        "C-x 5 2" 'make-window
        "C-x 5 0" 'delete-current-window
        "C-x 5 1" 'delete-window
-       "C-x C-f" 'open-file)
+       "C-x C-f" 'nyxt/file-manager-mode:open-file)
 
       scheme:vi-normal
       (list

--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -172,4 +172,4 @@ download."
 
 (define-command download-open-file ()
   "Open file in Nyxt or externally."
-  (open-file :default-directory (expand-path (download-path (current-buffer)))))
+  (nyxt/file-manager-mode:open-file :default-directory (expand-path (download-path (current-buffer)))))

--- a/source/mode/editor.lisp
+++ b/source/mode/editor.lisp
@@ -65,9 +65,10 @@ get/set-content (which is necessary for operation)."
   "Open a file in the internal editor."
   (let ((file (prompt1
                 :prompt "Open file"
+                :extra-modes '(nyxt/file-manager-mode:file-manager-mode)
                 :input (uiop:native-namestring (uiop:getcwd))
                 :sources
-                (list (make-instance 'user-file-source
+                (list (make-instance 'nyxt/file-manager-mode:user-file-source
                                      :name "Absolute file path"
                                      :actions '(identity))
                       (make-instance 'prompter:raw-source

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -159,8 +159,7 @@ See `supported-media-types' of `file-mode'."
                  (let* ((program (prompt1
                                    :prompt "The program to open the selected files with"
                                    :sources (list (make-instance 'user-program-source)))))
-                   (dolist (file files)
-                     (uiop:launch-program (list program (namestring file)))))))
+                   (uiop:launch-program (cons (uiop:native-namestring program) (mapcar #'uiop:native-namestring files))))))
          (slot-value source 'prompter:actions))))
 
 #+linux

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -77,7 +77,7 @@
   "Return non-nil if FILE is executable for USER name.
 When the user is unspecified, take the current one."
   (sera:true
-   ;; FIXME: Some files (like /usr/bin/[) cause IOLIB to choke on ENOENT.
+   ;; FIXME: Some files cause IOLIB to choke on ENOENT.
    (let ((permissions (ignore-errors (iolib/os:file-permissions file))))
      (or (and (string= (file-author file)
                        user)

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -95,7 +95,7 @@ When the user is unspecified, take the current one."
      (remove-if
       #'uiop:hidden-pathname-p
       (mapcar #'uiop:resolve-symlinks
-              (alex:mappend (lambda (path) (uiop:directory-files path)) paths))))))
+              (alex:mappend #'uiop:directory-files paths))))))
 
 (define-class program-source (prompter:source)
   ((prompter:name "Programs")

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -77,12 +77,11 @@
   "Return non-nil if FILE is executable for USER name.
 When the user is unspecified, take the current one."
   (sera:true
-   ;; FIXME: Some files cause IOLIB to choke on ENOENT.
-   (let ((permissions (ignore-errors (iolib/os:file-permissions file))))
-     (or (and (string= (file-author file)
-                       user)
+   (let* ((filename (uiop:native-namestring file))
+          (permissions (iolib/os:file-permissions filename)))
+     (or (and (string= (file-author file) user)
               (member :user-exec permissions))
-         (and (= (file-group-id file)
+         (and (= (file-group-id filename)
                  (group-id user))
               (member :group-exec permissions))
          (member :other-exec permissions)))))

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -34,8 +34,9 @@
 (defun directory-elements (directory)
   "Return list of all the files and subdirectories inside DIRECTORY."
   (let ((directory (pathname directory)))
-    (append (uiop:subdirectories directory)
-            (uiop:directory-files directory))))
+    (mapcar #'uiop:resolve-symlinks
+            (append (uiop:subdirectories directory)
+                    (uiop:directory-files directory)))))
 
 (export-always 'recursive-directory-elements)
 (defun recursive-directory-elements (directory &key include-directories-p)

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -5,7 +5,7 @@
   (:use :common-lisp :nyxt)
   (:import-from #:keymap #:define-key #:define-scheme)
   (:import-from #:class-star #:define-class)
-  (:import-from #:serapeum #:export-always)
+  (:import-from #:serapeum #:export-always #:->)
   (:documentation "Mode for file choosing prompt buffer"))
 (in-package :nyxt/file-manager-mode)
 (use-nyxt-package-nicknames)
@@ -73,7 +73,7 @@
   #-sbcl
   (osicat-posix:stat-gid (osicat-posix:lstat file)))
 
-(sera:-> executable-p ((or trivial-types:pathname-designator) &key (:user string)) boolean)
+(-> executable-p ((or trivial-types:pathname-designator) &key (:user string)) boolean)
 (defun executable-p (file &key (user (current-user)))
   "Return non-nil if FILE is executable for USER name.
 When the user is unspecified, take the current one."

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -34,9 +34,8 @@
 (defun directory-elements (directory)
   "Return list of all the files and subdirectories inside DIRECTORY."
   (let ((directory (pathname directory)))
-    (mapcar #'uiop:resolve-symlinks
-            (append (uiop:subdirectories directory)
-                    (uiop:directory-files directory)))))
+    (append (uiop:subdirectories directory)
+            (uiop:directory-files directory))))
 
 (export-always 'recursive-directory-elements)
 (defun recursive-directory-elements (directory &key include-directories-p)

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -143,7 +143,7 @@ See `supported-media-types' of `file-mode'."
   (setf (slot-value source 'prompter:actions)
         (append
          (list (make-command open-file* (files)
-                 "Opens the file with `open-file-function' (a sensible default)."
+                 "Open files with `open-file-function' (a sensible default)."
                  (let* ((new-buffer-p (open-file-in-new-buffer-p source)))
                    ;; Open first file according to `open-file-in-new-buffer-p'
                    (funcall (open-file-function source) (first files)
@@ -155,7 +155,7 @@ See `supported-media-types' of `file-mode'."
                               :new-buffer-p t
                               :supported-p (supported-media-or-directory file source)))))
                (make-command open-with* (files)
-                 "Open the file with selected program."
+                 "Open files with the selected program."
                  (let* ((program (prompt1
                                    :prompt "The program to open the selected files with"
                                    :sources (list (make-instance 'user-program-source)))))

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -87,11 +87,12 @@ for which the `executable' slot is non-nil."
                   (uiop:native-namestring
                    (prompt1
                      :prompt "Password file"
+                     :extra-modes '(nyxt/file-manager-mode:file-manager-mode)
                      :sources (list (make-instance
-                                     'user-file-source
+                                     'nyxt/file-manager-mode:user-file-source
                                      :filter-preprocessor
-                                     (make-file-source-preprocessor
-                                      (alex:disjoin (match-extension "kdbx")
+                                     (nyxt/file-manager-mode::make-file-source-preprocessor
+                                      (alex:disjoin (nyxt/file-manager-mode::match-extension "kdbx")
                                                     #'uiop:directory-pathname-p))))))))
   (loop :until (password:password-correct-p password-interface)
         :do (setf (password::master-password password-interface)

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -90,10 +90,7 @@ for which the `executable' slot is non-nil."
                      :extra-modes '(nyxt/file-manager-mode:file-manager-mode)
                      :sources (list (make-instance
                                      'nyxt/file-manager-mode:user-file-source
-                                     :filter-preprocessor
-                                     (nyxt/file-manager-mode::make-file-source-preprocessor
-                                      (alex:disjoin (nyxt/file-manager-mode::match-extension "kdbx")
-                                                    #'uiop:directory-pathname-p))))))))
+                                     :extensions '("kdbx")))))))
   (loop :until (password:password-correct-p password-interface)
         :do (setf (password::master-password password-interface)
                   (prompt1

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1040,7 +1040,8 @@ See `gtk-browser's `modifier-translator' slot."
                                             (webkit:webkit-file-chooser-request-selected-files
                                              file-chooser-request)))
                                           (uiop:native-namestring (uiop:getcwd)))
-                                  :sources (list (make-instance 'file-source)))
+                                  :extra-modes '(nyxt/file-manager-mode:file-manager-mode)
+                                  :sources (list (make-instance 'nyxt/file-manager-mode:user-file-source)))
                         (nyxt-prompt-buffer-canceled ()
                           nil)))))
           (if files

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -284,8 +284,9 @@ Return the short error message and the full error message as second value."
            (alex:if-let ((init-path (expand-path *init-file-path*)))
              (uiop:pathname-directory-pathname (pathname init-path))
              (uiop:getcwd)))
+   :extra-modes '(nyxt/file-manager-mode:file-manager-mode)
    :sources
-   (make-instance 'user-file-source
+   (make-instance 'nyxt/file-manager-mode:user-file-source
                   :actions (list (make-command load-file* (files)
                                                (dolist (file files)
                                                  (load-lisp file)))))))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -287,6 +287,7 @@ Return the short error message and the full error message as second value."
    :extra-modes '(nyxt/file-manager-mode:file-manager-mode)
    :sources
    (make-instance 'nyxt/file-manager-mode:user-file-source
+                  :extensions '("lisp")
                   :actions (list (make-command load-file* (files)
                                                (dolist (file files)
                                                  (load-lisp file)))))))

--- a/source/web-extensions.lisp
+++ b/source/web-extensions.lisp
@@ -264,7 +264,8 @@ Value is the loadable URL of that file.")
                                            (if (equal (mimes:mime file) "text/html")
                                                (format nil "file://~a" file)
                                                (make-data-url file)))))
-                                 (recursive-directory-elements (extension-directory mode)))))))))
+                                 (nyxt/file-manager-mode:recursive-directory-elements
+                                  (extension-directory mode)))))))))
 
 (export-always 'has-permission-p)
 (defmethod has-permission-p ((extension extension) (permission string))


### PR DESCRIPTION
This puts all the Nyxt-specific file management utilities under the `nyxt/file-manager-mode` package and uses the newly re-introduced `file-manager-mode` as the auxiliary mode when prompting for files.

# What's New:
- `file-manager-mode` -- a prompt-buffer mode for file search. Not much there yet.
- `C-backspace` (CUA) and `C-l` (Emacs) strip one level of nesting from the currently inputted pathname.
- An ad-hoc search for executables to open the file with: `program-source`.

# Things to Discuss
How do we discover executables portably?

Closes #1219?