### PR TITLE
fix type error with NYXT_COMPRESS

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -398,7 +398,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
   (defmethod perform ((o image-op) (c system))
     (uiop:dump-image (output-file o c)
                      :executable t
-                     :compression (uiop:getenv "NYXT_COMPRESS"))))
+                     :compression (parse-integer (uiop:getenv "NYXT_COMPRESS")))))
 
 (defmethod perform :before ((o image-op) (c system))
   "Register immutable systems to prevent compiled images of Nyxt from


### PR DESCRIPTION
Fixes:
```
Unhandled SIMPLE-TYPE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                         {100180C293}>:
  The value of SB-IMPL::COMPRESSION is "6", which is not of type (OR BOOLEAN
                                                                     (INTEGER
                                                                      -1 9)).
```