### PR TITLE
libssl-dev added for debian-based GTK dependencies

### DIFF
--- a/documents/README.org
+++ b/documents/README.org
@@ -131,7 +131,7 @@ git clone https://github.com/joachifm/cl-webkit ~/common-lisp/cl-webkit
 
 - Debian-based distributions:
   #+begin_src sh
-  sudo apt install sbcl libwebkit2gtk-4.0-dev gobject-introspection glib-networking gsettings-desktop-schemas libfixposix-dev pkg-config xclip enchant-2
+  sudo apt install sbcl libwebkit2gtk-4.0-dev gobject-introspection glib-networking gsettings-desktop-schemas libfixposix-dev pkg-config xclip enchant-2 libssl-dev
   #+end_src
 
 - Arch Linux:


### PR DESCRIPTION
fixed comiple error

Unable to load any of the alternatives:
("libcrypto.so.1.1" "libcrypto.so.1.0.0" "libcrypto.so")