### PR TITLE
Repeat key

### DIFF
--- a/source/input.lisp
+++ b/source/input.lisp
@@ -105,6 +105,10 @@ KEYCODE-LESS-DISPLAY (KEYCODE-DISPLAY)."
 (defun dispatch-command (function)
   (run-async function))
 
+(export-always 'dispatch-input-skip)
+(defun dispatch-input-skip (keyspecs)
+  (log:debug "Skipping input event key ~s" keyspecs))
+
 (export-always 'dispatch-input-event)
 (defun dispatch-input-event (event buffer window printable-p)
   "Dispatch keys in WINDOW `key-stack'.
@@ -157,13 +161,14 @@ Return nil to forward to renderer or non-nil otherwise."
              ((or (and buffer (forward-input-events-p buffer))
                   (pointer-event-p (first (last key-stack))))
               (log:debug "Forward key ~s" (keyspecs key-stack))
+              (funcall (input-skip-dispatcher window) (keyspecs key-stack))
               (setf key-stack nil)
               nil)
 
              ((and buffer (not (forward-input-events-p buffer)))
               ;; After checking `pointer-event-p', otherwise pointer events
               ;; might not be forwarded.
-              (log:debug "Skipping input event key ~s" (keyspecs key-stack))
+              (funcall (input-skip-dispatcher window) (keyspecs key-stack))
               (setf key-stack nil)
               t)
 

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -101,6 +101,10 @@ KEYCODE-LESS-DISPLAY (KEYCODE-DISPLAY)."
         (format nil "~s [~a]" no-code-specs (keymap:keys->keyspecs keys))
         (format nil "~s" no-code-specs))))
 
+(export-always 'dispatch-command)
+(defun dispatch-command (function)
+  (run-async function))
+
 (export-always 'dispatch-input-event)
 (defun dispatch-input-event (event buffer window printable-p)
   "Dispatch keys in WINDOW `key-stack'.
@@ -144,7 +148,7 @@ Return nil to forward to renderer or non-nil otherwise."
               ;; thread.
               (setf (last-key window) (first key-stack))
               (unwind-protect
-                   (run-async bound-function)
+                   (funcall (command-dispatcher window) bound-function)
                 ;; We must reset the key-stack on errors or else all subsequent
                 ;; keypresses will keep triggering the same erroring command.
                 (setf key-stack nil))

--- a/source/mode/base.lisp
+++ b/source/mode/base.lisp
@@ -3,6 +3,13 @@
 
 (in-package :nyxt)
 
+(defmacro make-repeat (times)
+  (let ((name (gensym (format nil "repeat-~a-" times))))
+    `(make-command ,name ()
+       ,(format nil "Repeat the command associated to the pressed key ~R times." times)
+       ;; FIXME: A dirty hack.
+       (funcall (read-from-string "nyxt/repeat-mode:repeat-key") :times ,times))))
+
 (define-mode base-mode ()
   "Bind general-purpose commands defined by `define-command'.
 This mode is a good candidate to be passed to `make-buffer'."
@@ -89,6 +96,15 @@ This mode is a good candidate to be passed to `make-buffer'."
        "C-d" 'list-downloads
        "M-x" 'execute-command
        "C-M-x" 'execute-extended-command
+       "M-1" (make-repeat 1)
+       "M-2" (make-repeat 2)
+       "M-3" (make-repeat 3)
+       "M-4" (make-repeat 4)
+       "M-5" (make-repeat 5)
+       "M-6" (make-repeat 6)
+       "M-7" (make-repeat 7)
+       "M-8" (make-repeat 8)
+       "M-9" (make-repeat 9)
        "C-x r j" 'set-url-from-bookmark
        "C-x r M" 'bookmark-current-url
        "C-x r m" 'bookmark-buffer-url
@@ -133,6 +149,15 @@ This mode is a good candidate to be passed to `make-buffer'."
        "C-h k" 'describe-key
        "C-h b" 'describe-bindings
        ":" 'execute-command
+       "1" (make-repeat 1)
+       "2" (make-repeat 2)
+       "3" (make-repeat 3)
+       "4" (make-repeat 4)
+       "5" (make-repeat 5)
+       "6" (make-repeat 6)
+       "7" (make-repeat 7)
+       "8" (make-repeat 8)
+       "9" (make-repeat 9)
        "W" 'make-window
        "C-w C-w" 'make-window
        "C-w q" 'delete-current-window

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -70,6 +70,12 @@ Cannot be null.")
     :type function
     :documentation "Function to process the command processed in `input-dispatcher'.
 Takes the function/command as the only argument.")
+   (input-skip-dispatcher
+    #'dispatch-input-skip
+    :type function
+    :documentation "Function to process the skipped input event.
+It runs when the pressed keybinding has no associated command.
+The only argument is a string representation of the pressed key.")
    (window-set-buffer-hook
     (make-instance 'hook-window-buffer)
     :type hook-window-buffer

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -61,9 +61,15 @@ The channel is popped when a prompt buffer is hidden.")
     :documentation "The height of the prompt buffer when open.")
    (input-dispatcher
     #'dispatch-input-event
+    :type function
     :documentation "Function to process input events.
 It takes EVENT, BUFFER, WINDOW and PRINTABLE-P parameters.
 Cannot be null.")
+   (command-dispatcher
+    #'dispatch-command
+    :type function
+    :documentation "Function to process the command processed in `input-dispatcher'.
+Takes the function/command as the only argument.")
    (window-set-buffer-hook
     (make-instance 'hook-window-buffer)
     :type hook-window-buffer


### PR DESCRIPTION
This introduces the `repeat-key` command to repeat the key-bound command an arbitrary number of times. This patch also includes:
- Conveninent bindings in Emacs (`M-1`, `M-2` etc.) and VI (mere digits) modes for pre-configured `repeat-key`.
- A major refactoring of the key-dispatch API, introducing `command-dispatcher` and `input-skip-dispatcher` slots of `window`, so that one doesn't have to re-implement `dispatch-key-event` every time they need to process the pressed key.
- `describe-key` nicely rewritten using the new API, as a proof of how much lines it saves :D  

# Things to Discuss 
- I don't particularly like `input-skip-dispatcher`.
  - Maybe only allow changing `command-dispatcher` for a one-shot use, binding it back to `dispatch-command` after _any_ key is processed? 
  -  Suggestions are welcome, as I'm a bit lost in our input handling :D
- When `input-skip-dispatcher` is ran and echoing some message (like in both `describe-key` and `repeat-key`), the echoed message is immeduately flushed somewhy. Anyone knows the reason? Is that the keypress that flushes the message area? How do I override this behavior?

Closes #1601 
Closes #1756