### PR TITLE
Lisp scheme: send `null` instead of no response at all?

### DIFF
--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -397,10 +397,11 @@ guarantee of the same result."
                         ;; supports, then we can override the encoding and
                         ;; decoding methods and allow arbitrary objects (like
                         ;; buffers) in the nyxt:// URL arguments..
-                        (when (or (scalar-p result)
-                                  (and (sequence-p result)
-                                       (every #'scalar-p result)))
-                          (cl-json:encode-json-to-string result)))
+                        (cl-json:encode-json-to-string
+                         (when (or (scalar-p result)
+                                   (and (sequence-p result)
+                                        (every #'scalar-p result)))
+                           result)))
                       "application/json"))
             (values "undefined" "application/json;charset=utf8"))))
   :cors-enabled-p t


### PR DESCRIPTION
Hi! Working on bookmarks I spotted a minor bug. When you set log level to `:debug` and try to remove a bookmark using `*Bookmarks*` buffer you'll see this in the error output stream:

~~~~
<DEBUG> [18:30:40] Error when evaluating lisp URL: The value
		                                     NIL
                                                   is not of type
                                                     ARRAY
~~~~

This patch removes these errors by sending `null` response when a result of call to lisp cannot be encoded as a JSON object.