### PR TITLE
Fixes for repl-mode completion and resetting of cursor

### DIFF
--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -156,8 +156,7 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
   "Complete the current symbol and insert the completion into the REPL prompt."
   (let* ((input (input repl))
          (cursor (cursor repl))
-         (empty-input (= cursor 0))
-         (previous-delimiter (unless empty-input
+         (previous-delimiter (unless (= cursor 0)
                                (position-if (lambda (c) (member c '(#\( #\) #\space))) input
                                            :end (1- cursor) :from-end t)))
          (previous-delimiter (if previous-delimiter (1+ previous-delimiter) 0))

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -156,8 +156,10 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
   "Complete the current symbol and insert the completion into the REPL prompt."
   (let* ((input (input repl))
          (cursor (cursor repl))
-         (previous-delimiter (position-if (lambda (c) (member c '(#\( #\) #\space))) input
-                                          :end (1- cursor) :from-end t))
+         (empty-input (= cursor 0))
+         (previous-delimiter (unless empty-input
+                               (position-if (lambda (c) (member c '(#\( #\) #\space))) input
+                                           :end (1- cursor) :from-end t)))
          (previous-delimiter (if previous-delimiter (1+ previous-delimiter) 0))
          (symbol-to-complete (subseq input previous-delimiter cursor))
          (completion (handler-case
@@ -212,4 +214,5 @@ Scroll history with `evaluation-history-previous' and `evaluation-history-next'.
              (:div :id "input"
                    (:span :id "prompt"
                           (format nil "~a>" (package-short-name *package*)))
-                   (:input :type "text" :id "input-buffer")))))))
+                   (:input :type "text" :id "input-buffer"
+                           :autofocus "autofocus")))))))


### PR DESCRIPTION
Empty buffer completion works, and refresh restores cursor position.

Previously you would get an error when tab completion was called with an empty input. This patch resolves this by simply checking if the input is empty and if it is not state that no delimiter was found since no text comes before the cursor.

In addition, the cursor is now set to the input area after a refresh. Since refreshes are done every time the return key is hit this prevents the user from having to select the input field every time and expression is evaluated.

