### PR TITLE
WIP: Fix list bookmarks

### DIFF
--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -108,6 +108,10 @@ Setf-able."))
 (define-ffi-generic ffi-buffer-load (buffer url)
   (:documentation "Load URL into BUFFER through the renderer."))
 
+(define-ffi-generic ffi-buffer-load-html (buffer html-content url)
+  (:documentation "Load HTML into BUFFER through the renderer.
+If URL is not nil, relative URLs are resolved against it."))
+
 (define-ffi-generic ffi-buffer-evaluate-javascript (buffer javascript &optional world-name)
   (:documentation "Evaluate JAVASCRIPT in the BUFFER web view.
 See also `ffi-buffer-evaluate-javascript-async'."))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1508,6 +1508,14 @@ local anyways, and it's better to refresh it if a load was queried."
           (load-webkit-history-entry buffer entry))
         (webkit:webkit-web-view-load-uri (gtk-object buffer) (quri:render-uri url)))))
 
+(define-ffi-method ffi-buffer-load-html ((buffer gtk-buffer) html-content url)
+  (declare (type quri:uri url))
+  (webkit:webkit-web-view-load-html (gtk-object buffer)
+                                    html-content
+                                    (if (url-empty-p url)
+                                        "about:blank"
+                                        (render-url url))))
+
 (defmethod ffi-buffer-evaluate-javascript ((buffer gtk-buffer) javascript &optional world-name)
   (%within-renderer-thread
    (lambda (&optional channel)


### PR DESCRIPTION
Fixes #2062. 

Or at least work around the memory issue.

I don't know if anyone is willing to work on pagination / buffering in cl-webkit CFFI, otherwise I suggest we implement a fix like here.

Try it out:

- Create a bookmark file with 3000+ entries like in https://github.com/atlas-engineer/nyxt/issues/2062#issuecomment-1088568861.
- Start nyxt.
- Run `list-bookmarks`.
- Run `list-bookmarks-populate`.

I've created a separate command which would obviously be gone in the final patch.

Proposal: create a list-bookmarks-populate mode, add  an `nyxt:on-signal-load-finished` specialization which does what `list-bookmarks-populate` does.

Thoughts?