### PR TITLE
docs: update references to Arch Linux

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,7 +78,7 @@ the following platforms:
 - Alpine.
 - Debian and derivatives such as Ubuntu and Linux Mint.
 - [[https://github.com/atlas-engineer/ports][MacPorts]].
-- Arch Linux.
+- [[https://archlinux.org/][Arch Linux]]: Install with =pacman -Syu nyxt=.
 - [[https://nixos.org/nix/][Nix]]: Install with =nix-env --install nyxt=.
 - [[https://guix.gnu.org][Guix]]: Install with =guix install nyxt=.
 - [[https://voidlinux.org/][Void]]: Install with =xbps-install nyxt=.

--- a/README.org
+++ b/README.org
@@ -78,8 +78,7 @@ the following platforms:
 - Alpine.
 - Debian and derivatives such as Ubuntu and Linux Mint.
 - [[https://github.com/atlas-engineer/ports][MacPorts]].
-- [[https://aur.archlinux.org/packages/nyxt][Arch Linux AUR]] and the [[https://aur.archlinux.org/packages/nyxt-browser-git/][-git PKGBUILD]].  See also the [[https://e-v.srht.site/nyxt-aur-builds.html][unofficial binary
-  packages]], courtesy of @edgar-vincent.
+- Arch Linux.
 - [[https://nixos.org/nix/][Nix]]: Install with =nix-env --install nyxt=.
 - [[https://guix.gnu.org][Guix]]: Install with =guix install nyxt=.
 - [[https://voidlinux.org/][Void]]: Install with =xbps-install nyxt=.

--- a/documents/README.org
+++ b/documents/README.org
@@ -136,9 +136,8 @@ git clone https://github.com/joachifm/cl-webkit ~/common-lisp/cl-webkit
 
 - Arch Linux:
   #+begin_src sh
-  sudo pacman -S git sbcl cl-asdf webkit2gtk glib-networking gsettings-desktop-schemas enchant
+  sudo pacman -S git sbcl cl-asdf webkit2gtk glib-networking gsettings-desktop-schemas enchant libfixposix
   #+end_src
-  The package libfixposix can be installed from the [[https://aur.archlinux.org/packages/libfixposix][AUR]], same for ~pkg-config~.
 
 - Fedora:
   #+begin_src sh


### PR DESCRIPTION
Nyxt and all required dependencies have been added to Arch's community repository.