### PR TITLE
Fix gtk extensions dir + install libnyxt.so + include source

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,9 +7,14 @@ Usage:
 Set DESTDIR to change the target destinatation.  It should be
 an absolute path.
 
+Set NYXT_SOURCE_PATH to where the source files will be installed.
+By default the GTK renderer loads the `libnyxt' library (enabling WebExtension
+support) relatively to the nyxt.asd location.  You can also configure this at
+runtime through the `gtk-extensions-directory' `resolve' method.
+
 Set LISP and LISP_FLAGS to accommodate to your Lisp compiler.
 
-Set NYXT_RENDERER to the renderer of your choice, e.g. "gtk".
+Set NYXT_RENDERER to the renderer of your choice, for instance "gtk".
 
 Set NYXT_VERSION to force the version number instead of deriving it from Git.
 This is useful for build systems without access to the .git metadata.

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -6,8 +6,10 @@
   (sb-ext:assert-version->= 2 0 0)
   (require 'sb-bsd-sockets))
 
-(defvar *prefix* (format nil "~a/~a"
-                         (or (uiop:getenv "DESTDIR") "")
+(defvar *prefix* (format nil "~a~a"
+                         (if (uiop:getenv "DESTDIR")
+                             (uiop:strcat (uiop:getenv "DESTDIR") "/")
+                             "")
                          (or (uiop:getenv "PREFIX")
                              "/usr/local")))
 (defvar *datadir* (or (uiop:getenv "DATADIR")

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -252,20 +252,18 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
            (if (uiop:absolute-pathname-p path)
                path
                (system-relative-pathname component path))))
-    (setf (uiop:getenv "CL_SOURCE_REGISTRY")
-          (uiop:strcat
-           (namestring
-            (uiop:truenamize
-             (uiop:ensure-directory-pathname
-              (ensure-absolute-path *submodules-dir* component))))
+    (setf (getenv "CL_SOURCE_REGISTRY")
+          (strcat
+           (native-namestring
+            (ensure-directory-pathname
+             (ensure-absolute-path *submodules-dir* component)))
            ;; Double-slash tells ASDF to traverse the tree recursively.
            "/"
            ;; Register this directory so that nyxt.asd is included, just in case.
-           (uiop:inter-directory-separator)
-           (namestring (uiop:truenamize (uiop:pathname-directory-pathname
-                                         (asdf:system-source-file component))))
-           (if (uiop:getenv "CL_SOURCE_REGISTRY")
-               (uiop:strcat (uiop:inter-directory-separator) (uiop:getenv "CL_SOURCE_REGISTRY"))
+           (inter-directory-separator)
+           (native-namestring (system-source-directory component))
+           (if (getenv "CL_SOURCE_REGISTRY")
+               (strcat (inter-directory-separator) (getenv "CL_SOURCE_REGISTRY"))
                ;; End with an empty string to tell ASDF to inherit configuration.
                (uiop:inter-directory-separator)))))
   (asdf:clear-configuration)

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -40,6 +40,18 @@
 (defvar *init-file* (make-instance 'init-file)
   "The initialization file.")
 
+(define-class nyxt-source-directory (nyxt-file)
+  ((nfiles:base-path (uiop:merge-pathnames* "nyxt/" asdf-user::*datadir*))
+   (nfiles:name "source"))
+  (:export-class-name-p t)
+  (:accessor-name-transformer (class*:make-name-transformer name)))
+
+(export-always '*source-directory*)
+(defvar *source-directory* (make-instance 'nyxt-source-directory)
+  "The directory where the source code is stored.
+This is set globally so that it can be looked up if there is no
+`*browser*' instance.")
+
 (define-class extensions-directory (nfiles:data-file nyxt-file)
   ((nfiles:base-path #p"extensions/")
    (nfiles:name "extensions"))
@@ -56,6 +68,7 @@ This is set globally so that extensions can be loaded even if there is no
 (defun nyxt-source-registry ()
   `(:source-registry
     (:tree ,(nfiles:expand *extensions-directory*))
+    (:tree ,(nfiles:expand *source-directory*))
     :inherit-configuration))
 
 (defparameter %buffer nil)              ; TODO: Make a monad?

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -41,7 +41,7 @@
   "The initialization file.")
 
 (define-class nyxt-source-directory (nyxt-file)
-  ((nfiles:base-path (uiop:merge-pathnames* "nyxt/" asdf-user::*datadir*))
+  ((nfiles:base-path asdf-user::*dest-source-dir*)
    (nfiles:name "source"))
   (:export-class-name-p t)
   (:accessor-name-transformer (class*:make-name-transformer name)))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -289,7 +289,7 @@ the renderer thread, use `defmethod' instead."
 By default it is found in the source directory."))
 
 (defmethod nfiles:resolve ((profile nyxt-profile) (file gtk-extensions-directory))
-  (sera:path-join (asdf:system-source-directory :nyxt) "libraries/web-extensions/"))
+  (asdf:system-relative-pathname :nyxt "libraries/web-extensions/"))
 
 (define-class cookies-file (nfiles:data-file data-manager-file)
   ((nfiles:name "cookies"))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -281,15 +281,15 @@ the renderer thread, use `defmethod' instead."
    (call-next-method)
    (pathname (str:concat (context-name file) "-web-context/"))))
 
-(define-class gtk-extensions-directory (nfiles:data-file data-manager-file)
+(define-class gtk-extensions-directory (nyxt-file)
   ((nfiles:name "gtk-extensions"))
   (:export-class-name-p t)
-  (:accessor-name-transformer (class*:make-name-transformer name)))
+  (:accessor-name-transformer (class*:make-name-transformer name))
+  (:documentation "Directory where to load the 'libnyxt' library.
+By default it is found in the source directory."))
 
 (defmethod nfiles:resolve ((profile nyxt-profile) (file gtk-extensions-directory))
-  (sera:path-join
-   (call-next-method)
-   (pathname (str:concat (context-name file) "-gtk-extensions/"))))
+  (sera:path-join (asdf:system-source-directory :nyxt) "libraries/web-extensions/"))
 
 (define-class cookies-file (nfiles:data-file data-manager-file)
   ((nfiles:name "cookies"))
@@ -769,11 +769,12 @@ See `gtk-browser's `modifier-translator' slot."
                                                                      (nfiles:expand data-manager-data-directory))
                                                :base-cache-directory (uiop:native-namestring
                                                                       (nfiles:expand data-manager-cache-directory)))))))
-         (gtk-extensions-path (nfiles:expand (make-instance 'gtk-extensions-directory :context-name name)))
+         (gtk-extensions-path (nfiles:expand (make-instance 'gtk-extensions-directory)))
          (cookie-manager (webkit:webkit-web-context-get-cookie-manager context)))
     (webkit:webkit-web-context-add-path-to-sandbox
      context (namestring (asdf:system-relative-pathname :nyxt "libraries/web-extensions/")) t)
     (unless (uiop:emptyp gtk-extensions-path)
+      (log:info "GTK extensions directory: ~s" gtk-extensions-path)
       ;; TODO: Should we also use `connect-signal' here?  Does this yield a memory leak?
       (gobject:g-signal-connect
        context "initialize-web-extensions"


### PR DESCRIPTION
3 commits for 3 related fixes:

- This fixes the GTK extension directory (was mistakenly made context-dependent in #2050) and sets it to something system-wide.  Indeed, we have only one such library, there is no point (for now at least) in supporting multiple libs.
- Install the lib together with the source code to a system-wide dir.  This partially addresses #2065.
- Update `nyxt-source-registry` to look into the newly installed source.

Thoughts?

This raises some questions, such as:

- Relying on `asdf-user::*data-dir*` is brittle.  Anything better?
- Should we introduce a new environment variable so that packagers have access to a more explicit configuration knob?