### PR TITLE
Remove file:// scheme use

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -408,7 +408,8 @@ Return the download object matching the download."
                  ;; Add a watcher / renderer for monitoring download
                  (let ((download-render (make-instance 'user-download :url (render-url url))))
                    (setf (destination-path download-render)
-                         (download-manager:filename download))
+                         (uiop:ensure-pathname
+                          (download-manager:filename download)))
                    (push download-render (downloads *browser*))
                    (run-thread
                      "download watcher"

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -333,21 +333,6 @@ Example:
   "Like `funcall' but does nothing when F is nil."
   (when f (apply #'funcall f args)))
 
-(defun read-file-string (url)
-  "Read a file from a file:// type URL into a string."
-  (uiop:read-file-string (quri:uri-path (quri:uri url))))
-
-(defun file-url-p (url-string &key check-exists-p)
-  "Check if a URL-STRING represents a file, and optionally check if said file
-exists."
-  ;; check if a string starts with file to avoid excessive processing
-  (when (str:starts-with-p "file" url-string)
-    (let ((url (quri:uri url-string)))
-      (if check-exists-p
-          (and (equalp "file" (quri:uri-scheme url))
-               (uiop:file-exists-p (quri:uri-path url)))
-          (equalp "file" (quri:uri-scheme url))))))
-
 (defun ensure-file-exists (pathname)
   (open pathname :direction :probe :if-does-not-exist :create))
 

--- a/source/mode/bookmarklets.lisp
+++ b/source/mode/bookmarklets.lisp
@@ -11,13 +11,13 @@
 
 (defmacro nyxt::define-bookmarklet-command (name documentation source)
   "Define a bookmarklet command, the source can either be a JavaScript string to
-evaluate, or a file:// URL with a file path to a JavaScript source file."
+evaluate, or a `cl:pathname' to a JavaScript source file."
   `(define-command-global ,name (&optional (buffer (current-buffer)))
      ,documentation
      (let* ((source ,source)
-            (source (if (nyxt::file-url-p source)
-                        (nyxt::read-file-string source)
-                        source)))
+            (source (etypecase source
+                      (pathname (uiop:read-file-string source))
+                      (string source))))
        (ffi-buffer-evaluate-javascript-async buffer source))))
 (sera:export-always 'nyxt::define-bookmarklet-command :nyxt)
 

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1675,7 +1675,9 @@ local anyways, and it's better to refresh it if a load was queried."
     (connect-signal download "created-destination" nil (webkit-download destination)
       (declare (ignore destination))
       (setf (destination-path download)
-            (webkit:webkit-download-destination webkit-download))
+            (uiop:ensure-pathname
+             (quri:uri-path (quri:uri
+                             (webkit:webkit-download-destination webkit-download)))))
       ;; TODO: We should not have to update the buffer, button actions should be
       ;; dynamic.  Bug in `user-interface'?
       (reload-buffers (list (find-if


### PR DESCRIPTION
Closes #1454.

The rationale is that we don't need `file:` except for interacting with the renderer.

After this change, `cl:pathnames` and `nfiles` are used consistently.  Should be way less confusing.