### PR TITLE
Annotations on tutorial

### DIFF
--- a/source/annotate.lisp
+++ b/source/annotate.lisp
@@ -57,7 +57,7 @@
   (nfiles:content (annotations-file (current-buffer))))
 
 (define-command annotate-current-url (&optional (buffer-id (id (current-buffer))))
-  "Create a annotation of the URL of buffer with BUFFER-ID."
+  "Create an annotation of the URL of buffer with BUFFER-ID."
   (let* ((buffer (buffers-get buffer-id))
          (data (prompt1
                     :prompt "Annotation"
@@ -78,7 +78,7 @@
     (annotation-add annotation)))
 
 (define-command annotate-highlighted-text (&optional (buffer (current-buffer)))
-  "Create a annotation for the highlighted text of BUFFER."
+  "Create an annotation for the highlighted text of BUFFER."
   (with-current-buffer buffer
     (let* ((snippet (%copy))
            (data (prompt1

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -179,6 +179,19 @@ Bookmarks can have the following settings:")
                                 bookmark-url nyxt/web-mode:bookmark-hint
                                 set-url-from-bookmark delete-bookmark
                                 nyxt/bookmark-mode:list-bookmarks)))
+   (:h3 "Annotations")
+   (:p "Annotations can have the following settings:")
+   (:ul
+    (:li (:code ":snippet") ": The snippet which was hilighted by the user.")
+    (:li (:code ":url") ": The URL of the annotation.")
+    (:li (:code ":title") ": The title of the annotation.")
+    (:li (:code ":annotation") ": The comment about the highlighted snippet or
+the URL.")
+    (:li (:code ":tags") ": A list of strings.  Useful to categorize and filter annotation."))
+   (:p "Annotate-related commands")
+   (:ul
+    (list-command-information '(annotate-current-url annotate-highlighted-text
+                                show-annotation show-annotations show-annotations-for-current-url)))
    (:h3 "Passthrough mode")
    (:p "The command " (:code "passthrough-mode") " forwards all keys to the
 renderer. For instance, using the default binding of Nyxt (" (:code "web-cua-map") ") the


### PR DESCRIPTION
Considering the questions and the interest from users about the feature on annotations (especially after the [article](https://nyxt.atlas.engineer/article/annotations.org) was published), I suggest the we incorporate it to the tutorial aiming for the 3.0 release. Also, the app grammarly indicated a problem with indefinite article rule in one of the docstrings - that I tried to fix.