### PR TITLE
Nyxt-native debug on error

### DIFF
--- a/source/global.lisp
+++ b/source/global.lisp
@@ -13,6 +13,11 @@
 This is useful when the browser is run from a REPL so that quitting does not
 close the connection.")
 
+(export-always '*debug-on-error*)
+(defvar *debug-on-error* nil
+  "Whether the Nyxt-internal debugger pops up when an error happens.
+Allows the user to fix immediate errors in runtime, given enough understanding.")
+
 (export-always '*browser*)
 (defvar *browser* nil
   "The entry-point object to a complete instance of Nyxt.

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -629,6 +629,22 @@ evaluate in order."
             until (eq object :eof)
             collect (funcall (lambda () (eval object)))))))
 
+(defmethod prompter:object-attributes ((restart restart))
+  `(("Name" ,(restart-name restart))))
+
+(define-class restarts-source (prompter:source)
+  ((prompter:name "Restarts"))
+  (:export-class-name-p t)
+  (:export-predicate-name-p t))
+
+(defun debug-prompt (condition)
+  (handler-case
+      (prompt1 :prompt (format nil "~a" condition)
+        :sources (list (make-instance 'restarts-source
+                                      :constructor (compute-restarts condition))))
+    (nyxt-prompt-buffer-canceled () 'abort)
+    (error () 'abort)))
+
 (defun error-buffer (&optional (title "Unknown error") (text ""))
   (sera:lret* ((error-buffer (make-instance 'user-web-buffer)))
     (with-current-buffer error-buffer

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -645,6 +645,14 @@ evaluate in order."
     (nyxt-prompt-buffer-canceled () 'abort)
     (error () 'abort)))
 
+(define-command-global toggle-debug-on-error (&key (value nil value-provided-p))
+  "Toggle Nyxt-native debugging.
+
+See `*debug-on-error*'."
+  (if value-provided-p
+      (setf *debug-on-error* value)
+      (setf *debug-on-error* (not *debug-on-error*))))
+
 (defun error-buffer (&optional (title "Unknown error") (text ""))
   (sera:lret* ((error-buffer (make-instance 'user-web-buffer)))
     (with-current-buffer error-buffer

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -629,9 +629,6 @@ evaluate in order."
             until (eq object :eof)
             collect (funcall (lambda () (eval object)))))))
 
-(defmethod prompter:object-attributes ((restart restart))
-  `(("Name" ,(restart-name restart))))
-
 (define-class restarts-source (prompter:source)
   ((prompter:name "Restarts"))
   (:export-class-name-p t)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -629,6 +629,9 @@ evaluate in order."
             until (eq object :eof)
             collect (funcall (lambda () (eval object)))))))
 
+(defmethod prompter:object-attributes ((restart restart))
+  `(("Name" ,(restart-name restart))))
+
 (define-class restarts-source (prompter:source)
   ((prompter:name "Restarts"))
   (:export-class-name-p t))

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -4,5 +4,6 @@
 (uiop:define-package nyxt/tests
   (:use #:common-lisp #:trivia)
   (:use #:nyxt)
+  (:shadowing-import-from #:prove #:*debug-on-error*)
   (:use #:prove)
   (:import-from #:class-star #:define-class))


### PR DESCRIPTION
This adds an ability to catch and process errors in Nyxt itself. Right now it's implemented as a prompt, but alternative designs are welcome (see Things to Discuss below).

# What's new
- `*debug-on-error*` variable to decide on whether to show debigging prompt in Nyxt.
  - `toggle-debug-on-error` command to toggle this variable.
- When `*debug-on-error*` is set and an error is caught, `with-protect` will pop us a prompt showing available restarts and the backtrace, freezing the thread until on of restarts is chosen.

# Things to discuss
- Should we catch conditions too? May be an overkill.
- Should we make the prompt resumable? Right now closing the prompt invokes `abort` restart, which may be too brutal of an action.
- Prompt may be a bad design, especially regarding the backtrace. It's not copyable too.
  - Maybe generate internal pages with restart buttons and backtraces (as discussed with @Ambrevar)? This will require storing all the pending conditions somewhere and manipulating those via nyxt/lisp URLs somehow.

# How to Test
- Run Nyxt with this patch.
- Execute `toggle-debug-on-error` command.
- Provoke some error.
  - For example, open `lisp-repl` and type `(error "some error text")` in it.
- Prompt should appear with a list of restarts and a backtrace.
- Choose the restart you like and enjoy the error being handled :)