### PR TITLE
Redesign the REPL to be a Notebook-like environment.

### DIFF
--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -34,7 +34,6 @@
       (list
        "C-return" 'evaluate-cell
        "(" 'paren
-       ")" 'closing-paren
        "tab" 'tab-complete-symbol
        ;; TODO: Check out the Jupyter notebook bindings.
        )

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -243,20 +243,32 @@
              (:div :id "evaluations"
                    (loop
                      for evaluation in (evaluations repl-mode)
-                     for order from 0 by 1
+                     for order from 0
                      collect (:div :class "input"
-                                   (:span :class "prompt" (package-short-name (eval-package evaluation)) "> ")
+                                   (:span :class "prompt"
+                                          (:button
+                                           :onclick (ps:ps (nyxt/ps:lisp-eval `(move-cell-up :id ,order)))
+                                           :title "Move this cell up."
+                                           "↑")
+                                          (:button
+                                           :onclick (ps:ps (nyxt/ps:lisp-eval `(move-cell-down :id ,order)))
+                                           :title "Move this cell down."
+                                           "↓") "> ")
                                    (:input :class "input-buffer" :data-repl-id order :type "text"
                                            :value (input evaluation)))
                      collect (loop
                                for result in (results evaluation)
-                               collect (:raw
-                                        (value->html
-                                         result (or (typep result 'standard-object)
-                                                    (typep result 'structure-object))))
+                               for sub-order from 0
+                               for name = (if (serapeum:single (results evaluation))
+                                              (intern (format nil "V~d" order))
+                                              (intern (format nil "V~d.~d" order sub-order)))
+                               do (setf (symbol-value name) result)
+                               collect (:span (format nil "~(~a~) = " name)
+                                              (:raw (value->html result (or (typep result 'standard-object)
+                                                                            (typep result 'structure-object)))))
                                collect (:br)))
                    (:div :class "input"
-                         (:span :class "prompt" (package-short-name *package*) "> ")
+                         (:span :class "prompt" ">")
                          (:input :class "input-buffer"
                                  :data-repl-id ""
                                  :type "text" :value ""

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -151,16 +151,17 @@
 (define-command evaluate-cell (&optional (repl (find-submode 'repl-mode)))
   "Evaluate the currently focused input cell."
   (let* ((input (input repl))
-         (id (current-evaluation repl))
+         (id (current-cell-id repl))
          (evaluation (make-instance 'evaluation
                                     :input input
                                     :results (nyxt::evaluate input))))
-    (if id
-        (setf (elt (evaluations repl) id) evaluation
-              (current-evaluation repl) id)
-        (setf (current-evaluation repl) (length (evaluations repl))
-              (evaluations repl) (append (evaluations repl) (list evaluation))))
-    (reload-buffers (list (buffer repl)))))
+    (unless (uiop:emptyp input)
+      (if id
+          (setf (elt (evaluations repl) id) evaluation
+                (current-evaluation repl) id)
+          (setf (current-evaluation repl) (length (evaluations repl))
+                (evaluations repl) (append (evaluations repl) (list evaluation))))
+      (reload-buffers (list (buffer repl))))))
 
 (define-command previous-cell (&optional (repl (find-submode 'repl-mode)))
   "Move to the previous input cell."

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -160,7 +160,7 @@
       ((zerop len)
        (focus ".input-buffer[data-repl-id=\"\"]"))
       ((or (null id) (zerop id))
-       (focus ".input-buffer[data-repl-id=\"0\"]"))
+       (focus (format nil ".input-buffer[data-repl-id=\"~a\"]" (1- len))))
       (t (focus (format nil ".input-buffer[data-repl-id=\"~a\"]" (1- id)))))))
 
 (define-command next-cell (&optional (repl (find-submode 'repl-mode)))

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -253,7 +253,7 @@
                                           (:button
                                            :onclick (ps:ps (nyxt/ps:lisp-eval `(move-cell-down :id ,order)))
                                            :title "Move this cell down."
-                                           "↓") "> ")
+                                           "↓"))
                                    (:input :class "input-buffer" :data-repl-id order :type "text"
                                            :value (input evaluation)))
                      collect (loop

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -5,6 +5,26 @@
     (:documentation "Mode for programming in Common Lisp."))
 (in-package :nyxt/repl-mode)
 
+(define-class evaluation ()
+  ((input
+    nil
+    :type (maybe string)
+    :documentation "User input.")
+   (eval-package
+    *package*
+    :type package
+    :documentation "The package that the evaluation happens in.")
+   (results
+    nil
+    :documentation "The results (as a list) of `input' evaluation.")
+   (raised-condition
+    nil
+    :type (maybe condition)
+    :documentation "The condition that was raised during the `input' execution."))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (class*:make-name-transformer name)))
+
 (define-mode repl-mode ()
   "Mode for interacting with the REPL."
   ((rememberable-p nil)
@@ -12,12 +32,12 @@
     (define-scheme "repl"
       scheme:cua
       (list
-       "return" 'return-input
+       "C-return" 'evaluate-cell
        "(" 'paren
        ")" 'closing-paren
        "tab" 'tab-complete-symbol
-       "up" 'evaluation-history-previous
-       "down" 'evaluation-history-next)
+       ;; TODO: Check out the Jupyter notebook bindings.
+       )
       scheme:emacs
       (list
        "C-f" 'nyxt/input-edit-mode:cursor-forwards
@@ -27,19 +47,21 @@
        "C-d" 'nyxt/input-edit-mode:delete-forwards
        "M-backspace" 'nyxt/input-edit-mode:delete-backwards-word
        "M-d" 'nyxt/input-edit-mode:delete-forwards-word
-       "M-p" 'evaluation-history-previous
-       "M-n" 'evaluation-history-next)
+       "C-M-x" 'evaluate-cell
+       "M-p" 'previous-cell
+       "M-n" 'next-cell)
       scheme:vi-normal
       (list
        ;; TODO: deleting chars/words
-       ;; TODO: evaluation-history-(previous|next)
        "l" 'nyxt/input-edit-mode:cursor-forwards
        "h" 'nyxt/input-edit-mode:cursor-backwards
        "w" 'nyxt/input-edit-mode:cursor-forwards-word
        "b" 'nyxt/input-edit-mode:cursor-backwards-word
        "x" 'nyxt/input-edit-mode:delete-forwards
        "d b" 'nyxt/input-edit-mode:delete-backwards-word
-       "d w" 'nyxt/input-edit-mode:delete-forwards-word)))
+       "d w" 'nyxt/input-edit-mode:delete-forwards-word
+       ;; TODO: Check out the VI bindings for such cases.
+       )))
    (style (theme:themed-css (theme *browser*)
             (* :font-family "monospace,monospace")
             (body :margin-right "0")
@@ -48,41 +70,31 @@
                           :height "100%"
                           :color theme:text
                           :background-color theme:background)
-            ("#input" :display "grid"
-                      :grid-template-columns "auto 1fr"
-                      :width "100%"
-                      :padding 0
-                      :margin 0
-                      :background-color theme:tertiary)
-            ("#input-buffer" :width "100%"
-                             :border "none"
-                             :outline "none"
-                             :padding "3px"
-                             :background-color theme:quaternary
-                             :autofocus "true")
-            ("#evaluation-history"
+            (.input :display "grid"
+                    :grid-template-columns "auto 1fr"
+                    :width "100%"
+                    :padding 0
+                    :margin 0
+                    :background-color theme:tertiary)
+            (.input-buffer :width "100%"
+                           :border "none"
+                           :outline "none"
+                           :padding "3px"
+                           :background-color theme:quaternary
+                           :autofocus "true")
+            ("#evaluations"
              :font-size "12px"
              :flex-grow "1"
              :overflow-y "auto"
              :overflow-x "auto")
-            ("#prompt" :padding-right "4px"
-                       :padding-left "4px"
-                       :line-height "30px"
-                       :color theme:background)
-            (ul :list-style "none"
-                :padding "0"
-                :margin "0")
-            (li :padding "2px"))
+            (.prompt :padding-right "4px"
+                     :padding-left "4px"
+                     :line-height "30px"
+                     :color theme:background))
           :documentation "The CSS applied to a REPL when it is set-up.")
-   (evaluation-history (list)
-                       :documentation "A list of pairs of (PACKAGE INPUT RESULTS).
-INPUT is a string and RESULTS is a list of Lisp values.")
-   (current-evaluation-history-element
-    nil
-    :type (or null integer)
-    :documentation "Current element of history being edited in the REPL prompt.
-
-Scroll history with `evaluation-history-previous' and `evaluation-history-next'."))
+   (evaluations
+    (list)
+    :documentation "A list of `evaluation's representing the current state of the REPL."))
   (:toggler-command-p nil))
 
 (defun package-short-name (package)
@@ -96,7 +108,7 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
 
 (defmethod (setf input) (new-text (mode repl-mode))
   (pflet ((set-input-text (text)
-           (setf (ps:@ (nyxt/ps:qs document "#input-buffer") value) (ps:lisp text))))
+           (setf (ps:@ document active-element value) (ps:lisp text))))
     (with-current-buffer (buffer mode)
       (set-input-text new-text))))
 
@@ -110,25 +122,57 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
 
 (defmethod (setf cursor) (new-position (mode repl-mode))
   (pflet ((selection-start (position)
-           (setf (ps:chain (nyxt/ps:qs document "#input-buffer") selection-start)
-                 (setf (ps:chain (nyxt/ps:qs document "#input-buffer") selection-end)
+           (setf (ps:@ document active-element selection-start)
+                 (setf (ps:@ document active-element selection-end)
                        (ps:lisp position)))))
     (with-current-buffer (buffer mode)
       (selection-start new-position))))
 
-(define-command return-input (&optional (repl (find-submode 'repl-mode)))
-  "Return inputted text."
-  (let ((input (input repl)))
-    (add-object-to-evaluation-history repl
-                                      (list (package-short-name *package*)
-                                            input
-                                            (nyxt::evaluate input)))
+(defmethod current-cell-id ((mode repl-mode))
+  (pflet ((get-id ()
+           (ps:chain document active-element (get-attribute "data-repl-id"))))
+    (with-current-buffer (buffer mode)
+      (ignore-errors (parse-integer (get-id))))))
+
+(define-command evaluate-cell (&optional (repl (find-submode 'repl-mode)))
+  "Evaluate the currently focused input cell."
+  (let* ((input (input repl))
+         (id (current-cell-id repl))
+         (evaluation (make-instance 'evaluation
+                                    :input input
+                                    :results (nyxt::evaluate input))))
+    (if id
+        (setf (elt (evaluations repl) id) evaluation)
+        (setf (evaluations repl) (append (evaluations repl) (list evaluation))))
     ;; Reset history counter, as it doesn't make sense with new input.
-    (setf (current-evaluation-history-element repl) nil)
     (reload-buffers (list (buffer repl)))))
 
-(defmethod add-object-to-evaluation-history ((repl repl-mode) item)
-  (push item (evaluation-history repl)))
+(define-parenscript focus (selector)
+  (ps:chain (nyxt/ps:qs document (ps:lisp selector)) (focus))
+  (when (functionp (ps:chain (nyxt/ps:qs document (ps:lisp selector)) select))
+    (ps:chain (nyxt/ps:qs document (ps:lisp selector)) (select))))
+
+(define-command previous-cell (&optional (repl (find-submode 'repl-mode)))
+  "Move to the previous input cell."
+  (let ((id (current-cell-id repl))
+        (len (length (evaluations repl))))
+    (cond
+      ((zerop len)
+       (focus ".input-buffer[data-repl-id=\"\"]"))
+      ((or (null id) (zerop id))
+       (focus ".input-buffer[data-repl-id=\"0\"]"))
+      (t (focus (format nil ".input-buffer[data-repl-id=\"~a\"]" (1- id)))))))
+
+(define-command next-cell (&optional (repl (find-submode 'repl-mode)))
+  "Move to the next input cell."
+  (let ((id (current-cell-id repl))
+        (len (length (evaluations repl))))
+    (cond
+      ((or (zerop len)
+           (null id)
+           (= id (1- len)))
+       (focus ".input-buffer[data-repl-id=\"\"]"))
+      (t (focus (format nil ".input-buffer[data-repl-id=\"~a\"]" (1+ id)))))))
 
 (define-command paren (&optional (repl (find-submode 'repl-mode)))
   ;; FIXME: Not an intuitive behavior? What does Emacs do?
@@ -150,7 +194,7 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
       (setf (cursor repl) cursor))))
 
 (define-command tab-complete-symbol (&optional (repl (find-submode 'repl-mode)))
-  "Complete the current symbol and insert the completion into the REPL prompt."
+  "Complete the current symbol and insert the completion into the current input area."
   (let* ((input (input repl))
          (cursor (cursor repl))
          (previous-delimiter (unless (= cursor 0)
@@ -172,23 +216,6 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
                                      completion (subseq input cursor))
             (cursor repl) (+ cursor (- (length completion) (- cursor previous-delimiter)))))))
 
-(define-command evaluation-history-previous (&optional (repl (find-submode 'repl-mode)))
-  "Fill REPL input with the value of the previous REPL history element."
-  (let* ((current (1+ (or (current-evaluation-history-element repl) -1)))
-         (elt (when (> (length (evaluation-history repl)) current)
-                (elt (evaluation-history repl) current))))
-    (if elt
-        (setf (input repl) (second elt)
-              (current-evaluation-history-element repl) current)
-        (echo-warning "No more elements in evaluation history"))))
-
-(define-command evaluation-history-next (&optional (repl (find-submode 'repl-mode)))
-  "Fill REPL input with the value of the next REPL history element."
-  (if (and (current-evaluation-history-element repl)
-           (not (zerop (current-evaluation-history-element repl))))
-      (setf (input repl) (elt (evaluation-history repl) (decf (current-evaluation-history-element repl))))
-      (echo-warning "No more elements in evaluation history")))
-
 (define-internal-page-command-global lisp-repl ()
     (repl-buffer "*Lisp REPL*" 'repl-mode)
   "Show Lisp REPL."
@@ -197,18 +224,24 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
       (:head (:style (style repl-mode)))
       (:body
        (:div :id "container"
-             (:div :id "evaluation-history"
-                   (:ul (loop
-                          for (package input results) in (reverse (evaluation-history repl-mode))
-                          collect (:li (:b package "> " input)
-                                       (loop
-                                         for result in results
-                                         collect (:li (:raw
-                                                       (value->html
-                                                        result (or (typep result 'standard-object)
-                                                                   (typep result 'structure-object))))))))))
-             (:div :id "input"
-                   (:span :id "prompt"
-                          (format nil "~a>" (package-short-name *package*)))
-                   (:input :type "text" :id "input-buffer"
-                           :autofocus "autofocus")))))))
+             (:div :id "evaluations"
+                   (loop
+                     for evaluation in (evaluations repl-mode)
+                     for order from 0 by 1
+                     collect (:div :class "input"
+                                   (:span :class "prompt" (package-short-name (eval-package evaluation)) "> ")
+                                   (:input :class "input-buffer" :data-repl-id order :type "text"
+                                           :value (input evaluation)))
+                     collect (loop
+                               for result in (results evaluation)
+                               collect (:raw
+                                        (value->html
+                                         result (or (typep result 'standard-object)
+                                                    (typep result 'structure-object))))
+                               collect (:br)))
+                   (:div :class "input"
+                         (:span :class "prompt" (package-short-name *package*) "> ")
+                         (:input :class "input-buffer"
+                                 :data-repl-id ""
+                                 :type "text" :value ""
+                                 :placeholder "Input some Lisp expression here"))))))))

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -109,7 +109,7 @@
 
 (defmethod input ((mode repl-mode))
   (with-current-buffer (buffer mode)
-    (peval (ps:@ (nyxt/ps:qs document "#input-buffer") value))))
+    (peval (ps:@ document active-element value))))
 
 (defmethod (setf input) (new-text (mode repl-mode))
   (pflet ((set-input-text (text)

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -34,9 +34,7 @@
       (list
        "C-return" 'evaluate-cell
        "(" 'paren
-       "tab" 'tab-complete-symbol
-       ;; TODO: Check out the Jupyter notebook bindings.
-       )
+       "tab" 'tab-complete-symbol)
       scheme:emacs
       (list
        "C-f" 'nyxt/input-edit-mode:cursor-forwards
@@ -47,6 +45,9 @@
        "M-backspace" 'nyxt/input-edit-mode:delete-backwards-word
        "M-d" 'nyxt/input-edit-mode:delete-forwards-word
        "C-M-x" 'evaluate-cell
+       ;; FIXME: Org uses C-c C-_ and C-c C-^, but those are shadowed by C-c in Nyxt.
+       "C-_" 'move-cell-down
+       "C-^" 'move-cell-up
        "M-p" 'previous-cell
        "M-n" 'next-cell)
       scheme:vi-normal
@@ -54,13 +55,15 @@
        ;; TODO: deleting chars/words
        "l" 'nyxt/input-edit-mode:cursor-forwards
        "h" 'nyxt/input-edit-mode:cursor-backwards
+       "k" 'previous-cell
+       "j" 'next-cell
+       "K" 'move-cell-down
+       "J" 'move-cell-up
        "w" 'nyxt/input-edit-mode:cursor-forwards-word
        "b" 'nyxt/input-edit-mode:cursor-backwards-word
        "x" 'nyxt/input-edit-mode:delete-forwards
        "d b" 'nyxt/input-edit-mode:delete-backwards-word
-       "d w" 'nyxt/input-edit-mode:delete-forwards-word
-       ;; TODO: Check out the VI bindings for such cases.
-       )))
+       "d w" 'nyxt/input-edit-mode:delete-forwards-word)))
    (style (theme:themed-css (theme *browser*)
             (* :font-family "monospace,monospace")
             (body :margin-right "0")

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -174,6 +174,22 @@
        (focus ".input-buffer[data-repl-id=\"\"]"))
       (t (focus (format nil ".input-buffer[data-repl-id=\"~a\"]" (1+ id)))))))
 
+(define-command move-cell-up (&key (repl (find-submode 'repl-mode)) (id (current-cell-id repl)))
+  "Move the current code cell up, swapping it with the one above."
+  (when (and id (not (zerop id)))
+    (let* ((evals (evaluations repl)))
+      (psetf (elt evals (1- id)) (elt evals id)
+             (elt evals id) (elt evals (1- id))))
+    (reload-buffers (list (buffer repl)))))
+
+(define-command move-cell-down (&key (repl (find-submode 'repl-mode)) (id (current-cell-id repl)))
+  "Move the current code cell down, swapping it with the one below."
+  (when (and id (< id (1- (length (evaluations repl)))))
+    (let* ((evals (evaluations repl)))
+      (psetf (elt evals (1+ id)) (elt evals id)
+             (elt evals id) (elt evals (1+ id))))
+    (reload-buffers (list (buffer repl)))))
+
 (define-command paren (&optional (repl (find-submode 'repl-mode)))
   ;; FIXME: Not an intuitive behavior? What does Emacs do?
   "Inserts the closing paren after the opening one is inputted."


### PR DESCRIPTION
This a draft of how our REPL could look as a Notebook-like multiple-pane enviroment. See the attached screenshot for the visuals. The features so far are:
- Evaluation of independent cells.
- Movement between cells.

![repl-redesigned](https://user-images.githubusercontent.com/57838654/166525178-3289ee05-548b-48f3-b44e-132bdbced889.png)

# Things to Do
- CUA bindings (based on Jupyter Notebook).
- Inline debugging (will require refactoring our internal debugger a bit).
- More commands for cell management.

# Things to Discuss
- Do we actually want to have it as a default REPL? Feels unfamilliar, even though it's cool...
- What are the VI bindings that could make sense for Notebook mode?
- Should we allow moving cells?
- How should one add new cells -- only in the bottom of the screen or between any existing cells?