### PR TITLE
Group bookmarks according to tags.

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -163,7 +163,8 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                 :components
                 ((:file "password")
                  (:file "bookmark")
-                 (:file "mode/bookmark-frequent-visits" :depends-on ("bookmark"))))
+                 (:file "mode/bookmark-frequent-visits" :depends-on ("bookmark"))
+                 (:file "mode/bookmark" :depends-on ("bookmark"))))
                (:module "web-mode commands"
                 :pathname "mode"
                 :depends-on ("Core modes" "file-manager-mode deps")

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -109,43 +109,6 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
                            (mapcar #'car (keywords (buffer source))))))
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(define-internal-page-command-global list-bookmarks ()
-    (bookmarks-buffer "*Bookmarks*" 'base-mode)
-  "List all bookmarks in a new buffer."
-  (flet ((html-bookmark-id (id)
-           (format nil "bookmark-~d" id)))
-    (spinneret:with-html-string
-      (:style (style bookmarks-buffer))
-      (:h1 "Bookmarks")
-      (:body
-       (or (with-data-unsafe (bookmarks (bookmarks-path (current-buffer)))
-             (loop for bookmark in bookmarks
-                   for id from 0 by 1
-                   collect
-                   (let ((url-display (render-url (url bookmark)))
-                         (url-href (render-url (url bookmark))))
-                     (:div
-                      :id (html-bookmark-id id)
-                      (:p (:b "Title: ") (title bookmark))
-                      (:p (:b "URL: ") (:a :href url-href
-                                           url-display))
-                      (:p (:b "Tags: ")
-                          (when (tags bookmark)
-                            (format nil " (~{~a~^, ~})" (tags bookmark))))
-                      (:p (:button :class "button"
-                                   :onclick
-                                   (ps:ps
-                                    (let ((element
-                                           (ps:chain
-                                            document
-                                            (get-element-by-id (ps:lisp (html-bookmark-id id))))))
-                                      (ps:chain element parent-node (remove-child element))
-                                      (nyxt/ps:lisp-eval
-                                       `(nyxt::delete-bookmark ,url-href))))
-                                   "Delete"))
-                      (:hr "")))))
-           (format nil "No bookmarks in ~s." (expand-path (bookmarks-path (current-buffer)))))))))
-
 (define-panel-global bookmarks ()
     (panel-buffer "*Bookmarks panel*")
   "Shows all the bookmarks in a compact panel-buffer layout."

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -1,0 +1,72 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(uiop:define-package nyxt/bookmark-mode
+  (:use #:cl #:nyxt)
+  (:import-from #:serapeum #:export-always)
+  (:documentation "Bookmark buffer mode and command"))
+(in-package :nyxt/bookmark-mode)
+
+(export-always 'bookmark-mode)
+(define-mode bookmark-mode ()
+  "Mode for the bookmarks buffer."
+  ((rememberable-p nil)
+   (style (theme:themed-css (theme *browser*)
+            ("summary"
+             :background-color theme:secondary
+             :color            theme:background
+             :font-size        "14px"
+             :padding          "16px"
+             :margin           "6px"
+             :width            "100%"
+             :border           "none"
+             :outline          "none"
+             :text-align       "left")))))
+
+(defun group-bookmarks (buffer)
+  (let ((bookmarks-table (make-hash-table :test #'equalp)))
+    (with-data-unsafe (bookmarks (bookmarks-path buffer))
+      (dolist (bookmark bookmarks)
+        (let ((tags (tags bookmark)))
+          (if tags
+              (dolist (tag tags)
+                (push bookmark (gethash tag bookmarks-table nil)))
+              (push bookmark (gethash tags bookmarks-table nil))))))
+    bookmarks-table))
+
+(export-always 'list-bookmarks)
+(define-internal-page-command-global list-bookmarks ()
+    (bookmarks-buffer "*Bookmarks*" 'bookmark-mode)
+  "List all bookmarks in a new buffer."
+  (let ((bookmarks (group-bookmarks bookmarks-buffer)))
+    (spinneret:with-html-string
+      (:style (style (find-mode bookmarks-buffer 'bookmark-mode)))
+      (:h1 "Bookmarks")
+      (:body
+       (if (zerop (hash-table-count bookmarks))
+           (format nil "No bookmarks in ~s." (expand-path (bookmarks-path bookmarks-buffer)))
+           (maphash
+            (lambda (tag bookmarks)
+              (:details
+               (:summary (or tag "Unsorted"))
+               (dolist (bookmark bookmarks)
+                 (let ((url-display (render-url (url bookmark)))
+                       (url-href (render-url (url bookmark))))
+                   (:div :class "bookmark-entry"
+                         (:p (:b "Title: ") (title bookmark))
+                         (:p (:b "URL: ") (:a :href url-href
+                                              url-display))
+                         (:p (:b "Tags: ")
+                             (when (tags bookmark)
+                               (format nil " (~{~a~^, ~})" (tags bookmark))))
+                         (:p (:button :class "button"
+                                      :onclick
+                                      (ps:ps
+                                        (let ((section (ps:chain document active-element
+                                                                 (closest ".bookmark-entry"))))
+                                          (ps:chain section parent-node (remove-child section))
+                                          (nyxt/ps:lisp-eval
+                                           `(nyxt::delete-bookmark ,url-href))))
+                                      "Delete"))
+                         (:hr ""))))))
+            bookmarks))))))


### PR DESCRIPTION
Hi. I decides to improve `list-bookmarks` command a bit. Bookmarks are now grouped by tags in this manner:
![20220130_09h10m50s_grim](https://user-images.githubusercontent.com/812069/151689403-bcee613a-6401-4d6b-a66e-4f6cec96c565.png)

When you click on a button, a list of bookmarks under this tags expands:
![20220130_09h10m56s_grim](https://user-images.githubusercontent.com/812069/151689418-88843252-7c88-40ad-9544-a86b7b5f814a.png)

I think it can help a lot in organizing bookmarks.