### PR TITLE
Reducing type specificity in prompter

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -266,7 +266,7 @@ attribute names are meant to be displayed or not.
 suggestion count is meant to be displayed or not.")
 
    (suggestion-maker #'make-suggestion
-                     :type (function (t &optional source string) suggestion)
+                     :type function
                      :documentation "Function that wraps an arbitrary
 object into a source `suggestion'.
 This is useful to set the suggestion slots such as `attributes' and `match-data'
@@ -278,15 +278,13 @@ Called on
 - (optional) current input.")
 
    (filter #'fuzzy-match
-           :type (or null
-                     (function (suggestion source string) (or null suggestion))
-                     function-symbol)
+           :type (or null function function-symbol)
            :documentation
            "Takes a `suggestion', the `source' and the `input' and return a new
 suggestion, or nil if the suggestion is discarded.")
 
    (filter-preprocessor #'delete-inexact-matches
-                        :type (or null (function (list source string) list) function-symbol)
+                        :type (or null function function-symbol)
                         :documentation
                         "Function called when
 input is modified, before filtering the suggestions.
@@ -296,7 +294,7 @@ It is passed the following arguments:
 - the input.")
 
    (filter-postprocessor nil
-                         :type (or null (function (list source string) list) function-symbol)
+                         :type (or null function function-symbol)
                          :documentation
                          "Function called when input is modified, after
 filtering the suggestions with `filter'.
@@ -377,7 +375,7 @@ If update calculation is aborted, nil is sent instead.")
                       "Whether multiple candidates can be marked.")
 
    (resumer nil
-            :type (or null (function (source)))
+            :type (or null function)
             :documentation
             "Function meant to be called with the source as argument when the
 prompter is resumed.

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -410,27 +410,27 @@ Return the download object matching the download."
         (:lisp
          (alex:when-let* ((path (download-directory buffer))
                           (download-dir (nfiles:expand path)))
-           (when (eq proxy-url :auto)
-             (setf proxy-url (proxy-url buffer :downloads-only t)))
-           (let* ((download nil))
-             (with-protect ("Download error: ~a" :condition)
-               (nfiles:with-file-content (downloads path)
-                 (setf download
-                       (download-manager:resolve url
-                                                 :directory download-dir
-                                                 :cookies cookies
-                                                 :proxy proxy-url))
-                 (push download downloads)
-                 ;; Add a watcher / renderer for monitoring download
-                 (let ((download-render (make-instance 'user-download :url (render-url url))))
-                   (setf (destination-path download-render)
-                         (uiop:ensure-pathname
-                          (download-manager:filename download)))
-                   (push download-render (downloads *browser*))
-                   (run-thread
-                     "download watcher"
-                     (download-watch download-render download)))
-                 download)))))
+                         (when (eq proxy-url :auto)
+                           (setf proxy-url (proxy-url buffer :downloads-only t)))
+                         (let* ((download nil))
+                           (with-protect ("Download error: ~a" :condition)
+                             (nfiles:with-file-content (downloads path)
+                               (setf download
+                                     (download-manager:resolve url
+                                                               :directory download-dir
+                                                               :cookies cookies
+                                                               :proxy proxy-url))
+                               (push download downloads)
+                               ;; Add a watcher / renderer for monitoring download
+                               (let ((download-render (make-instance 'user-download :url (render-url url))))
+                                 (setf (destination-path download-render)
+                                       (uiop:ensure-pathname
+                                        (download-manager:filename download)))
+                                 (push download-render (downloads *browser*))
+                                 (run-thread
+                                  "download watcher"
+                                  (download-watch download-render download)))
+                               download)))))
         (:renderer
          (ffi-buffer-download buffer (render-url url))))
     (list-downloads)))
@@ -673,17 +673,17 @@ sometimes yields the wrong result."
   (let ((buffer (current-buffer)))
     (values
      (sera:and-let* ((path (nfiles:expand (standard-output-file buffer))))
-       (setf *standard-output*
-             (open path
-                   :direction :output
-                   :if-does-not-exist :create
-                   :if-exists :append)))
+                    (setf *standard-output*
+                          (open path
+                                :direction :output
+                                :if-does-not-exist :create
+                                :if-exists :append)))
      (sera:and-let* ((path (nfiles:expand (error-output-file buffer))))
-       (setf *error-output*
-             (open path
-                   :direction :output
-                   :if-does-not-exist :create
-                   :if-exists :append))))))
+                    (setf *error-output*
+                          (open path
+                                :direction :output
+                                :if-does-not-exist :create
+                                :if-exists :append))))))
 
 (defmacro define-ffi-generic (name arguments &body options)
   `(progn
@@ -749,8 +749,8 @@ sometimes yields the wrong result."
                   (ps:let ((style (ps:chain document body style)))
                     (setf (ps:@ style zoom)
                           (ps:lisp value)))))
-      (with-current-buffer buffer
-        (zoom)))))
+           (with-current-buffer buffer
+             (zoom)))))
 (define-ffi-generic ffi-buffer-get-document (buffer)
   (:method ((buffer buffer))
     (pflet ((get-html (start end)
@@ -758,11 +758,11 @@ sometimes yields the wrong result."
                                                                              (ps:lisp end))))
             (get-html-length ()
                              (ps:chain document document-element |innerHTML| length)))
-      (with-current-buffer buffer
-        (let ((slice-size 10000))
-          (reduce #'str:concat
-                  (loop for i from 0 to (truncate (get-html-length)) by slice-size
-                        collect (get-html i (+ i slice-size)))))))))
+           (with-current-buffer buffer
+             (let ((slice-size 10000))
+               (reduce #'str:concat
+                       (loop for i from 0 to (truncate (get-html-length)) by slice-size
+                             collect (get-html i (+ i slice-size)))))))))
 (define-ffi-generic ffi-generate-input-event (window event))
 (define-ffi-generic ffi-generated-input-event-p (window event))
 (define-ffi-generic ffi-within-renderer-thread (browser thunk)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -299,24 +299,24 @@ prevents otherwise."))
    browser
    (lambda ()
      (run-thread "finalization"
-                 ;; Restart on init error, in case `*init-file*' broke the state.
-                 ;; We only `handler-case' when there is an init file, this way we avoid
-                 ;; looping indefinitely.
-                 (if (or (getf *options* :no-init)
-                         (not (uiop:file-exists-p (nfiles:expand *init-file*))))
-                     (startup browser urls)
-                     (catch 'startup-error
-                       (handler-bind ((error (lambda (c)
-                                               (log:error "Startup failed (probably due to a mistake in ~s):~&~a"
-                                                          (nfiles:expand *init-file*) c)
-                                               (throw 'startup-error
-                                                 (if *run-from-repl-p*
-                                                     (progn
-                                                       (quit)
-                                                       (reset-all-user-classes)
-                                                       (apply #'start (append *options* (list :urls urls :no-init t))))
-                                                     (restart-with-message c))))))
-                         (startup browser urls)))))))
+       ;; Restart on init error, in case `*init-file*' broke the state.
+       ;; We only `handler-case' when there is an init file, this way we avoid
+       ;; looping indefinitely.
+       (if (or (getf *options* :no-init)
+               (not (uiop:file-exists-p (nfiles:expand *init-file*))))
+           (startup browser urls)
+           (catch 'startup-error
+             (handler-bind ((error (lambda (c)
+                                     (log:error "Startup failed (probably due to a mistake in ~s):~&~a"
+                                                (nfiles:expand *init-file*) c)
+                                     (throw 'startup-error
+                                       (if *run-from-repl-p*
+                                           (progn
+                                             (quit)
+                                             (reset-all-user-classes)
+                                             (apply #'start (append *options* (list :urls urls :no-init t))))
+                                           (restart-with-message c))))))
+               (startup browser urls)))))))
   ;; Set `init-time' at the end of finalize to take the complete startup time
   ;; into account.
   (setf (slot-value *browser* 'init-time)
@@ -410,27 +410,28 @@ Return the download object matching the download."
         (:lisp
          (alex:when-let* ((path (download-directory buffer))
                           (download-dir (nfiles:expand path)))
-                         (when (eq proxy-url :auto)
-                           (setf proxy-url (proxy-url buffer :downloads-only t)))
-                         (let* ((download nil))
-                           (with-protect ("Download error: ~a" :condition)
-                             (nfiles:with-file-content (downloads path)
-                               (setf download
-                                     (download-manager:resolve url
-                                                               :directory download-dir
-                                                               :cookies cookies
-                                                               :proxy proxy-url))
-                               (push download downloads)
-                               ;; Add a watcher / renderer for monitoring download
-                               (let ((download-render (make-instance 'user-download :url (render-url url))))
-                                 (setf (destination-path download-render)
-                                       (uiop:ensure-pathname
-                                        (download-manager:filename download)))
-                                 (push download-render (downloads *browser*))
-                                 (run-thread
-                                  "download watcher"
-                                  (download-watch download-render download)))
-                               download)))))
+           (when (eq proxy-url :auto)
+             (setf proxy-url (proxy-url buffer :downloads-only t)))
+           (let* ((download nil))
+             (with-protect ("Download error: ~a" :condition)
+               (nfiles:with-file-content (downloads path)
+                 (setf download
+                       (download-manager:resolve url
+                                                 :directory download-dir
+                                                 :cookies cookies
+                                                 :proxy proxy-url))
+                 (push download downloads)
+                 ;; Add a watcher / renderer for monitoring download
+                 (let ((download-render (make-instance 'user-download
+                                                       :url (render-url url))))
+                   (setf (destination-path download-render)
+                         (uiop:ensure-pathname
+                          (download-manager:filename download)))
+                   (push download-render (downloads *browser*))
+                   (run-thread
+                       "download watcher"
+                     (download-watch download-render download)))
+                 download)))))
         (:renderer
          (ffi-buffer-download buffer (render-url url))))
     (list-downloads)))
@@ -673,17 +674,17 @@ sometimes yields the wrong result."
   (let ((buffer (current-buffer)))
     (values
      (sera:and-let* ((path (nfiles:expand (standard-output-file buffer))))
-                    (setf *standard-output*
-                          (open path
-                                :direction :output
-                                :if-does-not-exist :create
-                                :if-exists :append)))
+       (setf *standard-output*
+             (open path
+                   :direction :output
+                   :if-does-not-exist :create
+                   :if-exists :append)))
      (sera:and-let* ((path (nfiles:expand (error-output-file buffer))))
-                    (setf *error-output*
-                          (open path
-                                :direction :output
-                                :if-does-not-exist :create
-                                :if-exists :append))))))
+       (setf *error-output*
+             (open path
+                   :direction :output
+                   :if-does-not-exist :create
+                   :if-exists :append))))))
 
 (defmacro define-ffi-generic (name arguments &body options)
   `(progn

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -20,8 +20,8 @@ have an empty ID.")
    ;; TODO: Or maybe a dead-buffer should just be a buffer history?
    (profile
     (alex:if-let ((profile-class (find-profile-class (getf *options* :profile))))
-                 (make-instance profile-class)
-                 *global-profile*)
+      (make-instance profile-class)
+      *global-profile*)
     :type nyxt-profile
     :documentation "Buffer profiles are used to specialize the behaviour of
 various parts, such as the path of all data files.")
@@ -432,7 +432,7 @@ Return the created buffer."
   (unless no-history-p
     ;; Register buffer in global history:
     (nfiles:with-file-content (history (history-file buffer)
-                               :default (make-history-tree buffer))
+                                       :default (make-history-tree buffer))
       ;; Owner may already exist if history was just created with the above
       ;; default value.
       (unless (htree:owner history (id buffer))
@@ -546,41 +546,41 @@ inherited from the superclasses."))
 (define-class panel-buffer (user-web-buffer)
   ((width 250 :documentation "The width in pixels.")
    (style (theme:themed-css (theme *browser*)
-            (body
-             :background-color theme:background
-             :color theme:text
-             :margin "0"
-             :padding "10px"
-             :border-style "solid"
-             :border-width "0px 1px"
-             :border-color theme:tertiary)
-            ("h1,h2,h3,h4,h5,h6"
-             :font-family theme:font-family
-             :font-weight 500)
-            (a
-             :color theme:primary)
-            (button
-             :background "none"
-             :color "inherit"
-             :border "none"
-             :padding 0
-             :font "inherit"
-             :outline "inherit")
-            (.button
-             :display "inline-block"
-             :background-color "darkgray"
-             :color theme:background
-             :text-decoration "none"
-             :border-radius "2px"
-             :padding "6px"
-             :margin-left "2px"
-             :margin-right "2px")
-            (|.button:hover|
-             :color theme:text)
-            (|.button:visited|
-             :color theme:background)
-            (|.button:active|
-             :color theme:background))))
+                            (body
+                             :background-color theme:background
+                             :color theme:text
+                             :margin "0"
+                             :padding "10px"
+                             :border-style "solid"
+                             :border-width "0px 1px"
+                             :border-color theme:tertiary)
+                            ("h1,h2,h3,h4,h5,h6"
+                             :font-family theme:font-family
+                             :font-weight 500)
+                            (a
+                             :color theme:primary)
+                            (button
+                             :background "none"
+                             :color "inherit"
+                             :border "none"
+                             :padding 0
+                             :font "inherit"
+                             :outline "inherit")
+                            (.button
+                             :display "inline-block"
+                             :background-color "darkgray"
+                             :color theme:background
+                             :text-decoration "none"
+                             :border-radius "2px"
+                             :padding "6px"
+                             :margin-left "2px"
+                             :margin-right "2px")
+                            (|.button:hover|
+                             :color theme:text)
+                            (|.button:visited|
+                             :color theme:background)
+                            (|.button:active|
+                             :color theme:background))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:accessor-name-transformer (class*:make-name-transformer name)))
@@ -629,121 +629,121 @@ Delete it with `ffi-buffer-delete'"))
     :documentation "Display the modes as a list of glyphs.")
    (style
     (theme:themed-css (theme *browser*)
-      (body
-       :color theme:text
-       :background theme:tertiary
-       :font-size "14px"
-       :color theme:text
-       :padding 0
-       :margin 0
-       :line-height "20px")
-      (.loader
-       :border-width "2px"
-       :border-style "solid"
-       :border-color "transparent"
-       :border-top-color theme:accent
-       :border-left-color theme:accent
-       :border-radius "50%"
-       :display "inline-block"
-       :width "7px"
-       :height "7px"
-       :animation "spin 1s linear infinite")
-      ("@keyframes spin"
-       ("0%" :transform "rotate(0deg)")
-       ("100%" :transform "rotate(360deg)"))
-      (".arrow-right"
-       :clip-path "polygon(0 0, calc(100% - 10px) 0, 100% 50%, calc(100% - 10px) 100%, 0 100%)"
-       :margin-right "-10px")
-      (".arrow-left"
-       :clip-path "polygon(10px 0, 100% 0, 100% 100%, 10px 100%, 0% 50%)"
-       :margin-left "-10px")
-      ("#container"
-       :display "grid"
-       ;; Columns: controls, url, tabs, modes
-       :grid-template-columns "90px minmax(auto, 30ch) 1fr 220px"
-       :overflow-y "hidden")
-      ("#container-vi"
-       :display "grid"
-       ;; Columns: controls, vi-status, url, tabs, modes
-       :grid-template-columns "90px 30px minmax(auto, 30ch) 1fr 220px"
-       :overflow-y "hidden")
-      ("#controls"
-       :font-size "16px"
-       :font-weight "700"
-       :background-color theme:primary
-       :color theme:background
-       :padding-left "5px"
-       :overflow "hidden"
-       :white-space "nowrap"
-       :z-index "4")
-      ("#vi-mode"
-       :padding-right "10px"
-       :padding-left "10px"
-       :text-align "center"
-       :z-index "3")
-      (".vi-normal-mode"
-       :color theme:background
-       :background-color theme:secondary)
-      (".vi-insert-mode"
-       :color theme:background
-       :background-color theme:accent)
-      ("#url"
-       :color theme:background
-       :background-color theme:secondary
-       :min-width "100px"
-       :text-overflow "ellipsis"
-       :overflow-x "hidden"
-       :white-space "nowrap"
-       :padding-right "10px"
-       :padding-left "15px"
-       :z-index "2")
-      ("#tabs"
-       :color theme:background
-       :background-color theme:tertiary
-       :min-width "100px"
-       :white-space "nowrap"
-       :overflow-x "scroll"
-       :text-align "left"
-       :padding-left "15px"
-       :padding-right "10px"
-       :z-index "1")
-      ("#tabs::-webkit-scrollbar"
-       :display "none")
-      (.tab
-       :color theme:background
-       :white-space "nowrap"
-       :text-decoration "none"
-       :padding-left "5px"
-       :padding-right "5px")
-      (".tab:hover"
-       :color theme:text)
-      ("#modes"
-       :background-color theme:secondary
-       :color theme:background
-       :text-align "right"
-       :padding-left "10px"
-       :padding-right "5px"
-       :overflow-x "scroll"
-       :white-space "nowrap"
-       :z-index "2")
-      ("#modes::-webkit-scrollbar"
-       :display "none")
-      (button
-       :background "none"
-       :color "inherit"
-       :border "none"
-       :padding 0
-       :font "inherit"
-       :outline "inherit")
-      (.button
-       :color theme:background
-       :text-decoration "none"
-       :padding-left "2px"
-       :padding-right "2px"
-       :margin-left "2px"
-       :margin-right "2px")
-      (|.button:hover|
-       :color theme:text))))
+                      (body
+                       :color theme:text
+                       :background theme:tertiary
+                       :font-size "14px"
+                       :color theme:text
+                       :padding 0
+                       :margin 0
+                       :line-height "20px")
+                      (.loader
+                       :border-width "2px"
+                       :border-style "solid"
+                       :border-color "transparent"
+                       :border-top-color theme:accent
+                       :border-left-color theme:accent
+                       :border-radius "50%"
+                       :display "inline-block"
+                       :width "7px"
+                       :height "7px"
+                       :animation "spin 1s linear infinite")
+                      ("@keyframes spin"
+                       ("0%" :transform "rotate(0deg)")
+                       ("100%" :transform "rotate(360deg)"))
+                      (".arrow-right"
+                       :clip-path "polygon(0 0, calc(100% - 10px) 0, 100% 50%, calc(100% - 10px) 100%, 0 100%)"
+                       :margin-right "-10px")
+                      (".arrow-left"
+                       :clip-path "polygon(10px 0, 100% 0, 100% 100%, 10px 100%, 0% 50%)"
+                       :margin-left "-10px")
+                      ("#container"
+                       :display "grid"
+                       ;; Columns: controls, url, tabs, modes
+                       :grid-template-columns "90px minmax(auto, 30ch) 1fr 220px"
+                       :overflow-y "hidden")
+                      ("#container-vi"
+                       :display "grid"
+                       ;; Columns: controls, vi-status, url, tabs, modes
+                       :grid-template-columns "90px 30px minmax(auto, 30ch) 1fr 220px"
+                       :overflow-y "hidden")
+                      ("#controls"
+                       :font-size "16px"
+                       :font-weight "700"
+                       :background-color theme:primary
+                       :color theme:background
+                       :padding-left "5px"
+                       :overflow "hidden"
+                       :white-space "nowrap"
+                       :z-index "4")
+                      ("#vi-mode"
+                       :padding-right "10px"
+                       :padding-left "10px"
+                       :text-align "center"
+                       :z-index "3")
+                      (".vi-normal-mode"
+                       :color theme:background
+                       :background-color theme:secondary)
+                      (".vi-insert-mode"
+                       :color theme:background
+                       :background-color theme:accent)
+                      ("#url"
+                       :color theme:background
+                       :background-color theme:secondary
+                       :min-width "100px"
+                       :text-overflow "ellipsis"
+                       :overflow-x "hidden"
+                       :white-space "nowrap"
+                       :padding-right "10px"
+                       :padding-left "15px"
+                       :z-index "2")
+                      ("#tabs"
+                       :color theme:background
+                       :background-color theme:tertiary
+                       :min-width "100px"
+                       :white-space "nowrap"
+                       :overflow-x "scroll"
+                       :text-align "left"
+                       :padding-left "15px"
+                       :padding-right "10px"
+                       :z-index "1")
+                      ("#tabs::-webkit-scrollbar"
+                       :display "none")
+                      (.tab
+                       :color theme:background
+                       :white-space "nowrap"
+                       :text-decoration "none"
+                       :padding-left "5px"
+                       :padding-right "5px")
+                      (".tab:hover"
+                       :color theme:text)
+                      ("#modes"
+                       :background-color theme:secondary
+                       :color theme:background
+                       :text-align "right"
+                       :padding-left "10px"
+                       :padding-right "5px"
+                       :overflow-x "scroll"
+                       :white-space "nowrap"
+                       :z-index "2")
+                      ("#modes::-webkit-scrollbar"
+                       :display "none")
+                      (button
+                       :background "none"
+                       :color "inherit"
+                       :border "none"
+                       :padding 0
+                       :font "inherit"
+                       :outline "inherit")
+                      (.button
+                       :color theme:background
+                       :text-decoration "none"
+                       :padding-left "2px"
+                       :padding-right "2px"
+                       :margin-left "2px"
+                       :margin-right "2px")
+                      (|.button:hover|
+                       :color theme:text))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:export-predicate-name-p t)
@@ -766,8 +766,8 @@ Delete it with `ffi-buffer-delete'"))
       nyxt-identifier-counter)
     (setf nyxt-identifier-counter (add-nyxt-identifiers (ps:chain document body)))))
   (alex:when-let ((body-json (nyxt/dom::get-document-body-json)))
-                 (setf (document-model buffer)
-                       (nyxt/dom::named-json-parse body-json))))
+    (setf (document-model buffer)
+          (nyxt/dom::named-json-parse body-json))))
 
 (defun dead-buffer-p (buffer) ; TODO: Use this wherever needed.
   (str:empty? (id buffer)))
@@ -936,8 +936,8 @@ BUFFER's modes."
            &allow-other-keys)
     (or buffer t))
 (define-command make-buffer (&rest args &key (title "") modes (url (default-new-buffer-url *browser*)) parent-buffer
-                             no-history-p (load-url-p t) (buffer-class 'user-web-buffer)
-                             &allow-other-keys)
+                                   no-history-p (load-url-p t) (buffer-class 'user-web-buffer)
+                                   &allow-other-keys)
   "Create a new buffer.
 MODES is a list of mode symbols.
 If URL is empty, the `default-new-buffer-url' browser slot is used instead.
@@ -1046,8 +1046,8 @@ If URL is `:default', use `default-new-buffer-url'."
     (sera:and-let* ((owner (htree:owner history (id buffer)))
                     (current (htree:current owner))
                     (data (htree:data current)))
-      (setf (nyxt::scroll-position data) (nyxt:document-scroll-position buffer))
-      (htree:delete-owner history (id buffer))))
+                   (setf (nyxt::scroll-position data) (nyxt:document-scroll-position buffer))
+                   (htree:delete-owner history (id buffer))))
   (ffi-buffer-delete buffer))
 
 (defun buffer-hide (buffer)
@@ -1145,8 +1145,8 @@ proceeding."
           (mapcar #'active-buffer (window-list)))
         (buffers (buffer-list)))
     (alex:when-let ((diff (set-difference buffers active-buffers)))
-                   ;; Display the most recent inactive buffer.
-                   (sort-by-time diff))))
+      ;; Display the most recent inactive buffer.
+      (sort-by-time diff))))
 
 (define-command copy-url ()
   "Save current URL to clipboard."
@@ -1228,7 +1228,7 @@ second latest buffer first."
                                :actions (list (make-mapped-command buffer-delete))))))
 
 (define-internal-page-command-global reduce-to-buffer (&key (delete t))
-    (reduced-buffer "*Reduced Buffers*" 'base-mode)
+  (reduced-buffer "*Reduced Buffers*" 'base-mode)
   "Query the buffer(s) to \"reduce \" by copying their titles/URLs to a
 single buffer, optionally delete them. This function is useful for archiving a
 set of useful URLs or preparing a list to send to a someone else."
@@ -1241,7 +1241,7 @@ set of useful URLs or preparing a list to send to a someone else."
                                           :multi-selection-p t))))
     (unwind-protect
          (spinneret:with-html-string
-           (:style (style reduced-buffer))
+             (:style (style reduced-buffer))
            (:h1 "Reduced Buffers:")
            (:div
             (if buffers
@@ -1448,11 +1448,11 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
                                 (engine (default-search-engine))
                                 (completion (completion-function engine))
                                 (all-terms (str:join " " terms)))
-                  (mapcar (alex:rcurry #'make-completion-query
-                                       :engine      engine
-                                       :check-dns-p check-dns-p)
-                          (with-protect ("Error while completing default search: ~a" :condition)
-                            (funcall (completion-function engine) all-terms))))))))
+                               (mapcar (alex:rcurry #'make-completion-query
+                                                    :engine      engine
+                                                    :check-dns-p check-dns-p)
+                                       (with-protect ("Error while completing default search: ~a" :condition)
+                                         (funcall (completion-function engine) all-terms))))))))
 
 (define-class new-url-or-search-source (prompter:source)
   ((prompter:name "New URL or search query")
@@ -1584,7 +1584,7 @@ HISTORY may be NIL for buffers without history."
            (sera:equals (id buffer))
            buffers
            :key (lambda (b) (alex:when-let ((owner (htree:owner history (id b))))
-                              (htree:creator-id owner))))
+                         (htree:creator-id owner))))
           #'string< :key #'id)))
 
 (defun buffer-siblings (&optional (buffer (current-buffer)))
@@ -1617,20 +1617,20 @@ The tree is browsed in a depth-first fashion.
 When there is no previous buffer, go to the last one so as to cycle."
   (labels ((buffer-last-child (&optional (buffer (current-buffer)))
              (alex:if-let ((next-siblings (second (buffer-siblings buffer))))
-                          (buffer-last-child (alex:last-elt next-siblings))
-                          (alex:if-let ((children (buffer-children buffer)))
-                                       (buffer-last-child (alex:last-elt children))
-                                       buffer)))
+               (buffer-last-child (alex:last-elt next-siblings))
+               (alex:if-let ((children (buffer-children buffer)))
+                 (buffer-last-child (alex:last-elt children))
+                 buffer)))
            (buffer-sibling-previous (&optional (buffer (current-buffer)))
              (alex:when-let ((previous-siblings (first (buffer-siblings buffer))))
-                            (alex:last-elt previous-siblings))))
+               (alex:last-elt previous-siblings))))
     (alex:when-let ((previous (or (alex:when-let ((previous-sibling (buffer-sibling-previous buffer)))
-                                                 (alex:if-let ((children (buffer-children previous-sibling)))
-                                                              (buffer-last-child (first children))
-                                                              previous-sibling))
+                                    (alex:if-let ((children (buffer-children previous-sibling)))
+                                      (buffer-last-child (first children))
+                                      previous-sibling))
                                   (buffer-parent buffer)
                                   (buffer-last-child buffer))))
-                   (set-current-buffer previous))))
+      (set-current-buffer previous))))
 
 (define-command switch-buffer-next (&optional (buffer (current-buffer)))
   "Switch to the next buffer in the buffer tree.
@@ -1638,20 +1638,20 @@ The tree is browsed in a depth-first fashion.
 When there is no next buffer, go to the first one so as to cycle."
   (labels ((buffer-first-root (buffer)
              (alex:if-let ((parent (buffer-parent buffer)))
-                          (buffer-first-root parent)
-                          (first (first (buffer-siblings buffer)))))
+               (buffer-first-root parent)
+               (first (first (buffer-siblings buffer)))))
            (buffer-next-parent-sibling (buffer)
              (alex:when-let ((parent (buffer-parent buffer)))
-                            (alex:if-let ((next-siblings (second (buffer-siblings parent))))
-                                         (first next-siblings)
-                                         (buffer-next-parent-sibling parent))))
+               (alex:if-let ((next-siblings (second (buffer-siblings parent))))
+                 (first next-siblings)
+                 (buffer-next-parent-sibling parent))))
            (buffer-sibling-next (&optional (buffer (current-buffer)))
              (first (second (buffer-siblings buffer)))))
     (alex:when-let ((next (or (first (buffer-children buffer))
                               (buffer-sibling-next buffer)
                               (buffer-next-parent-sibling buffer)
                               (buffer-first-root buffer))))
-                   (set-current-buffer next))))
+      (set-current-buffer next))))
 
 (define-command switch-buffer-last ()
   "Switch to the last showing buffer in the list of buffers.
@@ -1670,7 +1670,7 @@ If MODE does not exist, return nil."
      mode)
     ((symbolp mode)
      (alex:when-let ((command (mode-command mode)))
-                    (name command)))
+       (name command)))
     (t
      (mode-name (sera:class-name-of mode)))))
 
@@ -1705,7 +1705,7 @@ ARGS are passed to the mode command."
                              #'modes
                              (uiop:ensure-list (buffers source)))
                             :test (lambda (i y) (equal (mode-name i)
-                                                       (mode-name y)))))))
+                                                  (mode-name y)))))))
   (:export-class-name-p t))
 (define-user-class active-mode-source)
 

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -8,6 +8,9 @@
 (export-always '(hook-keymaps-buffer))
 (hooks:define-hook-type url->url (function (quri:uri) quri:uri))
 
+(define-condition no-current-buffer (nyxt-condition)
+  ())
+
 (define-class buffer ()
   ((id
     ""
@@ -17,8 +20,8 @@ have an empty ID.")
    ;; TODO: Or maybe a dead-buffer should just be a buffer history?
    (profile
     (alex:if-let ((profile-class (find-profile-class (getf *options* :profile))))
-      (make-instance profile-class)
-      *global-profile*)
+                 (make-instance profile-class)
+                 *global-profile*)
     :type nyxt-profile
     :documentation "Buffer profiles are used to specialize the behaviour of
 various parts, such as the path of all data files.")
@@ -86,7 +89,7 @@ Auto-completions come from the default search engine.")
                           #'(lambda (results)
                               (alex:when-let* ((results results)
                                                (results (decode-json results)))
-                                (mapcar #'list (second results) (fourth results))))))
+                                              (mapcar #'list (second results) (fourth results))))))
           (make-instance 'search-engine
                          :shortcut "ddg"
                          :search-url "https://duckduckgo.com/?q=~a"
@@ -110,7 +113,7 @@ The default search engine (as per `default-search-engine') is used when the
 query is not a valid URL, or the first keyword is not recognized.")
    (current-keymaps-hook
     (make-instance 'hook-keymaps-buffer
-     :combination #'hooks:combine-composed-hook)
+                   :combination #'hooks:combine-composed-hook)
     :type hook-keymaps-buffer
     :documentation "Hook run as a return value of `current-keymaps'.")
    (conservative-word-move
@@ -234,64 +237,64 @@ A value of 0.95 means that the bottom 5% will be the top 5% when scrolling
 down.")
    (style
     (theme:themed-css
-        (theme *browser*)
-      (body
-       :color theme:text
-       :background-color theme:background
-       :margin-left "20px"
-       :margin-top "20px")
-      ("h1,h2,h3,h4,h5,h6"
-       :color theme:primary
-       :font-family theme:font-family)
-      (hr
-       :height "3px"
-       :border-radius "2px"
-       :border-width "0"
-       :color theme:secondary
-       :background-color theme:secondary)
-      (button
-       :background "none"
-       :color "inherit"
-       :border "none"
-       :padding 0
-       :font "inherit"
-       :outline "inherit")
-      (.button
-       :display "inline-block"
-       :background-color theme:secondary
-       :color theme:background
-       :text-decoration "none"
-       :border-radius "2px"
-       :padding "6px"
-       :margin-left "2px"
-       :margin-right "2px")
-      (|.button:hover|
-       :color theme:text)
-      (|.button:visited|
-       :color theme:background)
-      (|.button:active|
-       :color theme:background)
-      (a
-       :color theme:primary)
-      (pre
-       :color theme:text
-       :background-color theme:quaternary
-       :border-radius "2px"
-       :padding-bottom "10px")
-      ("table, th, td"
-       :border-color theme:quaternary
-       :border-collapse "collapse"
-       :border-width "1px"
-       :border-style "solid"
-       :color theme:text
-       :background-color theme:background)
-      (th
-       :background-color theme:primary
-       :color theme:background
-       :text-align "left")))
+     (theme *browser*)
+     (body
+      :color theme:text
+      :background-color theme:background
+      :margin-left "20px"
+      :margin-top "20px")
+     ("h1,h2,h3,h4,h5,h6"
+      :color theme:primary
+      :font-family theme:font-family)
+     (hr
+      :height "3px"
+      :border-radius "2px"
+      :border-width "0"
+      :color theme:secondary
+      :background-color theme:secondary)
+     (button
+      :background "none"
+      :color "inherit"
+      :border "none"
+      :padding 0
+      :font "inherit"
+      :outline "inherit")
+     (.button
+      :display "inline-block"
+      :background-color theme:secondary
+      :color theme:background
+      :text-decoration "none"
+      :border-radius "2px"
+      :padding "6px"
+      :margin-left "2px"
+      :margin-right "2px")
+     (|.button:hover|
+      :color theme:text)
+     (|.button:visited|
+      :color theme:background)
+     (|.button:active|
+      :color theme:background)
+     (a
+      :color theme:primary)
+     (pre
+      :color theme:text
+      :background-color theme:quaternary
+      :border-radius "2px"
+      :padding-bottom "10px")
+     ("table, th, td"
+      :border-color theme:quaternary
+      :border-collapse "collapse"
+      :border-width "1px"
+      :border-style "solid"
+      :color theme:text
+      :background-color theme:background)
+     (th
+      :background-color theme:primary
+      :color theme:background
+      :text-align "left")))
    (buffer-load-hook
     (make-instance 'hook-url->url
-     :combination #'hooks:combine-composed-hook)
+                   :combination #'hooks:combine-composed-hook)
     :type hook-url->url
     :accessor nil
     :export nil
@@ -337,7 +340,7 @@ The file where the system will create/save the global history.")
     (make-instance 'bookmarks-file)
     :type bookmarks-file
     :documentation "The file where the system will create/save the bookmarks.")
- (no-procrastinate-hosts-file
+   (no-procrastinate-hosts-file
     (make-instance 'no-procrastinate-hosts-file)
     :type no-procrastinate-hosts-file
     :documentation "The file where the system will create/save hosts associated
@@ -376,6 +379,10 @@ Rendered URLs or the Nyxt's manual qualify as examples.  Buffers are fully
 separated from one another, so that each has its own behaviour and settings."))
 
 (define-user-class buffer)
+
+(defmethod (setf last-access) (new-value (obj null))
+  "Sometimes last-access is null in headless mode."
+  nil)
 
 (define-class background-buffer (user-web-buffer)
   ()

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -66,9 +66,12 @@ This is set globally so that extensions can be loaded even if there is no
   (or %buffer
       (alex:if-let ((w (or window (current-window))))
         (active-buffer w)
-        (when *browser*
-             (log:debug "No active window, picking last active buffer.")
-             (last-active-buffer)))))
+        (if *browser*
+            (progn 
+              (log:debug "No active window, picking last active buffer.")
+              (or (last-active-buffer)
+                  (error 'no-current-buffer :message "No active buffer.")))
+            (error 'no-current-buffer :message "No active buffer. No *browser*")))))
 
 (export-always 'with-current-buffer)
 (defmacro with-current-buffer (buffer &body body)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -56,103 +56,103 @@ For instance, if we want to load some Slynk configuration code that lives in
   (uiop:quit))
 
 (sera:eval-always
-  (defun define-opts ()
-    "Define command line options.
+ (defun define-opts ()
+   "Define command line options.
 This must be called on startup so that code is executed in the user environment
 and not the build environment."
-    (opts:define-opts
-      (:name :help
-       :description "Print this help and exit."
-       :short #\h
-       :long "help")
-      (:name :verbose
-       :short #\v
-       :long "verbose"
-       :description "Print debugging information to stdout.")
-      (:name :version
-       :long "version"
-       :description "Print version and exit.")
-      (:name :system-information
-       :long "system-information"
-       :description "Print system information and exit.")
-      (:name :init
-       :short #\i
-       :long "init"
-       :arg-parser #'identity
-       :description (format nil "Set path to initialization file.
+   (opts:define-opts
+       (:name :help
+        :description "Print this help and exit."
+        :short #\h
+        :long "help")
+       (:name :verbose
+        :short #\v
+        :long "verbose"
+        :description "Print debugging information to stdout.")
+     (:name :version
+      :long "version"
+      :description "Print version and exit.")
+     (:name :system-information
+      :long "system-information"
+      :description "Print system information and exit.")
+     (:name :init
+      :short #\i
+      :long "init"
+      :arg-parser #'identity
+      :description (format nil "Set path to initialization file.
 Default: ~s" (nfiles:expand *init-file*)))
-      (:name :no-init
-       :short #\I
-       :long "no-init"
-       :description "Do not load the initialization file.")
-      (:name :auto-config
-       :short #\c
-       :long "auto-config"
-       :arg-parser #'identity
-       :description (format nil "Set path to auto-config file.
+     (:name :no-init
+      :short #\I
+      :long "no-init"
+      :description "Do not load the initialization file.")
+     (:name :auto-config
+      :short #\c
+      :long "auto-config"
+      :arg-parser #'identity
+      :description (format nil "Set path to auto-config file.
 Default: ~s" (nfiles:expand *auto-config-file*)))
-      (:name :no-auto-config
-       :short #\C
-       :long "no-auto-config"
-       :description "Do not load the user auto-config file.")
-      (:name :socket
-       :short #\s
-       :long "socket"
-       :arg-parser #'identity
-       :description "Set path to socket.
+     (:name :no-auto-config
+      :short #\C
+      :long "no-auto-config"
+      :description "Do not load the user auto-config file.")
+     (:name :socket
+      :short #\s
+      :long "socket"
+      :arg-parser #'identity
+      :description "Set path to socket.
 Unless evaluating remotely (see --remote), Nyxt starts in single-instance mode when a socket is set.
 The socket can also be set from the NYXT_SOCKET environment variable.")
-      (:name :no-socket
-       :short #\S
-       :long "no-socket"
-       :description "Do not use any socket.")
-      (:name :eval
-       :short #\e
-       :long "eval"
-       :arg-parser #'identity
-       :description "Eval the Lisp expressions.  Can be specified multiple times.
+     (:name :no-socket
+      :short #\S
+      :long "no-socket"
+      :description "Do not use any socket.")
+     (:name :eval
+      :short #\e
+      :long "eval"
+      :arg-parser #'identity
+      :description "Eval the Lisp expressions.  Can be specified multiple times.
 Without --quit or --remote, the evaluation is done after parsing the init file
 (if any) and before initializing the browser.")
-      (:name :load
-       :short #\l
-       :long "load"
-       :arg-parser #'identity
-       :description "Load the Lisp file.  Can be specified multiple times.
+     (:name :load
+      :short #\l
+      :long "load"
+      :arg-parser #'identity
+      :description "Load the Lisp file.  Can be specified multiple times.
 Without --quit or --remote, the loading is done after parsing the init file
 (if any) and before initializing the browser.")
-      (:name :quit
-       :short #\q
-       :long "quit"
-       :description "Quit after --load or --eval.")
-      (:name :script
-       :long "script"
-       :arg-parser #'identity
-       :description "Load the Lisp file (skip #! line if any), skip init file, then exit.
+     (:name :quit
+      :short #\q
+      :long "quit"
+      :description "Quit after --load or --eval.")
+     (:name :script
+      :long "script"
+      :arg-parser #'identity
+      :description "Load the Lisp file (skip #! line if any), skip init file, then exit.
 Set to '-' to read standard input instead.")
-      (:name :remote
-       :short #\r
-       :long "remote"
-       :description "Send the --eval and --load arguments to the running instance of Nyxt.
+     (:name :remote
+      :short #\r
+      :long "remote"
+      :description "Send the --eval and --load arguments to the running instance of Nyxt.
 Implies --quit.
 The remote instance must be listening on a socket which you can specify with --socket
 and have the `remote-execution-p' browser slot to non-nil.")
-      (:name :headless
-       :long "headless"
-       :description "Start Nyxt without showing any graphical element.
+     (:name :headless
+      :long "headless"
+      :description "Start Nyxt without showing any graphical element.
 This is useful to run scripts for instance.")
-      (:name :profile
-       :short #\p
-       :long "profile"
-       :arg-parser #'identity
-       :description "Use the given profile. ")
-      (:name :list-profiles
-       :long "list-profiles"
-       :description "List the known profiles and exit.
+     (:name :profile
+      :short #\p
+      :long "profile"
+      :arg-parser #'identity
+      :description "Use the given profile. ")
+     (:name :list-profiles
+      :long "list-profiles"
+      :description "List the known profiles and exit.
 Known profiles are found among subclasses of `nyxt-profile'.")
-      (:name :with-file
-       :long "with-file"
-       :arg-parser (lambda (arg) (str:split "=" arg :limit 2))
-       :description "Set path reference to the given path.
+     (:name :with-file
+      :long "with-file"
+      :arg-parser (lambda (arg) (str:split "=" arg :limit 2))
+      :description "Set path reference to the given path.
 Can be specified multiple times.  An empty path means it won't be used.
 Example: --with-file bookmarks=/path/to/bookmarks
          --with-file session="))))
@@ -210,7 +210,7 @@ before running this command."
             (file-position stream p)))))))
 
 (cffi:defcallback handle-interrupt
-    :void ((signum :int) (siginfo :pointer) (ptr :pointer))
+  :void ((signum :int) (siginfo :pointer) (ptr :pointer))
   (declare (ignore signum siginfo ptr))
   (quit))
 
@@ -414,7 +414,7 @@ Otherwise bind socket and return the listening thread."
        (log:info "Listening to socket ~s." socket-path)
        (uiop:delete-file-if-exists socket-path) ; Safe since socket-path is a :socket at this point.
        (run-thread "socket listener"
-         (listen-socket))))))
+                   (listen-socket))))))
 
 (defun remote-eval (expr)
   "If another Nyxt is listening on the socket, tell it to evaluate EXPR."
@@ -564,16 +564,16 @@ Finally, run the browser, load URL-STRINGS if any, then run
       (load-lisp (nfiles:expand *auto-config-file*) :package (find-package :nyxt-user))
       (match (multiple-value-list (load-lisp (nfiles:expand *init-file*)
                                              :package (find-package :nyxt-user)))
-             (nil nil)
-             ((list message full-message)
-              (setf startup-error-reporter
-                    (lambda ()
-                      (echo-warning "~a." message)
-                      (error-in-new-window "*Init file errors*" full-message)))))
+        (nil nil)
+        ((list message full-message)
+         (setf startup-error-reporter
+               (lambda ()
+                 (echo-warning "~a." message)
+                 (error-in-new-window "*Init file errors*" full-message)))))
       (load-or-eval :remote nil)
       (setf *browser* (make-instance (if *headless-p*
                                          'user-headless-browser
-                                       'user-browser)
+                                         'user-browser)
                                      :startup-error-reporter-function startup-error-reporter
                                      :startup-timestamp startup-timestamp
                                      :socket-thread thread))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -564,14 +564,16 @@ Finally, run the browser, load URL-STRINGS if any, then run
       (load-lisp (nfiles:expand *auto-config-file*) :package (find-package :nyxt-user))
       (match (multiple-value-list (load-lisp (nfiles:expand *init-file*)
                                              :package (find-package :nyxt-user)))
-        (nil nil)
-        ((list message full-message)
-         (setf startup-error-reporter
-               (lambda ()
-                 (echo-warning "~a." message)
-                 (error-in-new-window "*Init file errors*" full-message)))))
+             (nil nil)
+             ((list message full-message)
+              (setf startup-error-reporter
+                    (lambda ()
+                      (echo-warning "~a." message)
+                      (error-in-new-window "*Init file errors*" full-message)))))
       (load-or-eval :remote nil)
-      (setf *browser* (make-instance 'user-browser
+      (setf *browser* (make-instance (if *headless-p*
+                                         'user-headless-browser
+                                       'user-browser)
                                      :startup-error-reporter-function startup-error-reporter
                                      :startup-timestamp startup-timestamp
                                      :socket-thread thread))


### PR DESCRIPTION
These changes should fix problems when SBCL Type checks class slots (it does not by default). 
Also added a class for headless browser which and fixed a small bug when running headless. Although headless doesn't work :( because it gets stuck in a webkit ffi call.