### PR TITLE
Switch from strings to uninterned symbols for IDs.

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -95,8 +95,9 @@ This can be used to resume former buffers.")
     :export nil
     :documentation "A ring that keeps track of deleted buffers.")
    (windows
-    (make-hash-table :test #'equal)
-    :export nil)
+    (make-hash-table)
+    :export nil
+    :documentation "Table of all windows, indexed by their `id'.")
    (last-active-window
     nil
     :type (or window null)
@@ -106,8 +107,8 @@ useful when no Nyxt window is focused and we still want `ffi-window-active' to
 return something.
 See `current-window' for the user-facing function.")
    (buffers
-    :initform (make-hash-table :test #'equal)
-    :documentation "To manipulate the list of buffers,
+    :initform (make-hash-table)
+    :documentation "Table of all live buffers, indexed by their `id'.
 see `buffer-list', `buffers-get', `buffers-set' and `buffers-delete'.")
    (startup-error-reporter-function
     nil
@@ -358,8 +359,8 @@ restored."
   (when (null browser)
     (error "There is no current *browser*. Is Nyxt started?")))
 
-(defmethod get-unique-identifier ((browser browser))
-  (symbol-name (gensym "")))
+(defun new-id ()
+  (gensym ""))
 
 (-> set-window-title (&optional window buffer) *)
 (export-always 'set-window-title)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -15,10 +15,9 @@
 
 (define-class buffer (renderer-buffer)
   ((id
-    ""
-    :documentation "Unique identifier for a buffer.
-Dead buffers or placeholder buffers (i.e. those not associated with a web view)
-have an empty ID.")
+    (new-id)
+    :type symbol
+    :documentation "Unique identifier for a buffer.")
    ;; TODO: Or maybe a dead-buffer should just be a buffer history?
    (profile
     (alex:if-let ((profile-class (find-profile-class (getf *options* :profile))))
@@ -108,11 +107,9 @@ representation of HTML documents.
 Rendered URLs or the Nyxt's manual qualify as examples.  Buffers are fully
 separated from one another, so that each has its own behaviour and settings."))
 
-(defmethod initialize-instance :after ((buffer buffer) &key (browser *browser*)
+(defmethod initialize-instance :after ((buffer buffer) &key
                                        &allow-other-keys)
-  "Set buffer ID and return buffer."
-  (when browser
-    (setf (id buffer) (get-unique-identifier browser)))
+  "Dummy method to allow forwarding other key arguments."
   buffer)
 
 (defmethod finalize-buffer ((buffer buffer) &key (browser *browser*) &allow-other-keys)
@@ -786,12 +783,12 @@ Return the created buffer."
                  (setf (document-model buffer)
                        (nyxt/dom::named-json-parse body-json))))
 
-(defun dead-buffer-p (buffer) ; TODO: Use this wherever needed.
-  (str:empty? (id buffer)))
+(defun dead-buffer-p (buffer)           ; TODO: Use this wherever needed.
+  (buffers-get (id buffer)))
 
-(-> resurrect-buffer (buffer &key (:browser browser)) (values &optional buffer))
-(defun resurrect-buffer (dead-buffer &key (browser *browser*))
-  (setf (id dead-buffer) (get-unique-identifier browser))
+(-> resurrect-buffer (buffer) (values &optional buffer))
+(defun resurrect-buffer (dead-buffer)
+  ;; (setf (id dead-buffer) (new-id))      ; TODO: Shall we reset the ID?
   (ffi-buffer-make dead-buffer)
   dead-buffer)
 
@@ -1013,8 +1010,6 @@ See `make-buffer' for a description of the arguments."
 (-> add-to-recent-buffers (buffer) *)
 (defun add-to-recent-buffers (buffer)
   "Create a recent-buffer from given buffer and add it to `recent-buffers'."
-  ;; Make sure it's a dead buffer:
-  (setf (id buffer) "")
   (containers:delete-item-if (recent-buffers *browser*) (buffer-match-predicate buffer))
   (containers:insert-item (recent-buffers *browser*) buffer))
 
@@ -1043,7 +1038,6 @@ associated to the buffer is already killed."
                                                  :url (quri:uri "about:blank")))))
         (window-set-buffer parent-window replacement-buffer)))
     (buffers-delete (id buffer))
-    ;; (setf (id buffer) "") ; TODO: Reset ID?
     (add-to-recent-buffers buffer)))
 
 (export-always 'buffer-list)
@@ -1571,7 +1565,7 @@ HISTORY may be NIL for buffers without history."
   (let* ((history (buffer-history buffer))
          (buffers (buffers-with-history history)))
     (sort (sera:filter
-           (sera:equals (id buffer))
+           (sera:eqs (id buffer))
            buffers
            :key (lambda (b) (alex:when-let ((owner (htree:owner history (id b))))
                               (htree:creator-id owner))))
@@ -1597,7 +1591,7 @@ HISTORY may be NIL for buffers without history."
                          (existing-creator-id owner)))))
              (common-parent-buffers
                (sort common-parent-buffers #'string< :key #'id)))
-        (sera:split-sequence-if (sera:equals (id buffer))
+        (sera:split-sequence-if (sera:eqs (id buffer))
                                 common-parent-buffers
                                 :key #'id)))))
 

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -727,7 +727,7 @@ the channel, wrapped alongside the condition and its restarts."))
   (declare (ignore hook))
   (when *debug-on-error*
     (let* ((*debugger-hook* *old-debugger-hook*)
-           (id (parse-integer (get-unique-identifier *browser*)))
+           (id (parse-integer (symbol-name (new-id))))
            (restarts (compute-restarts condition))
            (channel (make-channel 1))
            (handler (make-instance 'condition-handler

--- a/source/inspector.lisp
+++ b/source/inspector.lisp
@@ -38,7 +38,7 @@
      (when (equal value object)
        (return-from ensure-inspected-id id)))
    *inspected-values*)
-  (sera:lret ((id (get-unique-identifier *browser*)))
+  (sera:lret ((id (new-id)))
     (setf (inspected-value id) value)))
 
 

--- a/source/web-extensions-callbacks.lisp
+++ b/source/web-extensions-callbacks.lisp
@@ -123,7 +123,7 @@
 
 (defmethod tabs-on-removed ((buffer buffer))
   (flet ((integer-id (object)
-           (or (ignore-errors (parse-integer (id object)))
+           (or (ignore-errors (parse-integer (symbol-name (id object))))
                0)))
     (dolist (extension (all-extensions))
       (fire-extension-event

--- a/source/web-extensions.lisp
+++ b/source/web-extensions.lisp
@@ -329,7 +329,7 @@ If the popup already exists, close it."
           (nyxt::window-delete-panel-buffer (current-window) existing-popup)
           (let ((popup (make-instance 'panel-buffer
                                       :title (default-title (browser-action extension))
-                                      :id (nyxt::get-unique-identifier *browser*)
+                                      :id (nyxt::new-id)
                                       :default-modes (list extension-class))))
             (setf (popup-buffer extension) popup)
             (nyxt::window-add-panel-buffer

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -11,7 +11,10 @@
   (:metaclass mixin-class))
 
 (define-class window (renderer-window)
-  ((id "")
+  ((id
+    (new-id)
+    :type symbol
+    :documentation "Unique identifier for a window.")
    (titler
     'window-default-title
     :type (or function function-symbol)
@@ -107,7 +110,7 @@ The handlers take the window as argument."))
                                        &allow-other-keys)
   "Set ID."
   (when browser
-    (setf (id window) (get-unique-identifier browser))
+    (setf (id window) (new-id))
     (setf (slot-value browser 'last-active-window) window))
   window)
 


### PR DESCRIPTION
Rationale:
- IDs are expected to be numeric.
- The initial intent with string IDs was to allow for _naming_ buffers /
windows, but:
  - We never do this as of now.
	- Should we ever feel the need, we should introduce an aptly named slot, for
	instance `name'.

This simplifies the code somewhat.

## Question

`gensym` (uninterned symbol) is the idiomatic way to manipulate IDs in Common Lisp.
But Nyxt URLs might still preferer integers instead of uninterned symbols.

@aartaka Thoughts?

## To test:

- Are history owners working properly?
- Are Nyxt URLs working properly?

Fixes #2098.