### PR TITLE
WIP: build-scripts: Add report-unbound-exports.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Unbound exports
       shell: bash
       run: |
-        ros -e '(asdf:load-system :nyxt/submodules)' -e '(load "build-scripts/report-unbound-exports.lisp")' -e '(unbound-exports :nyxt)'
+        ros -e '(asdf:load-system :nyxt/submodules)' -e '(asdf:load-system :nyxt)' -e '(load "build-scripts/report-unbound-exports.lisp")' -e '(unbound-exports :nyxt)'
 
   guix-test:
     name: Guix test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,11 @@ jobs:
       run: |
         ros -e '(asdf:load-system :nyxt/submodules)' -e '(handler-case (asdf:load-system :nyxt/documentation) (error (a) (format t "caught error ~s~%~a~%" a a) (uiop:quit 17)))'
 
+    - name: Unbound exports
+      shell: bash
+      run: |
+        ros -e '(asdf:load-system :nyxt/submodules)' -e '(load "build-scripts/report-unbound-exports.lisp")' -e '(unbound-exports :nyxt)'
+
   guix-test:
     name: Guix test
     runs-on: ubuntu-latest

--- a/build-scripts/report-unbound-exports.lisp
+++ b/build-scripts/report-unbound-exports.lisp
@@ -1,0 +1,37 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(defun list-unbound-exports (package)
+  (let ((result '()))
+    (do-external-symbols (s (find-package package) result)
+      (when (and (not (fboundp s))
+                 (not (boundp s))
+                 (not (find-class s nil))
+                 ;; TODO: How can we portably check if symbol refers to a type?
+                 #+sbcl
+                 (not (sb-ext:defined-type-name-p s)))
+        (push s result )))))
+
+(defun subpackage-p (subpackage package)
+  "Return non-nil if SUBPACKAGE is a sub-package of PACKAGE.
+A sub-package has a name that starts with that of PACKAGE followed by a '/' separator."
+  (not (null
+        (uiop:string-prefix-p (uiop:strcat (package-name package) "/")
+                              (package-name subpackage)))))
+
+(defun list-subpackages (package)
+  (remove-if (lambda (pkg) (not (subpackage-p pkg package))) (list-all-packages)))
+
+(defun unbound-exports (package)
+  "Report unbound exported symbols for PACKAGE and all its subpackages."
+  (let* ((package (find-package package))
+         (report (delete nil
+                         (mapcar (lambda (package)
+                                   (let ((exports (list-unbound-exports package)))
+                                     (when exports
+                                       (list package exports))))
+                                 (cons (find-package package) (list-subpackages package))))))
+    (when report
+      (format t "~a~&Found unbound symbols in ~a packages."
+              report (length report))
+      (uiop:quit 20))))


### PR DESCRIPTION
We can leverage this code in the CI to detect exported symbols that are unbound.

This can typically happen when there is a typo in an `(export ...)` call.

## To do:

- Test.
- Call it from the CI.

## Questions:

Is there a portable way to detect if a symbol points to a type?  In CCL?
We can do it in SBCL, but it's an extension.

If there is no portable way, then we shall run this CI script only with SBCL.