### PR TITLE
Make downloads more WebKit-ish.

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -451,45 +451,6 @@ view.")
   (:export-accessor-names-p t)
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defun preprocess-request (request-data)
-  "Deal with REQUEST-DATA with the following rules:
-- If a binding matches KEYS in `request-resource-scheme', run the bound function.
-- If `new-window-p' is non-nil, load in new buffer.
-- If `known-type-p' is nil, download the file.
-- Otherwise let the renderer load the request."
-  (with-slots (url buffer keys) request-data
-    (let* ((keymap (scheme-keymap buffer (request-resource-scheme buffer)))
-           (bound-function (the (or symbol keymap:keymap null)
-                                (keymap:lookup-key keys keymap))))
-      (declare (type quri:uri url))
-      (cond
-        ((not (valid-scheme-p (quri:uri-scheme url)))
-         (uiop:launch-program (list *open-program* (quri:render-uri url))))
-        (bound-function
-         (log:debug "Resource request key sequence ~a" (keyspecs-with-optional-keycode keys))
-         (funcall bound-function :url url :buffer buffer)
-         nil)
-        ((new-window-p request-data)
-         (log:debug "Load URL in new buffer: ~a" (render-url url))
-         (open-urls (list url))
-         nil)
-        ((and (not (known-type-p request-data))
-              (toplevel-p request-data))
-         (log:debug "Buffer ~a initiated download of ~s." (id buffer) (render-url url))
-         (funcall (resolve-symbol :download :function)
-                  buffer url
-                  :proxy-url (proxy-url buffer :downloads-only t)
-                  :cookies "")
-         ;; TODO: WebKitGTK emits "load-failed" if we call
-         ;; webkit-policy-decision-ignore on a download requestion.
-         ;; To work around this, we set the `status' to a value other than
-         ;; `:loading'.
-         (setf (slot-value buffer 'status) :finished)
-         nil)
-        (t
-         (log:debug "Forwarding ~a for buffer ~s" (render-url url) buffer)
-         request-data)))))
-
 (export-always 'url-dispatching-handler)
 (-> url-dispatching-handler
     (symbol

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1685,9 +1685,10 @@ local anyways, and it's better to refresh it if a load was queried."
       (setf (nyxt/download-mode:completion-percentage download)
             (* 100 (webkit:webkit-download-estimated-progress webkit-download))))
     (connect-signal download "decide-destination" nil (webkit-download suggested-file-name)
-      (alex:when-let* ((download-dir (or (download-directory
-                                          (find (webkit:webkit-download-get-web-view webkit-download)
-                                                (buffer-list) :key #'gtk-object))
+      (alex:when-let* ((download-dir (or (ignore-errors
+                                          (download-directory
+                                           (find (webkit:webkit-download-get-web-view webkit-download)
+                                                 (buffer-list) :key #'gtk-object)))
                                          (make-instance 'download-directory)))
                        (download-directory (files:expand download-dir))
                        (native-download-directory (unless (files:nil-pathname-p download-directory)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -808,9 +808,6 @@ See `gtk-browser's `modifier-translator' slot."
      (lambda (context download)
        (declare (ignore context))
        (with-protect ("Error in \"download-started\" signal thread: ~a" :condition)
-         ;; FIXME: Right now we cancel the download and start a new one from
-         ;; the Lisp side. We should rather wrap the DOWNLOAD into the
-         ;; Lisp-side structure.
          (wrap-download download))))
     (maphash
      (lambda (scheme scheme-object)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -930,76 +930,70 @@ See `finalize-buffer'."
       (setf modifiers (funcall (modifier-translator *browser*)
                                (webkit:webkit-navigation-action-get-modifiers navigation-action))))
     (setf url (quri:uri (webkit:webkit-uri-request-uri request)))
-    (if (and (null (hooks:handlers (request-resource-hook buffer)))
-             (null (hooks:handlers (pre-request-hook buffer))))
-        (progn
-          (log:debug "Forward to ~s's renderer (no pre-request-hook nor request-resource-hook handlers)."
-                     buffer)
-          (webkit:webkit-policy-decision-use response-policy-decision))
-        (let* ((request-data
-                 (hooks:run-hook
-                  (request-resource-hook buffer)
-                  (hooks:run-hook (pre-request-hook buffer)
-                                  (make-instance 'request-data
-                                                 :buffer buffer
-                                                 :url (quri:copy-uri url)
-                                                 :keys (unless (uiop:emptyp mouse-button)
-                                                         (list (keymap:make-key
-                                                                :value mouse-button
-                                                                :modifiers modifiers)))
-                                                 :event-type event-type
-                                                 :new-window-p is-new-window
-                                                 :toplevel-p (quri:uri=
-                                                              url (quri:uri (webkit:webkit-web-view-uri
-                                                                             (gtk-object buffer))))
-                                                 :mime-type mime-type
-                                                 :known-type-p is-known-type))))
-               (keymap (scheme-keymap (buffer request-data) (request-resource-scheme (buffer request-data))))
-               (bound-function (the (or symbol keymap:keymap null)
-                                    (keymap:lookup-key (keys request-data) keymap))))
-          (cond
-            ((not (typep request-data 'request-data))
-             (log:debug "Don't forward to ~s's renderer (non request data)."
-                        buffer)
-             (webkit:webkit-policy-decision-ignore response-policy-decision))
-            ;; FIXME: Do we ever use it? Do we actually need it?
-            (bound-function
-             (log:debug "Resource request key sequence ~a" (keyspecs-with-optional-keycode (keys request-data)))
-             (funcall bound-function :url url :buffer buffer)
-             (webkit:webkit-policy-decision-ignore response-policy-decision))
-            ((new-window-p request-data)
-             (log:debug "Load URL in new buffer: ~a" (render-url (url request-data)))
-             (open-urls (list (url request-data)))
-             (webkit:webkit-policy-decision-ignore response-policy-decision))
-            ((not (valid-scheme-p (quri:uri-scheme (url request-data))))
-             (uiop:launch-program (list *open-program* (quri:render-uri (url request-data)))))
-            ((and (not (known-type-p request-data))
-                  (toplevel-p request-data))
-             (log:debug "Initiate download of ~s." (render-url (url request-data)))
-             (webkit:webkit-policy-decision-download response-policy-decision))
-            ((quri:uri= url (url request-data))
-             (log:debug "Forward to ~s's renderer (unchanged URL)."
-                        buffer)
-             (webkit:webkit-policy-decision-use response-policy-decision))
-            ((and (quri:uri= (url buffer) (quri:uri (webkit:webkit-uri-request-uri request)))
-                  (not (quri:uri= (quri:uri (webkit:webkit-uri-request-uri request))
-                                  (url request-data))))
-             ;; Low-level URL string, we must not render the puni codes so use
-             ;; `quri:render-uri'.
-             (setf (webkit:webkit-uri-request-uri request) (quri:render-uri (url request-data)))
-             (log:debug "Don't forward to ~s's renderer (resource request replaced with ~s)."
-                        buffer
-                        (render-url (url request-data)))
-             ;; Warning: We must ignore the policy decision _before_ we
-             ;; start the new load request, or else WebKit will be
-             ;; confused about which URL to load.
-             (webkit:webkit-policy-decision-ignore response-policy-decision)
-             (webkit:webkit-web-view-load-request (gtk-object buffer) request))
-            (t
-             (log:info "Cannot redirect to ~a in an iframe, forwarding to the original URL (~a)."
-                       (render-url (url request-data))
-                       (webkit:webkit-uri-request-uri request))
-             (webkit:webkit-policy-decision-use response-policy-decision)))))))
+    (let* ((request-data
+            (hooks:run-hook
+             (request-resource-hook buffer)
+             (hooks:run-hook (pre-request-hook buffer)
+                             (make-instance 'request-data
+                                            :buffer buffer
+                                            :url (quri:copy-uri url)
+                                            :keys (unless (uiop:emptyp mouse-button)
+                                                    (list (keymap:make-key
+                                                           :value mouse-button
+                                                           :modifiers modifiers)))
+                                            :event-type event-type
+                                            :new-window-p is-new-window
+                                            :toplevel-p (quri:uri=
+                                                         url (quri:uri (webkit:webkit-web-view-uri
+                                                                        (gtk-object buffer))))
+                                            :mime-type mime-type
+                                            :known-type-p is-known-type))))
+           (keymap (scheme-keymap (buffer request-data) (request-resource-scheme (buffer request-data))))
+           (bound-function (the (or symbol keymap:keymap null)
+                                (keymap:lookup-key (keys request-data) keymap))))
+      (cond
+       ((not (typep request-data 'request-data))
+        (log:debug "Don't forward to ~s's renderer (non request data)."
+                   buffer)
+        (webkit:webkit-policy-decision-ignore response-policy-decision))
+       ;; FIXME: Do we ever use it? Do we actually need it?
+       (bound-function
+        (log:debug "Resource request key sequence ~a" (keyspecs-with-optional-keycode (keys request-data)))
+        (funcall bound-function :url url :buffer buffer)
+        (webkit:webkit-policy-decision-ignore response-policy-decision))
+       ((new-window-p request-data)
+        (log:debug "Load URL in new buffer: ~a" (render-url (url request-data)))
+        (open-urls (list (url request-data)))
+        (webkit:webkit-policy-decision-ignore response-policy-decision))
+       ((not (valid-scheme-p (quri:uri-scheme (url request-data))))
+        (uiop:launch-program (list *open-program* (quri:render-uri (url request-data)))))
+       ((and (not (known-type-p request-data))
+             (toplevel-p request-data))
+        (log:debug "Initiate download of ~s." (render-url (url request-data)))
+        (webkit:webkit-policy-decision-download response-policy-decision))
+       ((quri:uri= url (url request-data))
+        (log:debug "Forward to ~s's renderer (unchanged URL)."
+                   buffer)
+        (webkit:webkit-policy-decision-use response-policy-decision))
+       ((and (quri:uri= (url buffer) (quri:uri (webkit:webkit-uri-request-uri request)))
+             (not (quri:uri= (quri:uri (webkit:webkit-uri-request-uri request))
+                             (url request-data))))
+        ;; Low-level URL string, we must not render the puni codes so use
+        ;; `quri:render-uri'.
+        (setf (webkit:webkit-uri-request-uri request) (quri:render-uri (url request-data)))
+        (log:debug "Don't forward to ~s's renderer (resource request replaced with ~s)."
+                   buffer
+                   (render-url (url request-data)))
+        ;; Warning: We must ignore the policy decision _before_ we
+        ;; start the new load request, or else WebKit will be
+        ;; confused about which URL to load.
+        (webkit:webkit-policy-decision-ignore response-policy-decision)
+        (webkit:webkit-web-view-load-request (gtk-object buffer) request))
+       (t
+        (log:info "Cannot redirect to ~a in an iframe, forwarding to the original URL (~a)."
+                  (render-url (url request-data))
+                  (webkit:webkit-uri-request-uri request))
+        (webkit:webkit-policy-decision-use response-policy-decision))))))
 
 ;; See https://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#WebKitLoadEvent
 (defmethod on-signal-load-changed ((buffer gtk-buffer) load-event)


### PR DESCRIPTION
# Description

This makes downloads to re-use existing WebKit infrastructure, and allows to download things with the `"download-started"` WebKitWebContext signal, which makes previously inaccessible downloads possible now!

While it does not yet address #2237, it fixes bugs that were biting me for a long time (like being unable to download anything from Telegram Web).

This also rewamps the request processing, allowing for more flexibility in request redirection (notable highlight: one can now redirect the download URL and make it point to something else). Given this, we can, for example, enable #2164 and other niceties.

# Discussion

- We store `download-directory` in the buffer, but this change renders it quite useless -- most downloads go though WebKitWebContext anyway, which makes them a browser-level phenomena. How about we move the downloads directory to the `browser`?
- I've moved the `request-resource-keys` processing to `on-signal-decide-policy`, but realized that I've never seen or experienced it used. Anywhere. At all. Do we actually need it? Maybe remove it before 3.0?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [X] I have pulled from master before submitting this PR
- [X] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [X] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
