### PR TITLE
Change button CSS to better indicate what is and isn't clickable.

### DIFF
--- a/source/status.lisp
+++ b/source/status.lisp
@@ -12,7 +12,7 @@
 This leverages `mode-status' which can be specialized for individual modes."
   (spinneret:with-html-string
     (when (nosave-buffer-p buffer) (:span "⚠ nosave"))
-    (:button :type "button"
+    (:button :type "button" :class "button"
              :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt:toggle-modes)))
              :title (str:concat "Enabled modes: " (list-modes buffer)) "✚")
     (loop for mode in (sera:filter (alex:conjoin #'enabled-p #'visible-in-status-p)
@@ -35,16 +35,16 @@ This leverages `mode-status' which can be specialized for individual modes."
 (export-always 'format-status-buttons)
 (defun format-status-buttons ()
   (spinneret:with-html-string
-    (:button :type "button"
+    (:button :type "button" :class "button"
              :title "Backwards"
              :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/web-mode:history-backwards))) "«")
-    (:button :type "button"
+    (:button :type "button" :class "button"
              :title "Reload"
              :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt:reload-current-buffer))) "↺")
-    (:button :type "button"
+    (:button :type "button" :class "button"
              :title "Forwards"
              :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/web-mode:history-forwards))) "»")
-    (:button :type "button"
+    (:button :type "button" :class "button"
              :title "Execute"
              :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt:execute-command))) "≡")))
 
@@ -72,7 +72,7 @@ This leverages `mode-status' which can be specialized for individual modes."
 (export-always 'format-status-url)
 (defun format-status-url (buffer)
   (spinneret:with-html-string
-    (:button :type "button"
+    (:button :type "button" :class "button"
              :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt:set-url)))
              (format nil " ~a — ~a"
                      (render-url (url buffer))
@@ -85,7 +85,7 @@ This leverages `mode-status' which can be specialized for individual modes."
                          (sera:filter-map #'quri:uri-domain
                                           (mapcar #'url (sort-by-time (buffer-list))))
                          :test #'equal)
-          collect (:button :type "tab"
+          collect (:button :type "tab" :class "button"
                            :onclick (ps:ps (nyxt/ps:lisp-eval
                                             `(nyxt::switch-buffer-or-query-domain ,domain)))
                            domain))))


### PR DESCRIPTION
Previously there was no hover attribute for any of the status buttons other than
the modes. This PR is a simple change which gives a consistent hover attribute
to each of the buttons on the default status buffer.

Before
![bad-css](https://user-images.githubusercontent.com/34443260/168201239-048aca38-b7f2-445f-909f-96e04999f479.gif)

After
![better-css](https://user-images.githubusercontent.com/34443260/168201284-ba504380-00a2-402f-b1ec-7d60e9e9e1ce.gif)

