### PR TITLE
mode/force-https: Fix force-https-handler (quri update)

### DIFF
--- a/source/mode/force-https.lisp
+++ b/source/mode/force-https.lisp
@@ -58,9 +58,9 @@ Example:
        (log:info "HTTPS enforced on '~a'" (render-url url))
        ;; FIXME: http-only websites are displayed as "https://foo.bar"
        ;; FIXME: some websites (e.g., go.com) simply time-out
-       (setf (quri:uri-scheme url) "https"
-             (quri:uri-port url) (quri.port:scheme-default-port "https")
-             (url request-data) url)
+       (setf (url request-data)
+             (quri:copy-uri url :scheme "https"
+                                :port (quri.port:scheme-default-port "https")))
        request-data))))
 
 (defmethod enable ((mode force-https-mode) &key)


### PR DESCRIPTION
Due to a change in the quri library - the scheme of the URIs is no longer
setfable.

This must be merged after this [gets merged into the quri library](https://github.com/fukamachi/quri/pull/58).