### PR TITLE
shell.nix: `gobjectIntrospection` -> `gobject-introspection`

### DIFF
--- a/build-scripts/shell.nix
+++ b/build-scripts/shell.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    pkgs.gobjectIntrospection
+    pkgs.gobject-introspection
     pkgs.pkg-config
     pkgs.enchant.out
     pkgs.gsettings-desktop-schemas.out
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
                                                    pkgs.enchant.out
                                                    pkgs.glib-networking.out
                                                    pkgs.webkitgtk
-                                                   pkgs.gobjectIntrospection
+                                                   pkgs.gobject-introspection
                                                    pkgs.pkg-config.out
                                                    pkgs.gtk3
                                                    pkgs.pango.out


### PR DESCRIPTION
The package name has changed in the `nixpkgs` repository in December (https://github.com/NixOS/nixpkgs/commit/a51a99c69041d155892bde91be4993fb29bbea65). A couple of weeks ago they made it so that using the previous name now throws, hence it should be updated accordingly.