### PR TITLE
Fix #2101

### DIFF
--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -107,7 +107,10 @@ When the user is unspecified, take the current one."
 (define-user-class program-source)
 
 (defmethod prompter:object-attributes ((path pathname))
-  `(("Name" ,(or (pathname-name path) ""))
+  `(("Path" ,(uiop:native-namestring path))
+    ("Name" ,(if (uiop:directory-pathname-p path)
+                 (enough-namestring path (nfiles:parent path))
+                 (pathname-name path)))
     ("Extension" ,(or (nfiles:pathname-type* path) ""))
     ("Directory" ,(uiop:native-namestring (nfiles:parent path)))))
 
@@ -141,6 +144,9 @@ It's suitable for `prompter:filter-preprocessor'."
 
 (define-class file-source (prompter:source)
   ((prompter:name "Files")
+   (prompter:active-attributes-keys
+    '("Name" "Extension" "Directory")
+    :accessor nil)
    (prompter:filter-preprocessor (make-file-source-preprocessor))
    (prompter:multi-selection-p t)
    (open-file-in-new-buffer-p t :documentation "If nil, don't open files and directories in a new buffer.")


### PR DESCRIPTION
1) Print top-level directories in the "Name" column of prompter buffer.
   This allows fixes autocompletion for files residing not in the home
   directory.
2) Fix PROMPTER:ATTRIBUTES-DEFAULT for file suggestions. We need to
   return the whole namestring intact, not just "Name" part of
   suggestion's attributes.