### PR TITLE
Ensure prompter is destroyed after it's selection is returned.

### DIFF
--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -399,10 +399,10 @@ instead."
     (setf action #'identity))
   (setf (returned-p prompter) t)
   (add-input-to-history prompter)
-  (alex:when-let ((selection-values (resolve-selection prompter)))
+  (alex:if-let ((selection-values (resolve-selection prompter)))
     (let ((action-result (funcall action selection-values)))
-      (calispel:! (result-channel prompter) action-result)))
-  (destroy prompter))
+      (calispel:! (result-channel prompter) action-result))
+    (destroy prompter)))
 
 (export-always 'toggle-follow)
 (defun toggle-follow (prompter &optional (source (selected-source prompter)))

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -399,10 +399,10 @@ instead."
     (setf action #'identity))
   (setf (returned-p prompter) t)
   (add-input-to-history prompter)
-  (alex:if-let ((selection-values (resolve-selection prompter)))
+  (alex:when-let ((selection-values (resolve-selection prompter)))
     (let ((action-result (funcall action selection-values)))
-      (calispel:! (result-channel prompter) action-result))
-    (destroy prompter)))
+      (calispel:! (result-channel prompter) action-result)))
+  (destroy prompter))
 
 (export-always 'toggle-follow)
 (defun toggle-follow (prompter &optional (source (selected-source prompter)))

--- a/source/mode/element-hint.lisp
+++ b/source/mode/element-hint.lisp
@@ -170,7 +170,9 @@ FUNCTION is the action to perform on the selected elements."
                                             (add-element-hints :selector selector)))
                             :after-destructor (lambda () (with-current-buffer buffer
                                                       (remove-element-hints))))))
-    (funcall function result)))
+    (funcall function result)
+    (with-current-buffer buffer
+      (remove-element-hints))))
 
 (defmethod prompter:object-attributes :around ((element plump:element))
   `(,@(when (plump:get-attribute element "nyxt-hint")


### PR DESCRIPTION
This is important for use in `query-hints` since without ensuring the prompt is
destroyed the hints will remain on the screen. This is only an issue when the
hints are used to select a input window since this does not refresh the buffer
and therefor will never remove the hints.

I tried to test this against the multiple selection but none the only ones I tried didn't work complaining about the argument number being given to a lambda. If anyone knows of a working command that supports multiple selection against I'd be happy to test it.