### PR TITLE
Fix source location on deploy

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -42,6 +42,7 @@ to use your local install of Quicklisp.  For example:
 But in this case, you don't have to use `make' at all.  Instead, you could build
 Nyxt with an invocation along these lines:
 
+    export NYXT_LOGICAL_PATH=true # Dynamic relocation of the source code
     sbcl --non-interactive --no-userinit --eval '(require "asdf")' --eval '(asdf:make :nyxt/gi-gtk-application)' --quit
 
 (Assuming Nyxt is checked out in a directory traversed by ASDF, like

--- a/makefile
+++ b/makefile
@@ -15,6 +15,7 @@ LISP_FLAGS ?= $(SBCL_FLAGS) --no-userinit --non-interactive
 
 NYXT_SUBMODULES=true
 NYXT_RENDERER=gi-gtk
+NYXT_LOGICAL_PATH=true
 
 .PHONY: help
 help:

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -20,6 +20,16 @@
         ("NYXT:libraries;**;*.*.*"
          ,(uiop:ensure-pathname (uiop:subpathname* *default-pathname-defaults* "libraries/") :wilden t))))
 
+(defun npath (path)
+  "If NYXT_LOGICAL_PATH environment variable is set, use logical path source
+location, otherwise use the translated path.
+
+Tools such as Emacs (SLIME and SLY) may fail to make use of logical paths, say,
+to go to the compilation error location."
+  (if (uiop:getenv "NYXT_LOGICAL_PATH")
+      (translate-logical-pathname path)
+      path))
+
 (defvar *prefix* (merge-pathnames* (if (getenv "PREFIX")
                                        (relativize-pathname-directory (ensure-directory-pathname (getenv "PREFIX")))
                                        #p"usr/local/")
@@ -114,7 +124,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                nyxt/ospm
                nyxt/prompter
                nyxt/theme)
-  :pathname #p"NYXT:source;"
+  :pathname #.(npath #p"NYXT:source;")
   :components ((:file "package")
                (:module "Utilities"
                 :pathname ""
@@ -389,7 +399,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
   :depends-on (nyxt
                cl-cffi-gtk
                cl-webkit2)
-  :pathname #p"NYXT:source;"
+  :pathname #.(npath #p"NYXT:source;")
   :serial t
   :components ((:file "web-extensions")
                (:file "web-extensions-callbacks")
@@ -400,7 +410,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
   :depends-on (nyxt/gtk
                cl-gobject-introspection
                bordeaux-threads)
-  :pathname #p"NYXT:source;"
+  :pathname #.(npath #p"NYXT:source;")
   :components ((:file "renderer/gi-gtk"))
   :in-order-to ((test-op (test-op "nyxt/gi-gtk/tests"))))
 
@@ -415,7 +425,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
   :depends-on (nyxt
                cl-webengine
                trivial-main-thread)
-  :pathname #p"NYXT:source;"
+  :pathname #.(npath #p"NYXT:source;")
   :components ((:file "renderer/qt")))
 
 ;; We should not set the build-pathname in systems that have a component.
@@ -566,7 +576,7 @@ the few modules that's not automatically included in the image."
                log4cl
                quri
                str)
-  :pathname #p"NYXT:libraries;download-manager;"
+  :pathname #.(npath #p"NYXT:libraries;download-manager;")
   :components ((:file "package")
                (:file "engine")
                (:file "native"))
@@ -583,7 +593,7 @@ the few modules that's not automatically included in the image."
                serapeum
                alexandria
                cl-ppcre)
-  :pathname #p"NYXT:libraries;analysis;"
+  :pathname #.(npath #p"NYXT:libraries;analysis;")
   :components ((:file "package")
                (:file "data")
                (:file "stem")
@@ -596,13 +606,13 @@ the few modules that's not automatically included in the image."
 
 (defsystem "nyxt/user-interface"
   :depends-on (spinneret)
-  :pathname #p"NYXT:libraries;user-interface;"
+  :pathname #.(npath #p"NYXT:libraries;user-interface;")
   :components ((:file "package")
                (:file "user-interface")))
 
 (defsystem "nyxt/text-buffer"
   :depends-on (cluffer)
-  :pathname #p"NYXT:libraries;text-buffer;"
+  :pathname #.(npath #p"NYXT:libraries;text-buffer;")
   :components ((:file "package")
                (:file "text-buffer")))
 
@@ -612,7 +622,7 @@ the few modules that's not automatically included in the image."
                local-time
                nyxt/class-star
                trivial-package-local-nicknames)
-  :pathname #p"NYXT:libraries;history-tree;"
+  :pathname #.(npath #p"NYXT:libraries;history-tree;")
   :components ((:file "package")
                (:file "history-tree"))
   :in-order-to ((test-op (test-op "nyxt/history-tree/tests"))))
@@ -630,7 +640,7 @@ the few modules that's not automatically included in the image."
                uiop
                nyxt/class-star
                serapeum)
-  :pathname #p"NYXT:libraries;password-manager;"
+  :pathname #.(npath #p"NYXT:libraries;password-manager;")
   :components ((:file "package")
                (:file "password")
                (:file "password-keepassxc")
@@ -640,7 +650,7 @@ the few modules that's not automatically included in the image."
 
 (defsystem "nyxt/keymap"
   :depends-on (alexandria fset str)
-  :pathname #p"NYXT:libraries;keymap;"
+  :pathname #.(npath #p"NYXT:libraries;keymap;")
   :components ((:file "package")
                (:file "types")
                (:file "conditions")
@@ -657,7 +667,7 @@ the few modules that's not automatically included in the image."
 
 (defsystem "nyxt/class-star"
   :depends-on (hu.dwim.defclass-star moptilities alexandria)
-  :pathname #p"NYXT:libraries;class-star;"
+  :pathname #.(npath #p"NYXT:libraries;class-star;")
   :components ((:file "package")
                (:file "patch")
                (:file "class-star"))
@@ -680,7 +690,7 @@ the few modules that's not automatically included in the image."
                str
                trivia
                nyxt/class-star)
-  :pathname #p"NYXT:libraries;ospm;"
+  :pathname #.(npath #p"NYXT:libraries;ospm;")
   :components ((:file "package")
                (:file "scheme-syntax")
                (:file "guix-backend")
@@ -705,7 +715,7 @@ the few modules that's not automatically included in the image."
                str
                trivial-package-local-nicknames
                nyxt/class-star)
-  :pathname #p"NYXT:libraries;prompter;"
+  :pathname #.(npath #p"NYXT:libraries;prompter;")
   :components ((:file "package")
                (:file "filter-preprocessor")
                (:file "filter")
@@ -724,7 +734,7 @@ the few modules that's not automatically included in the image."
                serapeum
                nyxt/class-star
                cl-css)
-  :pathname #p"NYXT:libraries;theme;"
+  :pathname #.(npath #p"NYXT:libraries;theme;")
   :components ((:file "package")
                (:file "theme"))
   :in-order-to ((test-op (test-op "nyxt/theme/tests"))))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -465,7 +465,9 @@ See `asdf::*immutable-systems*'.
 the few modules that's not automatically included in the image."
   #+sbcl
   (require :sb-sprof)
-  (map () 'register-immutable-system (already-loaded-systems)))
+  (map () 'register-immutable-system
+       (remove-if (lambda (system) (uiop:string-prefix-p "nyxt" system))
+                  (asdf:already-loaded-systems))))
 
 (defsystem "nyxt/install"
   :depends-on (alexandria

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -6,6 +6,12 @@
   (sb-ext:assert-version->= 2 0 0)
   (require 'sb-bsd-sockets))
 
+(setf (logical-pathname-translations "NYXT")
+      `(("NYXT:source;**;*.*.*"
+         ,(uiop:ensure-pathname (uiop:subpathname* *default-pathname-defaults* "source/")  :wilden t))
+        ("NYXT:libraries;**;*.*.*"
+         ,(uiop:ensure-pathname (uiop:subpathname* *default-pathname-defaults* "libraries/")  :wilden t))))
+
 (defvar *prefix* (merge-pathnames* (if (getenv "PREFIX")
                                        (relativize-pathname-directory (ensure-directory-pathname (getenv "PREFIX")))
                                        #p"usr/local/")
@@ -100,7 +106,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
                nyxt/ospm
                nyxt/prompter
                nyxt/theme)
-  :pathname "source/"
+  :pathname #p"NYXT:source;"
   :components ((:file "package")
                (:module "Utilities"
                 :pathname ""
@@ -375,7 +381,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
   :depends-on (nyxt
                cl-cffi-gtk
                cl-webkit2)
-  :pathname "source/"
+  :pathname #p"NYXT:source;"
   :serial t
   :components ((:file "web-extensions")
                (:file "web-extensions-callbacks")
@@ -386,7 +392,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
   :depends-on (nyxt/gtk
                cl-gobject-introspection
                bordeaux-threads)
-  :pathname "source/"
+  :pathname #p"NYXT:source;"
   :components ((:file "renderer/gi-gtk"))
   :in-order-to ((test-op (test-op "nyxt/gi-gtk/tests"))))
 
@@ -401,7 +407,7 @@ A naive benchmark on a 16 Mpbs bandwidth gives us
   :depends-on (nyxt
                cl-webengine
                trivial-main-thread)
-  :pathname "source/"
+  :pathname #p"NYXT:source;"
   :components ((:file "renderer/qt")))
 
 ;; We should not set the build-pathname in systems that have a component.
@@ -550,7 +556,7 @@ the few modules that's not automatically included in the image."
                log4cl
                quri
                str)
-  :pathname "libraries/download-manager/"
+  :pathname #p"NYXT:libraries;download-manager;"
   :components ((:file "package")
                (:file "engine")
                (:file "native"))
@@ -567,7 +573,7 @@ the few modules that's not automatically included in the image."
                serapeum
                alexandria
                cl-ppcre)
-  :pathname "libraries/analysis/"
+  :pathname #p"NYXT:libraries;analysis;"
   :components ((:file "package")
                (:file "data")
                (:file "stem")
@@ -580,13 +586,13 @@ the few modules that's not automatically included in the image."
 
 (defsystem "nyxt/user-interface"
   :depends-on (spinneret)
-  :pathname "libraries/user-interface/"
+  :pathname #p"NYXT:libraries;user-interface;"
   :components ((:file "package")
                (:file "user-interface")))
 
 (defsystem "nyxt/text-buffer"
   :depends-on (cluffer)
-  :pathname "libraries/text-buffer/"
+  :pathname #p"NYXT:libraries;text-buffer;"
   :components ((:file "package")
                (:file "text-buffer")))
 
@@ -596,7 +602,7 @@ the few modules that's not automatically included in the image."
                local-time
                nyxt/class-star
                trivial-package-local-nicknames)
-  :pathname "libraries/history-tree/"
+  :pathname #p"NYXT:libraries;history-tree;"
   :components ((:file "package")
                (:file "history-tree"))
   :in-order-to ((test-op (test-op "nyxt/history-tree/tests"))))
@@ -614,7 +620,7 @@ the few modules that's not automatically included in the image."
                uiop
                nyxt/class-star
                serapeum)
-  :pathname "libraries/password-manager/"
+  :pathname #p"NYXT:libraries;password-manager;"
   :components ((:file "package")
                (:file "password")
                (:file "password-keepassxc")
@@ -624,7 +630,7 @@ the few modules that's not automatically included in the image."
 
 (defsystem "nyxt/keymap"
   :depends-on (alexandria fset str)
-  :pathname "libraries/keymap/"
+  :pathname #p"NYXT:libraries;keymap;"
   :components ((:file "package")
                (:file "types")
                (:file "conditions")
@@ -641,7 +647,7 @@ the few modules that's not automatically included in the image."
 
 (defsystem "nyxt/class-star"
   :depends-on (hu.dwim.defclass-star moptilities alexandria)
-  :pathname "libraries/class-star/"
+  :pathname #p"NYXT:libraries;class-star;"
   :components ((:file "package")
                (:file "patch")
                (:file "class-star"))
@@ -664,7 +670,7 @@ the few modules that's not automatically included in the image."
                str
                trivia
                nyxt/class-star)
-  :pathname "libraries/ospm/"
+  :pathname #p"NYXT:libraries;ospm;"
   :components ((:file "package")
                (:file "scheme-syntax")
                (:file "guix-backend")
@@ -689,7 +695,7 @@ the few modules that's not automatically included in the image."
                str
                trivial-package-local-nicknames
                nyxt/class-star)
-  :pathname "libraries/prompter/"
+  :pathname #p"NYXT:libraries;prompter;"
   :components ((:file "package")
                (:file "filter-preprocessor")
                (:file "filter")
@@ -708,7 +714,7 @@ the few modules that's not automatically included in the image."
                serapeum
                nyxt/class-star
                cl-css)
-  :pathname "libraries/theme/"
+  :pathname #p"NYXT:libraries;theme;"
   :components ((:file "package")
                (:file "theme"))
   :in-order-to ((test-op (test-op "nyxt/theme/tests"))))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -6,11 +6,19 @@
   (sb-ext:assert-version->= 2 0 0)
   (require 'sb-bsd-sockets))
 
+;; REVIEW: Use `*load-pathname*' or `*load-truename*' instead of `*default-pathname-defaults*'?
+;; We could also use (asdf:system-source-directory :nyxt)), but only after the definition of the system.
 (setf (logical-pathname-translations "NYXT")
-      `(("NYXT:source;**;*.*.*"
-         ,(uiop:ensure-pathname (uiop:subpathname* *default-pathname-defaults* "source/")  :wilden t))
+      `(("NYXT:source;**;*.fasl.*"
+         ,(uiop:ensure-pathname (asdf:apply-output-translations *default-pathname-defaults*)
+                                :wilden t))
+        ("NYXT:source;**;*.*.*"
+         ,(uiop:ensure-pathname (uiop:subpathname* *default-pathname-defaults* "source/") :wilden t))
+        ("NYXT:libraries;**;*.fasl.*"
+         ,(uiop:ensure-pathname (asdf:apply-output-translations *default-pathname-defaults*)
+                                :wilden t))
         ("NYXT:libraries;**;*.*.*"
-         ,(uiop:ensure-pathname (uiop:subpathname* *default-pathname-defaults* "libraries/")  :wilden t))))
+         ,(uiop:ensure-pathname (uiop:subpathname* *default-pathname-defaults* "libraries/") :wilden t))))
 
 (defvar *prefix* (merge-pathnames* (if (getenv "PREFIX")
                                        (relativize-pathname-directory (ensure-directory-pathname (getenv "PREFIX")))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -26,6 +26,8 @@ location, otherwise use the translated path.
 
 Tools such as Emacs (SLIME and SLY) may fail to make use of logical paths, say,
 to go to the compilation error location."
+  ;; REVIEW: Would not be necessary if https://github.com/slime/slime/issues/727
+  ;; and https://github.com/atlas-engineer/nyxt/pull/2371 were fixed.
   (if (uiop:getenv "NYXT_LOGICAL_PATH")
       (translate-logical-pathname path)
       path))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -503,7 +503,9 @@ Examples:
 "))
   (pushnew 'nyxt-source-registry asdf:*default-source-registries*)
   (asdf:clear-configuration)
-  (set-nyxt-source-location (asdf:system-source-directory :nyxt))
+  (if (uiop:directory-exists-p (asdf:system-source-directory :nyxt))
+      (set-nyxt-source-location (asdf:system-source-directory :nyxt))
+      (log:debug "Nyxt source directory not found."))
 
   ;; Initialize the lparallel kernel
   (initialize-lparallel-kernel)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -503,6 +503,7 @@ Examples:
 "))
   (pushnew 'nyxt-source-registry asdf:*default-source-registries*)
   (asdf:clear-configuration)
+  (set-nyxt-source-location (asdf:system-source-directory :nyxt))
 
   ;; Initialize the lparallel kernel
   (initialize-lparallel-kernel)


### PR DESCRIPTION
# Description

Previously the installed binary failed to see:
- The new location of the source.
- the new path to nyxt.asd (2nd commit).

This partially addresses the concerns raised in #2360.

# Discussion

Today I discovered an awesome (and completely arcane) feature of Common Lisp (credit goes to https://old.reddit.com/r/Common_Lisp/comments/vc6hix/source_location_for_deployed_binary/icciw5y/): **logical pathnames**.

Everyone keeps saying they are arcane and only useful for compatibility with old systems.  Well, seems that we found a pretty good use case here!

I know one Common Lisp application that uses it precisely for source relocation: SBCL.  So I borrowed some code from it! :)

# Sacrifice

Logical pathnames only accept case-insensitive alpha-numeric characters as well as `-`.  
This is not a big deal since it's what we are using now, but if some day we want to add a file `foo+bar.lisp`, it won't work.  

Something to keep in mind.

# To do:

The major drawback of this approach is that SLIME / SLY compilation warnings under SBCL will use the logical pathname as reference, and thus Emacs' `next-error` fails to find the location.

I can think of 2 fixes:

- [x] Add a conditional in the nyxt.asd to only use logical pathnames when packaging.  Easy.
- [x] Ask SBCL if they can report warnings using the physical pathname instead of the logical one.

    Actually the problem is not with SBCL but with SLY (and maybe SLIME).  See https://github.com/slime/slime/issues/727.

  Mention this in the `nfile` doc.

- [x] (Optional) Ask https://github.com/Shinmera/deploy is they have a solution.

  They don't: https://github.com/Shinmera/deploy/issues/19.

- [x] Do not crash if `set-nyxt-source-location` fails.
- [ ] Ensure that `CL_SOURCE_REGISTRY` is set to the right location as it seems to be a problem for @bubbleguuum.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [x] I have pulled from master before submitting this PR
- [x] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
