### PR TITLE
Generic / CLOS-based status-buffer API + untangled `vi-mode` out of it

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -161,7 +161,6 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                  (:file "history" :depends-on ("history-tree" "list-history"))
                  (:file "certificate-exception")
                  (:file "keymap-scheme")
-                 (:file "vi") ; TODO: Move to non-core modes when `status' no longer depends on it.
                  (:file "proxy")
                  (:file "download")
                  (:file "process")))
@@ -228,6 +227,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                  (:file "small-web")
                  (:file "style" :depends-on ("bookmarklets"))
                  (:file "tts")
+                 (:file "vi")
                  (:file "visual")
                  (:file "watch"))))
   :in-order-to ((test-op (test-op "nyxt/tests")

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -602,6 +602,15 @@ Return BUFFER."
   "Return the current prompt-buffer."
   (first (active-prompt-buffers (current-window))))
 
+(export-always 'focused-buffer)
+(defun focused-buffer (&optional (window (current-window)) )
+  "Return the current prompt-buffer."
+  ;; TODO: Add message-buffer when we have the slot in `window'.
+  (find-if #'ffi-focused-p
+           (list (first (active-prompt-buffers window))
+                 (active-buffer window)
+                 (status-buffer window))))
+
 (defmethod write-output-to-log ((browser browser))
   "Set the *standard-output* and *error-output* to write to a log file."
   (let ((buffer (current-buffer)))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -604,7 +604,7 @@ Return BUFFER."
 
 (export-always 'focused-buffer)
 (defun focused-buffer (&optional (window (current-window)) )
-  "Return the current prompt-buffer."
+  "Return the currently  focused buffer."
   ;; TODO: Add message-buffer when we have the slot in `window'.
   (find-if #'ffi-focused-p
            (list (first (active-prompt-buffers window))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -593,7 +593,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
   (:accessor-name-transformer (class*:make-name-transformer name))
   (:metaclass user-class))
 
-(define-class status-buffer (buffer)
+(define-class status-buffer (input-buffer)
   ((window nil
     :type (maybe window)
     :documentation "The `window' to which the status buffer is attached.")

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1103,7 +1103,7 @@ proceeding."
   ;; switched inside a `with-current-buffer':
   (setf %buffer nil)
   (set-window-title window)
-  (print-status nil window)
+  (print-status window)
   (when (and (network-buffer-p buffer)
              (eq (slot-value buffer 'status) :unloaded))
     (reload-buffers (list buffer))))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -639,11 +639,6 @@ store them somewhere and `ffi-buffer-delete' them once done."))
        ;; Columns: controls, url, tabs, modes
        :grid-template-columns "90px minmax(auto, 30ch) 1fr 220px"
        :overflow-y "hidden")
-      ("#container-vi"
-       :display "grid"
-       ;; Columns: controls, vi-status, url, tabs, modes
-       :grid-template-columns "90px 30px minmax(auto, 30ch) 1fr 220px"
-       :overflow-y "hidden")
       ("#controls"
        :font-size "16px"
        :font-weight "700"
@@ -653,17 +648,11 @@ store them somewhere and `ffi-buffer-delete' them once done."))
        :overflow "hidden"
        :white-space "nowrap"
        :z-index "4")
-      ("#vi-mode"
+      ("#scheme-mode"
        :padding-right "10px"
        :padding-left "10px"
        :text-align "center"
        :z-index "3")
-      (".vi-normal-mode"
-       :color theme:background
-       :background-color theme:secondary)
-      (".vi-insert-mode"
-       :color theme:background
-       :background-color theme:accent)
       ("#url"
        :color theme:background
        :background-color theme:secondary

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -594,7 +594,10 @@ store them somewhere and `ffi-buffer-delete' them once done."))
   (:metaclass user-class))
 
 (define-class status-buffer (buffer)
-  ((height
+  ((window nil
+    :type (maybe window)
+    :documentation "The `window' to which the status buffer is attached.")
+   (height
     24
     :type integer
     :documentation "The height of the status buffer in pixels.")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -350,7 +350,7 @@ the " (:code "define-configuration") " macro.")
    (:h3 "Appearance")
    (:p "Much of the visual style can be configured by the user.  Search the
 class slots for 'style'.  To customize the status buffer, see
-the " (:code "status-formatter") " window slot.")
+the " (:code "status-buffer") " window slot.")
 
    (:h3 "Advanced configuration")
    (:p "While " (:code "define-configuration") " is convenient, it is mostly

--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -20,7 +20,8 @@ A same source can be used by different prompt buffers.
 Each source offers a set of 'return-actions' for its selection(s).
 Return-actions can be listed and run with `return-selection-over-action' (bound to
 \"M-return\" by default)."
-  ((keymap-scheme
+  ((visible-in-status-p nil)
+   (keymap-scheme
     (define-scheme "prompt-buffer"
       scheme:cua
       (list

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -120,3 +120,18 @@ See also `vi-normal-mode' and `vi-insert-mode'."
 
 (defmethod nyxt/document-mode:element-focused ((mode vi-normal-mode))
   (enable-modes '(vi-insert-mode)))
+
+(defmethod nyxt:mode-status ((status status-buffer) (vi-mode vi-normal-mode))
+  (let ((buffer (current-buffer (window status))))
+    (spinneret:with-html-string
+      (cond ((find-submode 'nyxt/vi-mode:vi-normal-mode buffer)
+             (:div
+              (:button :type "button"
+                       :title "vi-normal-mode"
+                       :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/vi-mode:vi-insert-mode))) "N")))
+            ((find-submode 'nyxt/vi-mode:vi-insert-mode buffer)
+             (:div
+              (:button :type "button"
+                       :title "vi-insert-mode"
+                       :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/vi-mode:vi-normal-mode))) "I")))
+            (t (:span ""))))))

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -97,8 +97,7 @@ See also `vi-normal-mode' and `vi-insert-mode'."
       (enable-modes '(nyxt/passthrough-mode:passthrough-mode)
                     buffer))))
 
-(define-command vi-button1 (&optional (buffer (or (current-prompt-buffer)
-                                                  (current-buffer))))
+(define-command vi-button1 (&optional (buffer (focused-buffer)))
   "Enable VI insert mode when focus is on an input element on the web page.
 See also `vi-normal-mode' and `vi-insert-mode'."
   ;; First we generate a button1 event so that the web view element is clicked

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -121,17 +121,17 @@ See also `vi-normal-mode' and `vi-insert-mode'."
 (defmethod nyxt/document-mode:element-focused ((mode vi-normal-mode))
   (enable-modes '(vi-insert-mode)))
 
-(defmethod nyxt:mode-status ((status status-buffer) (vi-mode vi-normal-mode))
-  (let ((buffer (current-buffer (window status))))
-    (spinneret:with-html-string
-      (cond ((find-submode 'nyxt/vi-mode:vi-normal-mode buffer)
-             (:div
-              (:button :type "button"
-                       :title "vi-normal-mode"
-                       :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/vi-mode:vi-insert-mode))) "N")))
-            ((find-submode 'nyxt/vi-mode:vi-insert-mode buffer)
-             (:div
-              (:button :type "button"
-                       :title "vi-insert-mode"
-                       :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/vi-mode:vi-normal-mode))) "I")))
-            (t (:span ""))))))
+(defmethod nyxt:mode-status ((status status-buffer) (vi-normal vi-normal-mode))
+  (spinneret:with-html-string
+    (:button :type "button"
+             :title "vi-normal-mode"
+             :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/vi-mode:vi-insert-mode)))
+             (:code "N"))))
+
+(defmethod nyxt:mode-status ((status status-buffer) (vi-normal vi-insert-mode))
+  (spinneret:with-html-string
+    (:button :type "button"
+             :title "vi-insert-mode"
+             :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/vi-mode:vi-normal-mode)))
+             ;; Note: We use :code to make it monospaced, so that it's more clickable.
+             (:code "I"))))

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -47,8 +47,7 @@ See `vi-normal-mode'."
       scheme:vi-insert
       (list
        "C-z" 'nyxt/passthrough-mode:passthrough-mode
-       "escape" 'switch-to-vi-normal-mode
-       "button1" 'vi-button1)))
+       "escape" 'switch-to-vi-normal-mode)))
    (passthrough-mode-p nil
                        :type boolean
                        :documentation "Whether to default to `passthrough-mode'
@@ -106,13 +105,9 @@ See also `vi-normal-mode' and `vi-insert-mode'."
   ;; (e.g. a text field gets focus).
   (forward-to-renderer :window (current-window) :buffer buffer)
   (let ((response (nyxt/document-mode:%clicked-in-input? buffer)))
-    (cond
-      ((and (nyxt/document-mode:input-tag-p response)
-            (find-submode 'vi-normal-mode buffer))
-       (enable-modes '(vi-insert-mode) buffer))
-      ((and (not (nyxt/document-mode:input-tag-p response))
-            (find-submode 'nyxt/vi-mode:vi-insert-mode buffer))
-       (enable-modes '(vi-normal-mode) buffer)))))
+    (when (and (nyxt/document-mode:input-tag-p response)
+               (find-submode 'vi-normal-mode buffer))
+      (enable-modes '(vi-insert-mode) buffer))))
 
 (defmethod on-signal-load-finished ((mode vi-insert-mode) url)
   (declare (ignore url))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -229,6 +229,8 @@ See also `show-prompt-buffer'."
 (defun prompt-render-prompt (prompt-buffer)
   (let* ((suggestions (prompter:all-suggestions prompt-buffer))
          (marks (prompter:all-marks prompt-buffer))
+         ;; TODO: Should prompt-buffer be a status-buffer?
+         ;; Then no need to depend on the current status buffer.
          (status-buffer (status-buffer (current-window))))
     (ffi-buffer-evaluate-javascript-async
      prompt-buffer
@@ -241,7 +243,9 @@ See also `show-prompt-buffer'."
                :multi-selection-p (some #'prompter:multi-selection-p
                                         (prompter:sources prompt-buffer)))))
        (setf (ps:chain document (get-element-by-id "prompt-modes") |innerHTML|)
-             (ps:lisp (format-status-modes status-buffer)))))))
+             (ps:lisp (str:join " "
+                                (mapcar (alex:curry #'mode-status status-buffer)
+                                        (sort-modes-for-status (modes prompt-buffer))))))))))
 
 (export 'prompt-render-suggestions)
 (defmethod prompt-render-suggestions ((prompt-buffer prompt-buffer))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -52,12 +52,6 @@ chosen suggestions inside brackets.")
                :grid-template-columns "auto auto 1fr auto"
                :width "100%"
                :color theme:background)
-              ("#prompt-area-vi"
-               :background-color theme:tertiary
-               :display "grid"
-               :grid-template-columns "auto auto 1em 1fr auto"
-               :width "100%"
-               :color theme:background)
               ("#prompt"
                :padding-left "10px"
                :line-height "26px")
@@ -68,13 +62,6 @@ chosen suggestions inside brackets.")
                :line-height "26px"
                :padding-left "3px"
                :padding-right "3px")
-              ("#vi-mode"
-               :margin "2px"
-               :padding "1px")
-              (".vi-normal-mode"
-               :background-color theme:primary)
-              (".vi-insert-mode"
-               :background-color theme:accent)
               ("#input"
                :border "none"
                :outline "none"
@@ -242,14 +229,7 @@ See also `show-prompt-buffer'."
 (defun prompt-render-prompt (prompt-buffer)
   (let* ((suggestions (prompter:all-suggestions prompt-buffer))
          (marks (prompter:all-marks prompt-buffer))
-         ;; TODO: Should make this part mode-extensible instead of hard-coding VI behaviour.
-         (vi-class (cond ((find-submode (resolve-symbol :vi-normal-mode :mode) prompt-buffer)
-                          "vi-normal-mode")
-                         ((find-submode (resolve-symbol :vi-insert-mode :mode) prompt-buffer)
-                          "vi-insert-mode")))
-         (vi-letter (match vi-class
-                      ("vi-normal-mode" "N")
-                      ("vi-insert-mode" "I"))))
+         (status-buffer (status-buffer (current-window))))
     (ffi-buffer-evaluate-javascript-async
      prompt-buffer
      (ps:ps
@@ -260,16 +240,8 @@ See also `show-prompt-buffer'."
                :pad-p t
                :multi-selection-p (some #'prompter:multi-selection-p
                                         (prompter:sources prompt-buffer)))))
-       (when (ps:lisp vi-class)
-         (let ((vi-indicator (ps:chain document (get-element-by-id "vi-mode"))))
-           (setf (ps:chain vi-indicator |innerHTML|) (ps:lisp vi-letter))
-           (setf (ps:chain vi-indicator class-name) (ps:lisp vi-class))))
        (setf (ps:chain document (get-element-by-id "prompt-modes") |innerHTML|)
-             (ps:lisp
-              (format nil "~{~a~^ ~}" (delete "prompt-buffer-mode"
-                                              (mapcar #'princ-to-string
-                                                      (modes prompt-buffer))
-                                              :test #'string=))))))))
+             (ps:lisp (format-status-modes status-buffer)))))))
 
 (export 'prompt-render-suggestions)
 (defmethod prompt-render-suggestions ((prompt-buffer prompt-buffer))
@@ -353,28 +325,23 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
 
 (defun prompt-render-skeleton (prompt-buffer)
   (erase-document prompt-buffer)
-  ;; TODO: Should make this part mode-extensible instead of hard-coding VI behaviour.
-  (let ((vi-mode? (or (find-submode (resolve-symbol :vi-normal-mode :mode) prompt-buffer)
-                      (find-submode (resolve-symbol :vi-insert-mode :mode) prompt-buffer))))
-    (html-set (spinneret:with-html-string
-                (:head (:style (style prompt-buffer)))
-                (:body
-                 (:div :id (if vi-mode? "prompt-area-vi" "prompt-area")
-                       (:div :id "prompt" (:mayberaw (prompter:prompt prompt-buffer)))
-                       (:div :id "prompt-extra" "[?/?]")
-                       (when vi-mode?
-                         (:div :id "vi-mode" ""))
-                       (:div (:input :type (if (invisible-input-p prompt-buffer)
-                                               "password"
-                                               "text")
-                                     :id "input"
-                                     :value (prompter:input prompt-buffer)))
-                       (:div :id "prompt-modes" ""))
-                 (:div :id "suggestions"
-                       :style (if (invisible-input-p prompt-buffer)
-                                  "visibility:hidden;"
-                                  "visibility:visible;"))))
-              prompt-buffer)))
+  (html-set (spinneret:with-html-string
+              (:head (:style (style prompt-buffer)))
+              (:body
+               (:div :id "prompt-area"
+                     (:div :id "prompt" (:mayberaw (prompter:prompt prompt-buffer)))
+                     (:div :id "prompt-extra" "[?/?]")
+                     (:div (:input :type (if (invisible-input-p prompt-buffer)
+                                             "password"
+                                             "text")
+                                   :id "input"
+                                   :value (prompter:input prompt-buffer)))
+                     (:div :id "prompt-modes" ""))
+               (:div :id "suggestions"
+                     :style (if (invisible-input-p prompt-buffer)
+                                "visibility:hidden;"
+                                "visibility:visible;"))))
+            prompt-buffer))
 
 (defun prompt-render-focus (prompt-buffer)
   (ffi-buffer-evaluate-javascript-async

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -997,7 +997,7 @@ See `finalize-buffer'."
              (setf (slot-value buffer 'status) :loading)
              (nyxt/web-extensions::tabs-on-updated buffer '(("status" . "loading")))
              (nyxt/web-extensions::tabs-on-updated buffer `(("url" . ,(render-url url))))
-             (print-status nil (get-containing-window-for-buffer buffer *browser*))
+             (print-status (get-containing-window-for-buffer buffer *browser*))
              (on-signal-load-started buffer url)
              (unless (internal-url-p url)
                (echo "Loading ~s." (render-url url))))
@@ -1017,7 +1017,7 @@ See `finalize-buffer'."
              (nyxt/web-extensions::tabs-on-updated buffer '(("status" . "complete")))
              (nyxt/web-extensions::tabs-on-updated buffer `(("url" . ,(render-url url))))
              (on-signal-load-finished buffer url)
-             (print-status nil (get-containing-window-for-buffer buffer *browser*))
+             (print-status (get-containing-window-for-buffer buffer *browser*))
              (unless (internal-url-p url)
                (echo "Finished loading ~s." (render-url url))))))))
 

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -465,7 +465,6 @@ response.  The BODY is wrapped with `with-protect'."
          (setf (gtk:gtk-widget-size-request message-container)
                (list -1 (message-buffer-height window)))
 
-         (setf status-buffer (make-instance 'status-buffer))
          (gtk:gtk-box-pack-end root-box-layout status-container :expand nil)
          (gtk:gtk-box-pack-start status-container (gtk-object status-buffer) :expand t)
          (setf (gtk:gtk-widget-size-request status-container)

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -3,8 +3,13 @@
 
 (in-package :nyxt)
 
-(defmethod mode-status ((mode mode))
-  (princ-to-string mode))
+(export-always 'mode-status)
+(defgeneric mode-status (status mode)
+  (:method ((status status-buffer) (mode mode))
+    (if (glyph-mode-presentation-p status)
+        (glyph mode)
+        (princ-to-string mode)))
+  (:documentation "Render MODE `mode' for the STATUS `status-buffer'."))
 
 (export-always 'format-status-modes)
 (defun format-status-modes (buffer window)
@@ -18,9 +23,7 @@ This leverages `mode-status' which can be specialized for individual modes."
                  :title (str:concat "Enabled modes: " (modes-string buffer)) "✚")
         (loop for mode in (sera:filter (alex:conjoin #'enabled-p #'visible-in-status-p)
                                        (modes buffer))
-              collect (let* ((formatted-mode (if (glyph-mode-presentation-p (status-buffer window))
-                                                 (glyph mode)
-                                                 (mode-status mode))))
+              collect (let* ((formatted-mode (mode-status (status-buffer window) mode)))
                         (if (html-string-p formatted-mode)
                             (:raw formatted-mode)
                             (:button :class "button"

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -9,29 +9,36 @@
     (if (glyph-mode-presentation-p status)
         (glyph mode)
         (princ-to-string mode)))
-  (:documentation "Render MODE `mode' for the STATUS `status-buffer'."))
+  (:documentation "Return a MODE `mode' string description for the STATUS `status-buffer'.
+Upon returning NIL, the mode is not displayed."))
 
 (export-always 'format-status-modes)
 (defmethod format-status-modes ((status status-buffer))
-  "Format the modes for the status buffer.
+  "Render the enabled modes.
+Any `nyxt/keymap-scheme-mode:keymap-scheme-mode' is placed first.
+
 This leverages `mode-status' which can be specialized for individual modes."
   (let ((buffer (current-buffer (window status))))
     (if (modable-buffer-p buffer)
-        (spinneret:with-html-string
-          (when (nosave-buffer-p buffer) (:span "⚠ nosave"))
-          (:button :type "button" :class "button"
-                   :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt:toggle-modes)))
-                   :title (str:concat "Enabled modes: " (modes-string buffer)) "✚")
-          (loop for mode in (sera:filter (alex:conjoin #'enabled-p #'visible-in-status-p)
-                                         (modes buffer))
-                collect (let* ((formatted-mode (mode-status status mode)))
-                          (if (html-string-p formatted-mode)
-                              (:raw formatted-mode)
-                              (:button :class "button"
-                                       :onclick (ps:ps (nyxt/ps:lisp-eval
-                                                        `(describe-class :class (quote ,(name mode)))))
-                                       :title (format nil "Describe ~a" mode)
-                                       formatted-mode)))))
+        (let ((sorted-modes (multiple-value-bind (scheme-mode other-modes)
+                                (sera:partition #'nyxt/keymap-scheme-mode::keymap-scheme-mode-p
+                                                (sera:filter (alex:conjoin #'enabled-p #'visible-in-status-p)
+                                                             (modes buffer)))
+                              (append scheme-mode other-modes))))
+          (spinneret:with-html-string
+            (when (nosave-buffer-p buffer) (:span "⚠ nosave"))
+            (:button :type "button" :class "button"
+                     :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt:toggle-modes)))
+                     :title (str:concat "Enabled modes: " (modes-string buffer)) "✚")
+            (loop for mode in sorted-modes
+                  collect (alex:when-let ((formatted-mode (mode-status status mode)))
+                            (if (html-string-p formatted-mode)
+                                (:raw formatted-mode)
+                                (:button :class "button"
+                                         :onclick (ps:ps (nyxt/ps:lisp-eval
+                                                          `(describe-class :class ',(name mode))))
+                                         :title (format nil "Describe ~a" mode)
+                                         formatted-mode))))))
         "")))
 
 (defun modes-string (buffer)
@@ -56,20 +63,6 @@ This leverages `mode-status' which can be specialized for individual modes."
     (:button :type "button" :class "button"
              :title "Execute"
              :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt:execute-command))) "≡")))
-
-(defun format-status-vi-mode (&optional (buffer (current-buffer))) ; TODO: List scheme-modes first instead, then remove this.
-  (spinneret:with-html-string
-    (cond ((find-submode 'nyxt/vi-mode:vi-normal-mode buffer)
-           (:div
-            (:button :type "button"
-                     :title "vi-normal-mode"
-                     :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/vi-mode:vi-insert-mode))) "N")))
-          ((find-submode 'nyxt/vi-mode:vi-insert-mode buffer)
-           (:div
-            (:button :type "button"
-                     :title "vi-insert-mode"
-                     :onclick (ps:ps (nyxt/ps:lisp-eval '(nyxt/vi-mode:vi-normal-mode))) "I")))
-          (t (:span "")))))
 
 (export-always 'format-status-load-status)
 (defmethod format-status-load-status ((status status-buffer))
@@ -104,18 +97,11 @@ This leverages `mode-status' which can be specialized for individual modes."
 
 (export-always 'format-status)
 (defmethod format-status ((status status-buffer))
-  (let* ((buffer (current-buffer (window status)))
-         (vi-class (cond ((find-submode 'nyxt/vi-mode:vi-normal-mode buffer)
-                          "vi-normal-mode")
-                         ((find-submode 'nyxt/vi-mode:vi-insert-mode buffer)
-                          "vi-insert-mode"))))
+  (let* ((buffer (current-buffer (window status))))
     (spinneret:with-html-string
-      (:div :id (if vi-class "container-vi" "container")
+      (:div :id "container"
             (:div :id "controls" :class "arrow-right"
                   (:raw (format-status-buttons status)))
-            (when vi-class
-              (:div :id "vi-mode" :class (str:concat vi-class " arrow-right")
-                    (:raw (format-status-vi-mode buffer))))
             (:div :id "url" :class "arrow-right"
                   (:raw
                    (format-status-load-status status)

--- a/source/web-extensions.lisp
+++ b/source/web-extensions.lisp
@@ -297,14 +297,12 @@ slash. WebExtensions require this :/"
   (uiop:merge-pathnames* (string-left-trim "/" (namestring path))
                          (extension-directory extension)))
 
-;; TODO: This is not the right point where to hook into the status bar, since it
-;; won't work if glyphs are on.
-(defmethod nyxt::mode-status ((extension extension))
+(defmethod nyxt:mode-status ((extension extension))
   (spinneret:with-html-string
     (:button :class "button"
              :onclick (ps:ps (nyxt/ps:lisp-eval `(toggle-extension-popup ',(sera:class-name-of extension))))
              :title (format nil "Open the browser action of ~a" extension)
-             (name extension))))
+             (call-next-method))))
 
 (define-command-global toggle-extension-popup (&optional extension-class (buffer (current-buffer)))
   "Open the popup of the extension of EXTENSION-CLASS.

--- a/source/web-extensions.lisp
+++ b/source/web-extensions.lisp
@@ -297,7 +297,7 @@ slash. WebExtensions require this :/"
   (uiop:merge-pathnames* (string-left-trim "/" (namestring path))
                          (extension-directory extension)))
 
-(defmethod nyxt:mode-status ((extension extension))
+(defmethod nyxt:mode-status ((status status-buffer) (extension extension))
   (spinneret:with-html-string
     (:button :class "button"
              :onclick (ps:ps (nyxt/ps:lisp-eval `(toggle-extension-popup ',(sera:class-name-of extension))))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -222,13 +222,11 @@ See `define-panel' for the description of the arguments."
   (setf (slot-value window 'active-buffer) buffer)
   (print-status))
 
-(defun print-status (&optional status window) ; TODO: STATUS argument is never used.
-  (let ((window (or window (current-window))))
-    (when (and window (status-buffer window))
-      (ffi-print-status
-       window
-       (or status
-           (funcall (format-status window)))))))
+(defun print-status (&optional (window (current-window)))
+  (when (and window (status-buffer window))
+    (ffi-print-status
+     window
+     (format-status (status-buffer window)))))
 
 (hooks:define-hook-type window (function (window)))
 


### PR DESCRIPTION
Fixes #2218, #2219.

This removes some 50 lines of code! :)

To do:

- [x] Do not display all these modes in the prompt-buffer, and don't display them as buttons.