### PR TITLE
source/mode/bookmark.lisp: remove unnecessary let expression.

### DIFF
--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -24,14 +24,14 @@
              :text-align       "left")))))
 
 (defun group-bookmarks (buffer)
-  (let ((bookmarks-table (make-hash-table :test #'equalp)))
-    (let ((bookmarks (nfiles:content (bookmarks-file buffer))))
-      (dolist (bookmark bookmarks)
-        (let ((tags (tags bookmark)))
-          (if tags
-              (dolist (tag tags)
-                (push bookmark (gethash tag bookmarks-table nil)))
-              (push bookmark (gethash tags bookmarks-table nil))))))
+  (let ((bookmarks-table (make-hash-table :test #'equalp))
+        (bookmarks (nfiles:content (bookmarks-file buffer))))
+    (dolist (bookmark bookmarks)
+      (let ((tags (tags bookmark)))
+        (if tags
+            (dolist (tag tags)
+              (push bookmark (gethash tag bookmarks-table nil)))
+            (push bookmark (gethash tags bookmarks-table nil)))))
     bookmarks-table))
 
 (export-always 'list-bookmarks)


### PR DESCRIPTION
As pointed out by @jmercouris in a similar code, this nested let construction seems to be unnecessary.

Did I miss something?