### PR TITLE
EXTENSIONS.org: Amends list based on extension split

### DIFF
--- a/documents/EXTENSIONS.org
+++ b/documents/EXTENSIONS.org
@@ -26,9 +26,8 @@
   that you can use to test your Nyxt installation (i.e. can you load
   extensions).
 
-- [[https://github.com/efimerspan/nx-mapper][nx-mapper]] ::
-  nx-mapper is an extension which aims to reduce the complexity
-  associated with defining common browsing behaviors desired by power
-  users, such as specifying the look and behavior of sites, as well as
-  establishing healthy habits through blocklists, or managing your
-  browser themes on the fly.
+- [[https://github.com/efimerspan/nx-router][nx-router]] ::
+  nx-router is a URL routing extension for Nyxt. You can set up URL redirects, block lists, open resources with external applications, all in a cohesive configuration language.
+
+- [[https://github.com/efimerspan/nx-tailor][nx-tailor]] ::
+  nx-tailor is a tailor for all-things Nyxt themes which helps you manage them, change them on-the-fly, and discover new ones in a unified interface.


### PR DESCRIPTION
I recently split out the `nx-mapper` extension into two standalone extensions as I feel it's more cohesive to have them each be its own thing and tackle its own specific problems.