### PR TITLE
Remove dummy buffer after setting first buffer of window.

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -341,13 +341,10 @@ restored."
            (load-start-urls (urls)
              (open-urls (or urls (list (default-new-buffer-url browser))))))
     (window-make browser)
-    (let ((dummy (make-dummy-buffer)))
-      (window-set-buffer (current-window) dummy)
-      ;; Restore session before opening command line URLs, otherwise it will
-      ;; reset the session with the new URLs.
-      (restore-session)
-      (load-start-urls urls)
-      (ffi-buffer-delete dummy))
+    ;; Restore session before opening command line URLs, otherwise it will
+    ;; reset the session with the new URLs.
+    (restore-session)
+    (load-start-urls urls)
     (funcall* (startup-error-reporter-function *browser*))))
 
 ;; Catch a common case for a better error message.

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -438,7 +438,7 @@ response.  The BODY is wrapped with `with-protect'."
                                              :orientation :vertical
                                              :spacing 0))
        (setf key-string-buffer (make-instance 'gtk:gtk-entry))
-       (setf active-buffer (make-dummy-buffer))
+       (setf active-buffer (make-instance 'dummy-buffer))
 
        ;; Add the views to the box layout and to the window
        (gtk:gtk-box-pack-start main-buffer-container (gtk-object active-buffer) :expand t :fill t)


### PR DESCRIPTION
Should fix #2119.

I believe the dangling dummy buffer issue was introduced around c247e8282f62b78b4c058a62059b31428521800f.

@aartaka What do you think?