### PR TITLE
Progress bar fix

### DIFF
--- a/libraries/user-interface/user-interface.lisp
+++ b/libraries/user-interface/user-interface.lisp
@@ -79,7 +79,7 @@ filled up, use a number between 0 and 100.")))
                ;; empty string to force markup to make closing :div tag
                "")))
 
-(defmethod (setf percentage) :around (percentage (progress-bar progress-bar))
+(defmethod (setf percentage) :after (percentage (progress-bar progress-bar))
   (declare (ignorable percentage))
   (when (slot-boundp progress-bar 'buffer)
     (update progress-bar)))

--- a/source/user-interface.lisp
+++ b/source/user-interface.lisp
@@ -8,18 +8,22 @@
 (defmethod user-interface:update ((paragraph user-interface:paragraph))
   (ffi-buffer-evaluate-javascript-async
    (user-interface:buffer paragraph)
-   (ps:ps (let ((element (ps:chain document (get-element-by-id (ps:lisp (user-interface:id paragraph))))))
-            (setf (ps:chain element text-content) (ps:lisp (user-interface:text paragraph)))))))
+   (ps:ps
+     (let ((element (ps:chain document (get-element-by-id (ps:lisp (user-interface:id paragraph))))))
+       (setf (ps:chain element text-content) (ps:lisp (user-interface:text paragraph)))))))
 
 (defmethod user-interface:update ((progress-bar user-interface:progress-bar))
   (ffi-buffer-evaluate-javascript-async
    (user-interface:buffer progress-bar)
-   (ps:ps (let ((element (ps:chain document (get-element-by-id (ps:lisp (user-interface:id progress-bar))))))
-            (setf (ps:chain element style width) (ps:lisp (user-interface:percentage progress-bar)))))))
+   (ps:ps
+     (let ((element (ps:chain document (get-element-by-id (ps:lisp (user-interface:id progress-bar))))))
+       (setf (ps:chain element style width)
+             (ps:lisp (format nil "~,1f%" (user-interface:percentage progress-bar))))))))
 
 (defmethod user-interface:update ((button user-interface:button))
   (ffi-buffer-evaluate-javascript-async
    (user-interface:buffer button)
-   (ps:ps (let ((element (ps:chain document (get-element-by-id (ps:lisp (user-interface:id button))))))
-            (setf (ps:chain element text-content) (ps:lisp (user-interface:text button)))
-            (setf (ps:chain element onclick) (ps:lisp (user-interface:action button)))))))
+   (ps:ps
+     (let ((element (ps:chain document (get-element-by-id (ps:lisp (user-interface:id button))))))
+       (setf (ps:chain element text-content) (ps:lisp (user-interface:text button)))
+       (setf (ps:chain element onclick) (ps:lisp (user-interface:action button)))))))


### PR DESCRIPTION
These two commits fix the progress bar (you can download any file to see that it's broken).

The first commit fixes a wrong method qualifier introduced recently, but the second one is rather misterious: the progress bar's width was set in px units rather than in percents. I wonder how it worked earlier :) Will be grateful if someone can explain.