### PR TITLE
renderer/gtk: Fix using the wrong buffer in custom schemes.

### DIFF
--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -809,7 +809,12 @@ See `gtk-browser's `modifier-translator' slot."
         (lambda (request)
           (funcall* (callback scheme-object)
                     (webkit:webkit-uri-scheme-request-get-uri request)
-                    buffer))
+                    (find (webkit:webkit-uri-scheme-request-get-web-view request)
+                          (delete nil
+                                  (append (list (status-buffer (current-window))
+                                                (active-prompt-buffers (current-window))
+                                                (panel-buffers (current-window)))
+                                          (buffer-list))) :key #'gtk-object)))
         (or (error-callback scheme-object)
             (lambda (condition)
               (echo-warning "Error while routing ~s resource: ~a" scheme condition))))


### PR DESCRIPTION
This addresses #2102 by finding the proper buffer to run the custom scheme in. Instead of using the buffer that the context was created with (a relic of pre-#2050 times), it uses the one provided by the custom scheme request.

The other problem from the #2102 is rather to be moved to https://github.com/atlas-engineer/nyxt/issues/2114. It concerns how we set the initialization data for WebExtensions, which is a mechanism we need to rethink... or leave as it is :)

Closes #2102 