### PR TITLE
mode/history: Visit page in corresponding buffer when clicking on his…

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -64,6 +64,13 @@ various parts, such as the path of all data files.")
        :border-radius "2px"
        :padding "6px"
        :margin "2px")
+      (.link
+       :all "unset"
+       :text-decoration "underline"
+       :display "inline"
+       :color theme:primary)
+      (".link:hover"
+       :color theme:text)
       (.accent
        :background-color theme:accent)
       (|.button:hover|

--- a/source/mode/history-tree.lisp
+++ b/source/mode/history-tree.lisp
@@ -7,9 +7,6 @@
 (define-mode history-tree-mode ()
   "Mode for history-tree listing."
   ((rememberable-p nil)
-   (display-buffer-id-glyphs-p t
-                               :documentation "Whether to show unique glyphs
-matching buffer `id's along with buffer history entries.")
    (style
     (theme:themed-css (theme *browser*)
       (body

--- a/source/mode/history-tree.lisp
+++ b/source/mode/history-tree.lisp
@@ -16,10 +16,6 @@
       (* :margin 0
          :padding 0
          :list-style "none")
-      (a
-       :color theme:text)
-      ("a:hover"
-       :color theme:primary)
       (".current-buffer a"
        :color theme:text)
       (".current-buffer a:hover"

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -287,6 +287,8 @@ Clicking on a link navigates the history in the corresponding buffer."
                                             (cond
                                               ((eq node (htree:owner-node history current-buffer-id))
                                                (:i (:b title)))
+                                              ((eq node (htree:owner-node history (id buffer)))
+                                               (:i title))
                                               ((htree:owned-p (htree:owner history current-buffer-id) node)
                                                (:b title))
                                               (t title))))))))

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -263,22 +263,33 @@ Otherwise go forward to the only child."
         title)))
 
 (defun render-buffer-history-tree (buffer)
-  "Return the HTML presentation of BUFFER history."
+  "Return the HTML presentation of BUFFER history.
+Clicking on a link navigates the history in the corresponding buffer."
   (with-history (history buffer)
     (let ((current-buffer-id (id (current-buffer))))
       (spinneret:with-html-string
         (:ul (:raw (or (htree:map-owned-tree
                         #'(lambda (node)
-                            (spinneret:with-html-string
-                              (:li
-                               (:a :href (render-url (url (htree:data node)))
-                                   (let ((title (title-or-fallback (htree:data node))))
-                                     (cond
-                                       ((eq node (htree:owner-node history current-buffer-id))
-                                        (:i (:b title)))
-                                       ((htree:owned-p (htree:owner history current-buffer-id) node)
-                                        (:b title))
-                                       (t title)))))))
+                            (let ((node-id (nyxt::ensure-inspected-id node)))
+                              (spinneret:with-html-string
+                                (:li
+                                 (:button :class "button"
+                                          :onclick (ps:ps (nyxt/ps:lisp-eval
+                                                           `(let ((buffer (nyxt::buffers-get ,(id buffer)))
+                                                                  (url (url (htree:data (nyxt::inspected-value ,node-id)))))
+                                                              (with-current-buffer buffer
+                                                                (with-history (history buffer)
+                                                                  (htree:visit-all history (id buffer)
+                                                                                   (nyxt::inspected-value ,node-id)))
+                                                                (load-history-url url))
+                                                              (switch-buffer :id (id buffer)))))
+                                          (let ((title (title-or-fallback (htree:data node))))
+                                            (cond
+                                              ((eq node (htree:owner-node history current-buffer-id))
+                                               (:i (:b title)))
+                                              ((htree:owned-p (htree:owner history current-buffer-id) node)
+                                               (:b title))
+                                              (t title))))))))
                         history
                         (htree:owner history (id buffer))
                         :include-root t

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -312,8 +312,15 @@ Clicking on a link navigates the history in the corresponding buffer."
       (:div (:raw (with-current-buffer buffer (render-buffer-history-tree buffer)))))))
 
 (define-internal-page-command-global history-tree ()
-    (output-buffer "*History*" 'nyxt/history-tree-mode:history-tree-mode)
-  "Display the whole, global history tree."
+  (output-buffer "*History*" 'nyxt/history-tree-mode:history-tree-mode)
+  "Display the whole, global history tree.
+It displays one branch per buffer.
+
+As such, when nodes are shared by multiple buffers, they are displayed multiple
+times.
+
+Thus it is not representative of how the Global History Tree deduplicates nodes
+internally, but this display is clearer and more navigable."
   (let ((mode (find-submode 'nyxt/history-tree-mode:history-tree-mode output-buffer)))
     (spinneret:with-html-string
       (:body (:h1 "History")

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -273,7 +273,7 @@ Clicking on a link navigates the history in the corresponding buffer."
                             (let ((node-id (nyxt::ensure-inspected-id node)))
                               (spinneret:with-html-string
                                 (:li
-                                 (:button :class "button"
+                                 (:button :class "link"
                                           :onclick (ps:ps (nyxt/ps:lisp-eval
                                                            `(let ((buffer (nyxt::buffers-get ,(id buffer)))
                                                                   (url (url (htree:data (nyxt::inspected-value ,node-id)))))


### PR DESCRIPTION
…tory tree link.

Open the `history-tree` (or `buffer-history-tree`).  Now if you click on the link, it will switch to the corresponding buffer and navigate back or forward to the corresponding history location, without corrupting the flow of the history.

Try it, it's awesome!

@aartaka Initially the history tree visualization showed links, which could be seen as more appropriate.
But maybe they are not, since we are not loading anything?
Either way, the style looks really bad.  Can we somehow make it look more like links and less like buttons?