### PR TITLE
Documentation: improve developer readme to avoid quicklisp problem faced by an user

### DIFF
--- a/documents/README.org
+++ b/documents/README.org
@@ -244,6 +244,15 @@ mkdir -p ~/common-lisp
 git clone --recurse-submodules https://github.com/atlas-engineer/nyxt ~/common-lisp/nyxt
 #+end_src
 
+*** Observation
+
+    Quicklisp contains stable releases of Nyxt. If you are reading this, you
+    probably want to run cutting edge under development master branch of Nyxt
+    (not the last stable release). Via Quicklisp, some users end up installing a
+    stable release instead of running the frontier of Nyxt's live GitHub
+    repository. Thus, to access master branch do the git clone of Nyxt in
+    =~/quicklisp/local-projects=.
+
 ** Compile
 *** Using the Makefile
 

--- a/documents/README.org
+++ b/documents/README.org
@@ -241,7 +241,7 @@ will find it]]):
 
 #+begin_src sh
 mkdir -p ~/common-lisp
-git clone https://github.com/atlas-engineer/nyxt ~/common-lisp/nyxt
+git clone --recurse-submodules https://github.com/atlas-engineer/nyxt ~/common-lisp/nyxt
 #+end_src
 
 ** Compile


### PR DESCRIPTION
Hi guys,

I have been interacting with some alpha users of [Hermes](https://github.com/atlas-engineer/hermes) with @jmercouris. Yesterday, we were experimenting with an arch LInux user who was new to Nyxt and Hermes. He had a small problem during the installation.

We were willing to make him run Nyxt from source using cutting-edge master. However, while using quicklisp installation, he ended up having the last stable release of Nyxt in his machine. It was only possible to realize this because John and I were there. The new starting page also helped hugely.

It even took a while until John and I uncovered the problem. The fix was doing a git clone of Nyxt on `quicklisp/local-projects/`.
Also, there was a hassle with some dependencies. If my understanding is correct, this would have been avoided with a **recursive** `git clone`.

Thus, I am sending the patch. John, feel free to correct me if the narrative is wrong in some sense. @Ambrevar, feel free to change the "wording".