### PR TITLE
Headless mode (#1354) rebase

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -357,7 +357,15 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                cl-gobject-introspection
                bordeaux-threads)
   :pathname "source/"
-  :components ((:file "renderer/gi-gtk")))
+  :components ((:file "renderer/gi-gtk"))
+  :in-order-to ((test-op (test-op "nyxt/gobject/gtk/tests"))))
+
+(defsystem "nyxt/gobject/gtk/tests"
+  :depends-on (nyxt/gobject/gtk prove)
+  :components ((:file "tests/renderer-package"))
+  :perform (test-op (op c)
+                    (nyxt-run-test c "tests/renderer-offline/")
+                    (nyxt-run-test c "tests/renderer-online/" :network-needed-p t)))
 
 (defsystem "nyxt/qt"
   :depends-on (nyxt

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -13,6 +13,10 @@
 This is useful when the browser is run from a REPL so that quitting does not
 close the connection.")
 
+(defvar *headless-p* nil
+  "If non-nil, don't display anything.
+This is convenient for testing purposes or to drive Nyxt programmatically.")
+
 (export-always '*browser*)
 (defvar *browser* nil
   "The entry-point object to a complete instance of Nyxt.

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -185,6 +185,7 @@ See also `hide-prompt-buffer'."
   ;; TODO: Add method that returns if there is only 1 source with no filter.
   (when prompt-buffer
     (push prompt-buffer (active-prompt-buffers (window prompt-buffer)))
+    (calispel:! (prompt-buffer-channel (window prompt-buffer)) prompt-buffer)
     (prompt-render prompt-buffer)
     (run-thread "Show prompt watcher"
       (let ((prompt-buffer prompt-buffer))
@@ -202,6 +203,8 @@ See also `show-prompt-buffer'."
     ;; Note that PROMPT-BUFFER is not necessarily first in the list, e.g. a new
     ;; prompt-buffer was invoked before the old one reaches here.
     (alex:deletef (active-prompt-buffers window) prompt-buffer)
+    ;; The channel values are irrelevant, so is the element order:
+    (calispel:? (prompt-buffer-channel (window prompt-buffer)) 0)
     (if (resumable-p prompt-buffer)
         (flet ((prompter= (prompter1 prompter2)
                  (and (string= (prompter:prompt prompter1)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -368,7 +368,8 @@ response.  The BODY is wrapped with `with-protect'."
 
        (gtk:gtk-container-add gtk-object root-box-layout)
        (setf (slot-value *browser* 'last-active-window) window)
-       (gtk:gtk-widget-show-all gtk-object)
+       (unless *headless-p*
+         (gtk:gtk-widget-show-all gtk-object))
        (connect-signal window "key_press_event" nil (widget event)
          (declare (ignore widget))
          #+darwin
@@ -1058,7 +1059,8 @@ See `gtk-browser's `modifier-translator' slot."
   (let ((old-buffer (active-buffer window)))
     (gtk:gtk-container-remove (main-buffer-container window) (gtk-object old-buffer))
     (gtk:gtk-box-pack-start (main-buffer-container window) (gtk-object buffer) :expand t :fill t)
-    (gtk:gtk-widget-show (gtk-object buffer))
+    (unless *headless-p*
+      (gtk:gtk-widget-show (gtk-object buffer)))
     (when focus
       (gtk:gtk-widget-grab-focus (gtk-object buffer)))
     (nyxt/web-extensions::tabs-on-activated old-buffer buffer)
@@ -1076,7 +1078,8 @@ See `gtk-browser's `modifier-translator' slot."
             (push buffer (panel-buffers-right window))))
   (setf (gtk:gtk-widget-size-request (gtk-object buffer))
         (list (width buffer) -1))
-  (gtk:gtk-widget-show (gtk-object buffer)))
+  (unless *headless-p*
+    (gtk:gtk-widget-show (gtk-object buffer))))
 
 (define-ffi-method ffi-window-set-panel-buffer-width ((window gtk-window) (buffer panel-buffer) width)
   "Set the width of a panel buffer."

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -21,6 +21,13 @@ It's a function of the window argument that returns the title as a string.")
     (list)
     :export nil
     :documentation "A list of panel buffers appearing on the window.")
+   (prompt-buffer-channel
+    (make-channel) ; TODO: Rename `prompt-buffer-ready-channel'?
+    :export nil
+    :documentation "A channel one may listen to if waiting
+for the prompt buffer to be available.
+You should not rely on the value of this channel.
+The channel is popped when a prompt buffer is hidden.")
    (key-stack
     '()
     :documentation "A stack of the key chords a user has pressed.")
@@ -34,6 +41,7 @@ It's a function of the window argument that returns the title as a string.")
     :export nil
     :type boolean
     :documentation "Whether the window is displayed in fullscreen.")
+   ;; TODO: each frame should have a status buffer, not each window
    (status-buffer
     :export nil)
    (message-buffer-height

--- a/tests/renderer-online/set-url.lisp
+++ b/tests/renderer-online/set-url.lisp
@@ -1,0 +1,46 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nyxt/tests/renderer)
+
+(plan nil)
+
+(class-star:define-class nyxt-user::test-data-profile (nyxt:data-profile)
+  ((nyxt:name :initform "test"))
+  (:documentation "Test profile."))
+
+(defmethod nyxt:expand-data-path ((profile nyxt-user::test-data-profile) (path nyxt:data-path))
+  "Don't persist data"
+  nil)
+
+(defmacro with-prompt-buffer-test (command &body body)
+  (alexandria:with-gensyms (thread)
+    `(let ((,thread (bt:make-thread (lambda () ,command))))
+       (calispel:? (prompt-buffer-channel (current-window)))
+       ,@body
+       (return-selection)
+       (bt:join-thread ,thread))))
+
+;; TODO: Use `with-prompt-buffer-test'.
+;; (with-prompt-buffer-test (set-url)
+;;   (set-prompt-input (current-prompt-buffer) "foobar"))
+
+(subtest "set-url"
+  (setf nyxt::*headless-p* t)
+  (nyxt:start :no-init t :no-auto-config t
+              :socket "/tmp/nyxt-test.socket"
+              :data-profile "test")
+  (sleep 2)                             ; TODO: Wait properly.
+  (let ((url "http://example.org/"))
+    (let ((thread (bt:make-thread (lambda () (nyxt:set-url)))))
+      (calispel:? (nyxt::prompt-buffer-channel (nyxt:current-window)))
+      (nyxt::set-prompt-input (nyxt:current-prompt-buffer) url)
+      (prompter:all-ready-p (nyxt:current-prompt-buffer))
+      (nyxt/prompt-buffer-mode:return-selection)
+      ;; (bt:join-thread thread) ; TODO: Make sure thread always returns.
+      )
+    (sleep 1)                           ; TODO: Wait properly.
+    (prove:is (nyxt:render-url (nyxt:url (nyxt:current-buffer)))
+              url)))
+
+(finalize)

--- a/tests/renderer-package.lisp
+++ b/tests/renderer-package.lisp
@@ -1,0 +1,8 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package nyxt/tests/renderer
+  (:use #:common-lisp)
+  (:use #:nyxt)
+  (:use #:prove)
+  (:import-from #:class-star #:define-class))


### PR DESCRIPTION
This is a fresh rebase of #1354. Not much changed -- a good sign of `prompter` having a good and approachable API!

# Things to DIscuss

- Should `prompt-buffer-channel` be a hook, actually?


# Things to do
- [ ] Test it with some non-trivial scripting.
- [ ]  `nyxt-ready-hook` to start interactive commands from.
- [ ] Maybe utility macros to ease scripting? (see Selenium)

Closes #1168.