### PR TITLE
Feature bookmark hint get title

### DIFF
--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -194,6 +194,7 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
     (if (not (valid-url-p url))
         (echo "Invalid URL '~a'" url)
         (let* ((url (quri:uri url))
+               (title (fetch-url-title url))
                (tags (prompt
                       :prompt "Tag(s)"
                       :sources (list
@@ -202,7 +203,7 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
                                                :multi-selection-p t)
                                 (make-instance 'tag-source
                                                :marks (url-bookmark-tags url))))))
-          (bookmark-add url :tags tags)))))
+          (bookmark-add url :tags tags :title title)))))
 
 (define-command delete-bookmark (&optional urls-or-bookmark-entries)
   "Delete bookmark(s) matching URLS-OR-BOOKMARK-ENTRIES.

--- a/source/mode/element-hint.lisp
+++ b/source/mode/element-hint.lisp
@@ -407,7 +407,15 @@ visible nosave active buffer."
   (query-hints "Bookmark hint"
                (lambda (result)
                  (dolist (url (mapcar #'url result))
-                   (bookmark-url :url url)))
+                   (let ((tags (prompt
+                                :prompt "Tag(s)"
+                                :sources (list
+                                          (make-instance 'prompter:word-source
+                                                         :name "New tags"
+                                                         :multi-selection-p t)
+                                          (make-instance 'nyxt::tag-source
+                                                         :marks (url-bookmark-tags url))))))
+                     (bookmark-add url :tags tags :title (fetch-url-title url)))))
                :multi-selection-p t
                :selector "a, img"))
 

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -52,6 +52,15 @@ If the URL contains hexadecimal-encoded characters, return their unicode counter
          (or (ignore-errors (ffi-display-url url))
              url))))
 
+(export-always 'fetch-url-title)
+(defun fetch-url-title (url)
+  "Return page's title. The URL is fetched, which could explain a possible
+bottleneck."
+  (let* ((html-source (dex:get url))
+         (html-parsed (plump:parse html-source))
+         (title (plump:text (aref (clss:select "title" html-parsed) 0))))
+    title))
+
 (defmacro defmemo (name params &body body) ; TODO: Replace with https://github.com/AccelerationNet/function-cache?
   (alex:with-gensyms (memo-table args result result?)
     `(let ((,memo-table (make-hash-table :test 'equal)))


### PR DESCRIPTION
Hopefully, this PR solves #2053.

There is a small intersection with on-going PR #1771 about the functions `render-host-&-scheme` and `extract-url-title`. Depending on which one gets merged first, I will rebase, and adapt the other.