### PR TITLE
source/bookmark.lisp: remove unnecessary sort function.

### DIFF
--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -274,9 +274,7 @@ rest in background buffers."
         (write-string ")")))))
 
 (defmethod nfiles:serialize ((profile nyxt-profile) (file bookmarks-file) stream &key)
-  (let ((content
-          (sort (nfiles:content file)
-                #'url< :key #'url)))
+  (let ((content (nfiles:content file)))
     (write-string "(" stream)
     (dolist (entry content)
       (write-string +newline+ stream)


### PR DESCRIPTION
During a code review on no-[procrastinate](https://github.com/atlas-engineer/nyxt/pull/1771)-mode with @jmercouris, he brought my attention to the fact that this `sort` is unnecessary (and computationally expensive).

Did I miss something? Or should this PR remove it?