### PR TITLE
Export list-downloads to avoid breaking base-mode's bindings

### DIFF
--- a/source/mode/base.lisp
+++ b/source/mode/base.lisp
@@ -43,7 +43,7 @@ This mode is a good candidate to be passed to `make-buffer'."
        "f1 b" 'describe-bindings
        "f11" 'toggle-fullscreen
        "C-O" 'load-file
-       "C-j" 'list-downloads
+       "C-j" 'nyxt/download-mode:list-downloads
        "C-space" 'execute-command
        "C-M-space" 'execute-extended-command
        "M-space" 'resume-prompt
@@ -82,7 +82,7 @@ This mode is a good candidate to be passed to `make-buffer'."
        "C-h u s" 'universal-describe-slot
        "C-h k" 'describe-key
        "C-h b" 'describe-bindings
-       "C-d" 'list-downloads
+       "C-d" 'nyxt/download-mode:list-downloads
        "M-x" 'execute-command
        "C-M-x" 'execute-extended-command
        "M-1" (read-from-string "nyxt/repeat-mode:repeat-key")

--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -160,7 +160,7 @@ appearance in the buffer when they are setf'd."
           :background-color theme:tertiary))))
   (:toggler-command-p nil))
 
-
+(export-always 'list-downloads)
 (define-internal-page-command-global list-downloads ()
     (buffer "*Downloads*" 'download-mode)
   "Display a buffer listing all downloads.

--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -160,7 +160,6 @@ appearance in the buffer when they are setf'd."
           :background-color theme:tertiary))))
   (:toggler-command-p nil))
 
-(export-always 'list-downloads)
 (define-internal-page-command-global list-downloads ()
     (buffer "*Downloads*" 'download-mode)
   "Display a buffer listing all downloads.


### PR DESCRIPTION
Currently when C-j is used an error is printed since the function list-downloads
is not exported.