### PR TITLE
Disambiguate symbol in resolve-backtick-quote-links

### DIFF
--- a/libraries/prompter/filter-preprocessor.lisp
+++ b/libraries/prompter/filter-preprocessor.lisp
@@ -52,3 +52,13 @@ Suitable as a `source' `filter-preprocessor'."
                      (notevery (lambda (sub) (search sub (ensure-match-data-string suggestion source)))
                                words))
                    suggestions))))
+
+(export-always 'filter-exact-match)
+(defun filter-exact-match (suggestions source input)
+  "Return only SUGGESTIONS that are identical to INPUT"
+  (declare (ignore source))
+  (if (str:empty? input)
+      suggestions
+      (delete-if (lambda (suggestion)
+                   (not (string-equal input (attributes-default suggestion))))
+                 suggestions)))

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -421,6 +421,9 @@ suggestions; they only set the `suggestions' once they are done.  Conversely,
 `filter' is passed one suggestion at a time and it updates `suggestions' on each
 call."))
 
+(defmethod default-action ((source source))
+  (first (slot-value source 'actions)))
+
 (define-class yes-no-source (source)
   ((name "Confirm")
    (constructor '("yes" "no"))

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -81,6 +81,12 @@ It's called after the sources are cleaned up.
 
 Note that the function is executed *before* performing an action.")
 
+     (auto-return-p nil
+                    :type boolean
+                    :documentation
+                    "Automatically return and run default action when the
+suggestions are narrowed down to just one item.")
+
      (history (make-history)
               :type (or containers:ring-buffer-reverse null)
               :documentation
@@ -166,6 +172,9 @@ compution is not finished.")))
       (setf (slot-value prompter 'input) text)
       (update-sources prompter text)
       (select-first prompter)))
+  (when (and (auto-return-p prompter)
+             (sera:single (all-suggestions prompter)))
+    (return-selection prompter))
   text)
 
 (export-always 'destroy)

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -489,7 +489,8 @@ suggestions."
   "Return the list of the suggestions in the prompter."
   (alex:mappend #'suggestions (sources prompter)))
 
-(defun default-action (prompter)
+(export-always 'default-action)
+(defmethod default-action ((prompter prompter))
   (first (actions prompter)))
 
 (export-always 'resume)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -122,7 +122,14 @@ When INPUT does not have a unique match, prompt for the list of exact matches."
                   (symbol (let ((*package* (symbol-package parent-symbol)))
                             (read-from-string name)))
                   (url (when symbol
-                         (ps:ps (nyxt/ps:lisp-eval `(nyxt::describe-any ,(princ-to-string symbol)))))))
+                         (let ((old-indent ps:*indent-num-spaces*)
+                               (old-pring-pretty ps:*ps-print-pretty*))
+                           ;; Set those for all of Nyxt?
+                           (setf ps:*indent-num-spaces* 0
+                                 ps:*ps-print-pretty* nil)
+                           (ps:ps (nyxt/ps:lisp-eval `(nyxt::describe-any ,(princ-to-string symbol))))
+                           (setf ps:*indent-num-spaces* old-indent
+                                 ps:*ps-print-pretty* old-print-pretty)))))
              (spinneret:with-html-string
                (if url
                    (:a :href (javascript-url url)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -104,20 +104,12 @@ If INPUT, narrow down to exact matches of it."
            (let* ((name (subseq target-string (1+ match-start) (1- match-end)))
                   (symbol (let ((*package* (symbol-package parent-symbol)))
                             (read-from-string name)))
-                  (definition (swank-backend:find-definitions symbol))
-                  (type (caaar definition))
-                  (url (if type
-                           (cond
-                             ((eq type 'defvar)
-                              (nyxt-url 'describe-variable :variable symbol))
-                             ((eq type 'defclass)
-                              (nyxt-url 'describe-class :class symbol))
-                             ((member type '(defun defmethod defgeneric))
-                              (nyxt-url 'describe-function :function symbol))
-                             (t nil)))))
+                  (url (when symbol
+                         (ps:ps (nyxt/ps:lisp-eval `(nyxt::describe-any ,(princ-to-string symbol)))))))
              (spinneret:with-html-string
                (if url
-                   (:a :href url (:code name))
+                   (:button :class "button" ; TODO: Can we make it look slimmer?  Maybe more like a link?
+                            :onclick url (:code name))
                    (:code name))))))
     (if string
         ;; FIXME: Spaces are disallowed, but |one can use anything in a symbol|.

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -122,21 +122,15 @@ When INPUT does not have a unique match, prompt for the list of exact matches."
                   (symbol (let ((*package* (symbol-package parent-symbol)))
                             (read-from-string name)))
                   (url (when symbol
-                         (let ((old-indent ps:*indent-num-spaces*)
-                               (old-print-pretty ps:*ps-print-pretty*))
-                           (unwind-protect
-                                (progn
-                                  ;; TODO: Set those for all of Nyxt?
-                                  (setf ps:*indent-num-spaces* 0
-                                        ps:*ps-print-pretty* nil)
-                                  (ps:ps (nyxt/ps:lisp-eval `(nyxt::describe-any ,(princ-to-string symbol)))))
-                             (setf ps:*indent-num-spaces* old-indent
-                                   ps:*ps-print-pretty* old-print-pretty))))))
-             (spinneret:with-html-string
-               (if url
-                   (:a :href (javascript-url url)
-                        (:code name))
-                   (:code name))))))
+                         (ps:ps (nyxt/ps:lisp-eval `(nyxt::describe-any ,(princ-to-string symbol)))))))
+             (let ((*print-pretty* nil))
+               ;; Disable pretty-printing to avoid spurious space insertion within links:
+               ;; https://github.com/ruricolist/spinneret/issues/37#issuecomment-884740046
+               (spinneret:with-html-string
+                 (if url
+                     (:a :href (javascript-url url)
+                         (:code name))
+                     (:code name)))))))
     (if string
         ;; FIXME: Spaces are disallowed, but |one can use anything in a symbol|.
         ;; Maybe allow it?  The problem then is that it increases the chances of

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -109,8 +109,8 @@ If INPUT, narrow down to exact matches of it."
                          (ps:ps (nyxt/ps:lisp-eval `(nyxt::describe-any ,(princ-to-string symbol)))))))
              (spinneret:with-html-string
                (if url
-                   (:button :class "button" ; TODO: Can we make it look slimmer?  Maybe more like a link?
-                            :onclick url (:code name))
+                   (:a :href (javascript-url url)
+                        (:code name))
                    (:code name))))))
     (if string
         ;; FIXME: Spaces are disallowed, but |one can use anything in a symbol|.

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -32,26 +32,36 @@
   ((prompter:name "Variables")
    (prompter:constructor (package-variables))))
 
-(define-command describe-any ()
-  "Inspect anything and show it in a help buffer."
-  (prompt
-   :prompt "Describe:"
-   :sources (list (make-instance 'variable-source
-                                 :actions (list (make-command describe-variable* (variable)
-                                                  (describe-variable :variable variable))))
-                  (make-instance 'function-source
-                                 :actions (list (make-command describe-function* (function)
-                                                  (describe-function :function function))))
-                  (make-instance 'user-command-source
-                                 :actions (list (make-command describe-command* (command)
-                                                  (describe-command :command (name command)))))
-                  (make-instance 'class-source
-                                 :actions (list (make-command describe-class* (class)
-                                                  (describe-class :class class))))
-                  (make-instance 'slot-source
-                                 :actions (list (make-command describe-slot** (slot)
-                                                  (describe-slot :class (class-sym slot)
-                                                                 :name (name slot))))))))
+(define-command describe-any (&optional input)
+  "Inspect anything and show it in a help buffer.
+If INPUT, narrow down to exact matches of it."
+  (let ((preprocessor (if input
+                          'prompter:filter-exact-match
+                          'prompter:delete-inexact-matches)))
+    (prompt
+     :prompt "Describe:"
+     :input input
+     :sources (list (make-instance 'variable-source
+                                   :actions (list (make-command describe-variable* (variable)
+                                                    (describe-variable :variable variable)))
+                                   :filter-preprocessor preprocessor)
+                    (make-instance 'function-source
+                                   :actions (list (make-command describe-function* (function)
+                                                    (describe-function :function function)))
+                                   :filter-preprocessor preprocessor)
+                    (make-instance 'user-command-source
+                                   :actions (list (make-command describe-command* (command)
+                                                    (describe-command :command (name command))))
+                                   :filter-preprocessor preprocessor)
+                    (make-instance 'class-source
+                                   :actions (list (make-command describe-class* (class)
+                                                    (describe-class :class class)))
+                                   :filter-preprocessor preprocessor)
+                    (make-instance 'slot-source
+                                   :actions (list (make-command describe-slot** (slot)
+                                                    (describe-slot :class (class-sym slot)
+                                                                   :name (name slot))))
+                                   :filter-preprocessor preprocessor)))))
 
 (defun value->html (value &key (help-mode (current-mode 'help)))
   "Return the HTML representation of VALUE."

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -42,25 +42,25 @@ If INPUT, narrow down to exact matches of it."
      :prompt "Describe:"
      :input input
      :sources (list (make-instance 'variable-source
-                                   :actions (list (make-command describe-variable* (variable)
-                                                    (describe-variable :variable variable)))
+                                   :actions (list (make-command describe-variable* (variables)
+                                                    (describe-variable :variable (first variables))))
                                    :filter-preprocessor preprocessor)
                     (make-instance 'function-source
-                                   :actions (list (make-command describe-function* (function)
-                                                    (describe-function :function function)))
+                                   :actions (list (make-command describe-function* (functions)
+                                                    (describe-function :function (first functions))))
                                    :filter-preprocessor preprocessor)
                     (make-instance 'user-command-source
-                                   :actions (list (make-command describe-command* (command)
-                                                    (describe-command :command (name command))))
+                                   :actions (list (make-command describe-command* (commands)
+                                                    (describe-command :command (name (first commands)))))
                                    :filter-preprocessor preprocessor)
                     (make-instance 'class-source
-                                   :actions (list (make-command describe-class* (class)
-                                                    (describe-class :class class)))
+                                   :actions (list (make-command describe-class* (classes)
+                                                    (describe-class :class (first classes))))
                                    :filter-preprocessor preprocessor)
                     (make-instance 'slot-source
-                                   :actions (list (make-command describe-slot** (slot)
-                                                    (describe-slot :class (class-sym slot)
-                                                                   :name (name slot))))
+                                   :actions (list (make-command describe-slot** (slots)
+                                                    (describe-slot :class (class-sym (first slots))
+                                                                   :name (name (first slots)))))
                                    :filter-preprocessor preprocessor)))))
 
 (defun value->html (value &key (help-mode (current-mode 'help)))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -116,7 +116,8 @@ If INPUT, narrow down to exact matches of it."
         ;; Maybe allow it?  The problem then is that it increases the chances of
         ;; false-positives when the "`" character is used for other reasons.
         (spinneret:with-html-string
-          (:code (:raw (ppcre:regex-replace-all "`[^'\\s]+'" string #'resolve-regex))))
+          (:pre
+           (:code (:raw (ppcre:regex-replace-all "`[^'\\s]+'" string #'resolve-regex)))))
         "")))
 
 (define-internal-page-command-global describe-variable

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -41,6 +41,7 @@ If INPUT, narrow down to exact matches of it."
     (prompt
      :prompt "Describe:"
      :input input
+     :auto-return-p (not (uiop:emptyp input))
      :sources (list (make-instance 'variable-source
                                    :actions (list (make-command describe-variable* (variables)
                                                     (describe-variable :variable (first variables))))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -123,13 +123,15 @@ When INPUT does not have a unique match, prompt for the list of exact matches."
                             (read-from-string name)))
                   (url (when symbol
                          (let ((old-indent ps:*indent-num-spaces*)
-                               (old-pring-pretty ps:*ps-print-pretty*))
-                           ;; Set those for all of Nyxt?
-                           (setf ps:*indent-num-spaces* 0
-                                 ps:*ps-print-pretty* nil)
-                           (ps:ps (nyxt/ps:lisp-eval `(nyxt::describe-any ,(princ-to-string symbol))))
-                           (setf ps:*indent-num-spaces* old-indent
-                                 ps:*ps-print-pretty* old-print-pretty)))))
+                               (old-print-pretty ps:*ps-print-pretty*))
+                           (unwind-protect
+                                (progn
+                                  ;; TODO: Set those for all of Nyxt?
+                                  (setf ps:*indent-num-spaces* 0
+                                        ps:*ps-print-pretty* nil)
+                                  (ps:ps (nyxt/ps:lisp-eval `(nyxt::describe-any ,(princ-to-string symbol)))))
+                             (setf ps:*indent-num-spaces* old-indent
+                                   ps:*ps-print-pretty* old-print-pretty))))))
              (spinneret:with-html-string
                (if url
                    (:a :href (javascript-url url)

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -309,6 +309,11 @@ Example:
                          params)))
           (error "There's no nyxt:~a page defined" (param-name function-name))))))
 
+(export-always 'javascript-url)
+(defun javascript-url (javascript-string)
+  "Return a string that's a suitable value for an HTML href."
+  (str:concat "javascript:" (quri:url-encode javascript-string)))
+
 (export-always 'internal-url-p)
 (defun internal-url-p (url)
   (string= "nyxt" (quri:uri-scheme (url url))))


### PR DESCRIPTION
This addresses the issue mentioned in https://github.com/atlas-engineer/nyxt/issues/967#issuecomment-1022143645.

## To test:

Run `describe-variable`, find `*after-init-hook*`, then click on `*global*`.
The description of `*global*` should open automatically.

Then run `describe-command`, find `describe-command`, click on `execute-command`.  This time the multiple choices should be prompted.

## To do:

1. Currently the prompt buffer displays for a fraction of a second on single match.  This is normal, since the effect of `auto-return-p` is done after the first source update, which happens after display.

It's a  bit of a hack.  To fix it, we could hide the display until the first update is done.  But then if the update takes a while to complete, the user would get no feedback.  Maybe it's OK to leave it?

2. For now we only list Nyxt-related symbols.  What about symbols from other libraries?  If, say, `sera:single` is in a docstring, it won't be clickable then, which is too bad :p  Maybe we could add an extra parameter to all `describe-*` commands to specify which package to include, where `nil` would mean "all", and the default would be `(nyxt nyxt-user)`.

@aartaka What do you think?