### PR TITLE
mode/repl.lisp: Verbatim printing mode

### DIFF
--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -85,7 +85,13 @@ INPUT is a string and RESULTS is a list of Lisp values.")
     :type (or null integer)
     :documentation "Current element of history being edited in the REPL prompt.
 
-Scroll history with `evaluation-history-previous' and `evaluation-history-next'."))
+Scroll history with `evaluation-history-previous' and `evaluation-history-next'.")
+   (verbatim-p
+    nil
+    :type boolean
+    :documentation "If NIL results of evaluation will be
+pretty-printed with VALUE->HTML. Printed representations of most
+objects cannot be read back in this case. If T, use PRIN1-TO-STRING."))
   (:toggler-command-p nil))
 
 (defun package-short-name (package)
@@ -207,11 +213,15 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
                           for (package input results) in (reverse (evaluation-history repl-mode))
                           collect (:li (:b package "> " input)
                                        (loop
-                                         for result in results
-                                         collect (:li (:raw
-                                                       (value->html
-                                                        result (or (typep result 'standard-object)
-                                                                   (typep result 'structure-object))))))))))
+                                         for result in results collect
+                                             (:li
+                                              (if (verbatim-p repl-mode)
+                                                  (prin1-to-string result)
+                                                  (:raw
+                                                   (value->html
+                                                    result
+                                                    (or (typep result 'standard-object)
+                                                        (typep result 'structure-object)))))))))))
              (:div :id "input"
                    (:span :id "prompt"
                           (format nil "~a>" (package-short-name *package*)))


### PR DESCRIPTION
This commit brings back printing with `prin1-to-string` in REPL mode which was replaced with `value->html`. Rationale behind this:
![20220503_21h23m56s_grim](https://user-images.githubusercontent.com/812069/166520545-9e7a55d8-98fc-4c8b-8670-f386242eea94.png)

I cannot read the output of `*features*`. Printer says it's a property list, but I don't see semantics of a property list here. It's just a list with even number of arguments, there are no keys and values in it.

Because `value->html` was added on purpose, I think that user must have a choice between it and the previous behaviour (this choice is provided with `verbatim-p` which I introduced). Or maybe even revert aaed554.