### PR TITLE
Add `no-cors' option to the fetch function.

### DIFF
--- a/source/parenscript-macro.lisp
+++ b/source/parenscript-macro.lisp
@@ -73,7 +73,8 @@
 (defpsmacro lisp-eval (form &optional callback)
   "Request the lisp: URL and invoke callback when there's a successful result."
   `(let ((request (fetch (lisp (str:concat
-                                "lisp://" (quri:url-encode (write-to-string ,form)))))))
+                                "lisp://" (quri:url-encode (write-to-string ,form))))
+                         (create :mode "no-cors"))))
      (when ,callback
        (chain request
               (then (lambda (response)


### PR DESCRIPTION
Hi,

When I wrote the code to pass a callback to the lisp-eval function, I found that it did not work, so I added the following issue.

#2078

I wrote a patch to avoid this problem by changing the request mode of the fetch function used internally to `no-cors`.

This is an option that should be avoided as much as possible, but for this application, I think it is safe to specify it.

The best solution is to give the `Access-Control-Allow-Origin` header if the internal page can give a header to the response.
However, I could not find a way to do that.

Thank you,