### PR TITLE
source/bookmark.lisp: fix bug to get multiple buffers.

### DIFF
--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -172,7 +172,7 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
    :prompt "Bookmark URL from buffer(s)"
    :sources (make-instance 'user-buffer-source
                            :multi-selection-p t
-                           :actions (list (make-unmapped-command bookmark-current-url)))))
+                           :actions (list (make-mapped-command bookmark-current-url)))))
 
 (define-command bookmark-url (&key url)
   "Allow the user to bookmark a URL via minibuffer input."


### PR DESCRIPTION
This seems to fix PR #2094. Now, Nyxt stores the webpages from multiple buffers that were selected.

The UI is still a little bit uncomfortable for the user since the prompt-buffer asks in sequence which tags to attribute without a clear indication of which webpage are the tags being bind to.