### PR TITLE
Default auto-mode rules.

### DIFF
--- a/source/mode/auto.lisp
+++ b/source/mode/auto.lisp
@@ -397,7 +397,17 @@ Auto-mode is re-enabled once the page is reloaded."
     (values list &optional))
 (sera:export-always 'add-modes-to-auto-mode-rules)
 (defun add-modes-to-auto-mode-rules (test &key (append-p nil) exclude include (exact-p nil))
-  (with-data-access (rules (auto-mode-rules-path (current-buffer)))
+  (with-data-access
+      (rules (auto-mode-rules-path (current-buffer))
+       :default (list (make-instance 'auto-mode-rule
+                                     :test '(match-scheme "nyxt")
+                                     :excluded '(no-script-mode))
+                      (make-instance 'auto-mode-rule
+                                     :test '(match-scheme "gopher")
+                                     :included '(small-web-mode))
+                      (make-instance 'auto-mode-rule
+                                     :test '(match-scheme "gemini")
+                                     :included '(small-web-mode))))
     (let* ((rule (or (find test rules
                            :key #'test :test #'equal)
                      (make-instance 'auto-mode-rule :test test)))


### PR DESCRIPTION
This is an implementation for #2004 and response to #2060. @Ambrevar, here's how default auto-mode rules look for me as the prototype level.

# What's New
Auto mode rules, if null, will be set to the list of reasonable rules that `small-web-mode` and `no-script-mode` would need  to work properly. 

# To Do: 
Remove the code that simulates this from `small-web-mode`.

# Things to Discuss
Is it alrights that it implies empty auto-mode-rules.lisp file? Long-time users may need to move their file to re-populate it with default rules, but it will cost nothing for new users.
