### PR TITLE
Specialize prompter:object-attributes on source too.

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -265,7 +265,7 @@ call."))
   `(("Default" ,(princ-to-string object))))
 
 (export-always 'object-attributes)
-(defmethod object-attributes ((object t) (source t))
+(defmethod object-attributes ((object t) (source prompter:source))
   "Return an alist of non-dotted pairs (ATTRIBUTE-KEY ATTRIBUTE-VALUE) for OBJECT.
 Attributes are meant to describe the OBJECT in the context of the SOURCE.
 Both attribute-keys and attribute-values are strings.
@@ -563,12 +563,6 @@ This is a \"safe\" wrapper around `bt:make-thread'."
 (defmethod attributes-default ((suggestion suggestion))
   "Return SUGGESTION default attribute value."
   (second (first (attributes suggestion))))
-
-(defmethod attributes-default ((object t))
-  "Return OBJECT default attribute value.
-Since the OBJECT is taken outside of a source context, attributes are derived
-from `object-attributes'."
-  (second (first (object-attributes object nil))))
 
 (export-always 'attributes-non-default)
 (defmethod attributes-non-default ((suggestion suggestion))

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -265,7 +265,7 @@ call."))
   `(("Default" ,(princ-to-string object))))
 
 (export-always 'object-attributes)
-(defmethod object-attributes ((object t) (source source))
+(defmethod object-attributes ((object t) (source t))
   "Return an alist of non-dotted pairs (ATTRIBUTE-KEY ATTRIBUTE-VALUE) for OBJECT.
 Attributes are meant to describe the OBJECT in the context of the SOURCE.
 Both attribute-keys and attribute-values are strings.

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -22,173 +22,6 @@
    (complement #'exported-p)
    (mopu:slot-names object-specifier)))
 
-(defun default-object-attributes (object)
-  `(("Default" ,(princ-to-string object))))
-
-(export-always 'object-attributes)
-(defmethod object-attributes ((object t) (source prompter:source))
-  "Return an alist of non-dotted pairs (ATTRIBUTE-KEY ATTRIBUTE-VALUE) for OBJECT.
-Attributes are meant to describe the OBJECT in the context of the SOURCE.
-Both attribute-keys and attribute-values are strings.
-
-For structure and class instances, the alist is made of the exported slots: the
-keys are the sentence-cased slot names and the values the slot values passed to
-`princ-to-string'.
-
-It's used in `make-suggestion' which can be used as a `suggestion-maker' for `source's.
-
-It's useful to separate concerns and compose between different object attributes
-and different sources (for instance, the same `object-attributes' method can be
-inherited or used across different sources)."
-  (declare (ignorable source))
-  (cond
-    ((hash-table-p object)
-     (let ((result))
-       (maphash (lambda (key value)
-                  (push (list (princ-to-string key)
-                              (princ-to-string value))
-                        result))
-                object)
-       (sort result #'string< :key #'first)))
-    ((or (typep object 'standard-object)
-         (typep object 'structure-object))
-     (or
-      (mapcar (lambda (slot)
-                (list (string-capitalize (string slot))
-                      (princ-to-string (slot-value object slot))))
-              (object-public-slots object))
-      (default-object-attributes object)))
-    ((plist-p object)
-     (let ((result '()))
-       (alex:doplist (key value object result)
-                     (push (list (string-capitalize key) (princ-to-string value))
-                           result))
-       (nreverse result)))
-    ((undotted-alist-p object)
-     (mapcar (lambda (pair)
-               (list
-                (princ-to-string (first pair))
-                (princ-to-string (second pair))))
-             object))
-    ((alist-p object)
-     (mapcar (lambda (pair)
-               (list
-                (princ-to-string (first pair))
-                (princ-to-string (rest pair))))
-             object))
-    (t (default-object-attributes object))))
-
-(define-class suggestion ()
-  ((value nil ; TODO: Rename `data' as with the GHT?  Maybe confusing since we have `match-data'.
-          :type t)
-   (attributes '()
-               :documentation "A non-dotted alist of attributes to structure the filtering.
-Both the key and the value are strings or functions.
-If a function, it is run asynchronously and must return a string.")
-   (match-data nil
-               :type t
-               :documentation "Arbitrary data that can be used by the `filter'
-function and its preprocessors.  It's the responsibility of the filter to ensure
-the match-data is ready for its own use.")
-   (score 0.0
-          :documentation "A score the can be set by the `filter' function and
-used by the `sort-predicate'."))
-  (:export-class-name-p t)
-  (:export-accessor-names-p t)
-  (:accessor-name-transformer (class*:make-name-transformer name))
-  (:documentation "Suggestions are processed and listed in `source'.
-It wraps arbitrary object stored in the `value' slot.
-The other slots are optional.
-
-Suggestions are made with the `suggestion-maker' slot from `source'."))
-
-(defun pair-p (object)
-  (and (listp object)
-       (or (not (listp (rest object)))
-           (null (rest (rest object))))))
-
-(defun undotted-pair-p (object)
-  (and (listp object)
-       (listp (rest object))
-       (null (rest (rest object)))))
-
-(defun alist-p (object)
-  "Return non-nil if OBJECT is an alist, dotted or undotted."
-  (and (listp object)
-       (every #'pair-p object)))
-
-(defun undotted-alist-p (object &optional value-type)
-  "If VALUE-TYPE is non-nil, check if all values are of the specified type."
-  (and (listp object)
-       (every #'undotted-pair-p object)
-       (or (not value-type)
-           (every (lambda (e) (typep (first e) value-type))
-                  (mapcar #'rest object)))))
-
-(defun plist-p (object)
-  "Return non-nil if OBJECT is a plist."
-  (and (listp object)
-       (alex:proper-list-p object)
-       (evenp (length object))
-       (loop :for x :in object :by #'cddr
-             :always (keywordp x))))
-
-(defun object-attributes-p (object)
-  (undotted-alist-p object '(or string function)))
-
-(defmethod attribute-key ((attribute t))
-  (first attribute))
-(defmethod attribute-value ((attribute t))
-  (second attribute))
-(defmethod attributes-keys ((attributes t))
-  (mapcar #'attribute-key attributes))
-(defmethod attributes-values ((attributes t))
-  (mapcar #'attribute-value attributes))
-
-(defun ensure-string (object)
-  "Return \"\" if OBJECT is not a string."
-  (if (stringp object)
-      object
-      ""))
-
-(defun format-attributes (attributes)
-  "Performance bottleneck: This function is called as many times as they are
-suggestions."
-  (sera:string-join (mapcar #'ensure-string (attributes-values attributes)) " "))
-
-(defmethod initialize-instance :after ((suggestion suggestion) &key)
-  "Check validity."
-  (unless (object-attributes-p (attributes suggestion))
-    (warn "Attributes of ~s should be a non-dotted alist instead of ~s" (value suggestion) (attributes suggestion))
-    (setf (attributes suggestion) (default-object-attributes (value suggestion)))))
-
-(defun ensure-match-data-string (suggestion source)
-  "Return SUGGESTION's `match-data' as a string.
-If unset, set it to the return value of `format-attributes'."
-  (flet ((maybe-downcase (s)
-           (if (current-input-downcase-p source)
-               (string-downcase s)
-               s)))
-    (setf (match-data suggestion)
-          (if (and (match-data suggestion)
-                   (typep (match-data suggestion) 'string))
-              (if (not (eq (last-input-downcase-p source)
-                           (current-input-downcase-p source)))
-                  (maybe-downcase (match-data suggestion))
-                  (match-data suggestion))
-              (let ((result (format-attributes (attributes suggestion))))
-                (maybe-downcase result)))))
-  (match-data suggestion))
-
-(export-always 'make-suggestion)
-(defmethod make-suggestion ((value t) &optional source input)
-  "Return a `suggestion' wrapping around VALUE.
-Attributes are set with `object-attributes'."
-  (declare (ignore input))
-  (make-instance 'suggestion
-                 :value value
-                 :attributes (object-attributes value source)))
-
 (define-class source ()
   ((name (error "Source must have a name")
          :documentation
@@ -427,6 +260,173 @@ these functions is nil, it's equivalent to passing the suggestions unchanged.
 suggestions; they only set the `suggestion's once they are done.  Conversely,
 `filter' is passed one `suggestion' at a time and it updates `suggestion's on each
 call."))
+
+(defun default-object-attributes (object)
+  `(("Default" ,(princ-to-string object))))
+
+(export-always 'object-attributes)
+(defmethod object-attributes ((object t) (source source))
+  "Return an alist of non-dotted pairs (ATTRIBUTE-KEY ATTRIBUTE-VALUE) for OBJECT.
+Attributes are meant to describe the OBJECT in the context of the SOURCE.
+Both attribute-keys and attribute-values are strings.
+
+For structure and class instances, the alist is made of the exported slots: the
+keys are the sentence-cased slot names and the values the slot values passed to
+`princ-to-string'.
+
+It's used in `make-suggestion' which can be used as a `suggestion-maker' for `source's.
+
+It's useful to separate concerns and compose between different object attributes
+and different sources (for instance, the same `object-attributes' method can be
+inherited or used across different sources)."
+  (declare (ignorable source))
+  (cond
+    ((hash-table-p object)
+     (let ((result))
+       (maphash (lambda (key value)
+                  (push (list (princ-to-string key)
+                              (princ-to-string value))
+                        result))
+                object)
+       (sort result #'string< :key #'first)))
+    ((or (typep object 'standard-object)
+         (typep object 'structure-object))
+     (or
+      (mapcar (lambda (slot)
+                (list (string-capitalize (string slot))
+                      (princ-to-string (slot-value object slot))))
+              (object-public-slots object))
+      (default-object-attributes object)))
+    ((plist-p object)
+     (let ((result '()))
+       (alex:doplist (key value object result)
+                     (push (list (string-capitalize key) (princ-to-string value))
+                           result))
+       (nreverse result)))
+    ((undotted-alist-p object)
+     (mapcar (lambda (pair)
+               (list
+                (princ-to-string (first pair))
+                (princ-to-string (second pair))))
+             object))
+    ((alist-p object)
+     (mapcar (lambda (pair)
+               (list
+                (princ-to-string (first pair))
+                (princ-to-string (rest pair))))
+             object))
+    (t (default-object-attributes object))))
+
+(define-class suggestion ()
+  ((value nil ; TODO: Rename `data' as with the GHT?  Maybe confusing since we have `match-data'.
+          :type t)
+   (attributes '()
+               :documentation "A non-dotted alist of attributes to structure the filtering.
+Both the key and the value are strings or functions.
+If a function, it is run asynchronously and must return a string.")
+   (match-data nil
+               :type t
+               :documentation "Arbitrary data that can be used by the `filter'
+function and its preprocessors.  It's the responsibility of the filter to ensure
+the match-data is ready for its own use.")
+   (score 0.0
+          :documentation "A score the can be set by the `filter' function and
+used by the `sort-predicate'."))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (class*:make-name-transformer name))
+  (:documentation "Suggestions are processed and listed in `source'.
+It wraps arbitrary object stored in the `value' slot.
+The other slots are optional.
+
+Suggestions are made with the `suggestion-maker' slot from `source'."))
+
+(defun pair-p (object)
+  (and (listp object)
+       (or (not (listp (rest object)))
+           (null (rest (rest object))))))
+
+(defun undotted-pair-p (object)
+  (and (listp object)
+       (listp (rest object))
+       (null (rest (rest object)))))
+
+(defun alist-p (object)
+  "Return non-nil if OBJECT is an alist, dotted or undotted."
+  (and (listp object)
+       (every #'pair-p object)))
+
+(defun undotted-alist-p (object &optional value-type)
+  "If VALUE-TYPE is non-nil, check if all values are of the specified type."
+  (and (listp object)
+       (every #'undotted-pair-p object)
+       (or (not value-type)
+           (every (lambda (e) (typep (first e) value-type))
+                  (mapcar #'rest object)))))
+
+(defun plist-p (object)
+  "Return non-nil if OBJECT is a plist."
+  (and (listp object)
+       (alex:proper-list-p object)
+       (evenp (length object))
+       (loop :for x :in object :by #'cddr
+             :always (keywordp x))))
+
+(defun object-attributes-p (object)
+  (undotted-alist-p object '(or string function)))
+
+(defmethod attribute-key ((attribute t))
+  (first attribute))
+(defmethod attribute-value ((attribute t))
+  (second attribute))
+(defmethod attributes-keys ((attributes t))
+  (mapcar #'attribute-key attributes))
+(defmethod attributes-values ((attributes t))
+  (mapcar #'attribute-value attributes))
+
+(defun ensure-string (object)
+  "Return \"\" if OBJECT is not a string."
+  (if (stringp object)
+      object
+      ""))
+
+(defun format-attributes (attributes)
+  "Performance bottleneck: This function is called as many times as they are
+suggestions."
+  (sera:string-join (mapcar #'ensure-string (attributes-values attributes)) " "))
+
+(defmethod initialize-instance :after ((suggestion suggestion) &key)
+  "Check validity."
+  (unless (object-attributes-p (attributes suggestion))
+    (warn "Attributes of ~s should be a non-dotted alist instead of ~s" (value suggestion) (attributes suggestion))
+    (setf (attributes suggestion) (default-object-attributes (value suggestion)))))
+
+(defun ensure-match-data-string (suggestion source)
+  "Return SUGGESTION's `match-data' as a string.
+If unset, set it to the return value of `format-attributes'."
+  (flet ((maybe-downcase (s)
+           (if (current-input-downcase-p source)
+               (string-downcase s)
+               s)))
+    (setf (match-data suggestion)
+          (if (and (match-data suggestion)
+                   (typep (match-data suggestion) 'string))
+              (if (not (eq (last-input-downcase-p source)
+                           (current-input-downcase-p source)))
+                  (maybe-downcase (match-data suggestion))
+                  (match-data suggestion))
+              (let ((result (format-attributes (attributes suggestion))))
+                (maybe-downcase result)))))
+  (match-data suggestion))
+
+(export-always 'make-suggestion)
+(defmethod make-suggestion ((value t) &optional source input)
+  "Return a `suggestion' wrapping around VALUE.
+Attributes are set with `object-attributes'."
+  (declare (ignore input))
+  (make-instance 'suggestion
+                 :value value
+                 :attributes (object-attributes value source)))
 
 (defmethod default-return-action ((source source))
   (first (slot-value source 'return-actions)))

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -26,9 +26,9 @@
   `(("Default" ,(princ-to-string object))))
 
 (export-always 'object-attributes)
-(defmethod object-attributes ((object t))
+(defmethod object-attributes ((object t) (source t))
   "Return an alist of non-dotted pairs (ATTRIBUTE-KEY ATTRIBUTE-VALUE) for OBJECT.
-Attributes are meant to describe the OBJECT structurally.
+Attributes are meant to describe the OBJECT in the context of the SOURCE.
 Both attribute-keys and attribute-values are strings.
 
 For structure and class instances, the alist is made of the exported slots: the
@@ -40,6 +40,7 @@ It's used in `make-suggestion' which can be used as a `suggestion-maker' for `so
 It's useful to separate concerns and compose between different object attributes
 and different sources (for instance, the same `object-attributes' method can be
 inherited or used across different sources)."
+  (declare (ignorable source))
   (cond
     ((hash-table-p object)
      (let ((result))
@@ -183,10 +184,10 @@ If unset, set it to the return value of `format-attributes'."
 (defmethod make-suggestion ((value t) &optional source input)
   "Return a `suggestion' wrapping around VALUE.
 Attributes are set with `object-attributes'."
-  (declare (ignore source input))
+  (declare (ignore input))
   (make-instance 'suggestion
                  :value value
-                 :attributes (object-attributes value)))
+                 :attributes (object-attributes value source)))
 
 (define-class source ()
   ((name (error "Source must have a name")
@@ -567,7 +568,7 @@ This is a \"safe\" wrapper around `bt:make-thread'."
   "Return OBJECT default attribute value.
 Since the OBJECT is taken outside of a source context, attributes are derived
 from `object-attributes'."
-  (second (first (object-attributes object))))
+  (second (first (object-attributes object nil))))
 
 (export-always 'attributes-non-default)
 (defmethod attributes-non-default ((suggestion suggestion))

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -26,7 +26,7 @@
   `(("Default" ,(princ-to-string object))))
 
 (export-always 'object-attributes)
-(defmethod object-attributes ((object t) (source t))
+(defmethod object-attributes ((object t) (source prompter:source))
   "Return an alist of non-dotted pairs (ATTRIBUTE-KEY ATTRIBUTE-VALUE) for OBJECT.
 Attributes are meant to describe the OBJECT in the context of the SOURCE.
 Both attribute-keys and attribute-values are strings.

--- a/libraries/prompter/tests/tests.lisp
+++ b/libraries/prompter/tests/tests.lisp
@@ -89,7 +89,8 @@
    (title ""))
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((url url))
+(defmethod prompter:object-attributes ((url url) (source t))
+  (declare (ignore source))
   `(("URL" ,(url url))
     ("Title" ,(title url))))
 
@@ -441,7 +442,8 @@
    (keywords '("foo" "bar")))
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((buffer buffer))
+(defmethod prompter:object-attributes ((buffer buffer) (source t))
+  (declare (ignore source))
   `(("Title" ,(title buffer))
     ("Keywords" ,(lambda (buffer) (sleep 1) (write-to-string (keywords buffer))))))
 

--- a/libraries/prompter/tests/tests.lisp
+++ b/libraries/prompter/tests/tests.lisp
@@ -89,7 +89,7 @@
    (title ""))
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((url url) (source t))
+(defmethod prompter:object-attributes ((url url) (source prompter:source))
   (declare (ignore source))
   `(("URL" ,(url url))
     ("Title" ,(title url))))
@@ -442,7 +442,7 @@
    (keywords '("foo" "bar")))
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((buffer buffer) (source t))
+(defmethod prompter:object-attributes ((buffer buffer) (source prompter:source))
   (declare (ignore source))
   `(("Title" ,(title buffer))
     ("Keywords" ,(lambda (buffer) (sleep 1) (write-to-string (keywords buffer))))))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1171,7 +1171,7 @@ proceeding."
   (:export-class-name-p t)
   (:metaclass user-class))
 
-(defmethod prompter:object-attributes ((buffer buffer) (source t))
+(defmethod prompter:object-attributes ((buffer buffer) (source prompter:source))
   (declare (ignore source))
   `(("URL" ,(render-url (url buffer)))
     ("Title" ,(title buffer))))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -940,15 +940,6 @@ BUFFER's modes."
 
 (hooks:define-hook-type buffer (function (buffer)))
 
-(defmethod prompter:object-attributes ((buffer buffer))
-  `(("URL" ,(render-url (url buffer)))
-    ("Title" ,(title buffer))))
-
-(defmethod prompter:object-attributes ((buffer web-buffer))
-  `(("URL" ,(render-url (url buffer)))
-    ("Title" ,(title buffer))
-    ("Keywords" ,(lambda (buffer) (format nil "~:{~a~^ ~}" (keywords buffer))))))
-
 (define-command make-buffer (&rest args &key (title "") modes (url (default-new-buffer-url *browser*)) parent-buffer
                              no-history-p (load-url-p t) (buffer-class 'web-buffer)
                              &allow-other-keys)
@@ -1180,6 +1171,17 @@ proceeding."
   (:export-class-name-p t)
   (:metaclass user-class))
 
+(defmethod prompter:object-attributes ((buffer buffer) (source t))
+  (declare (ignore source))
+  `(("URL" ,(render-url (url buffer)))
+    ("Title" ,(title buffer))))
+
+(defmethod prompter:object-attributes ((buffer web-buffer) (source buffer-source))
+  (declare (ignore source))
+  `(("URL" ,(render-url (url buffer)))
+    ("Title" ,(title buffer))
+    ("Keywords" ,(lambda (buffer) (format nil "~:{~a~^ ~}" (keywords buffer))))))
+
 (define-command switch-buffer (&key buffer (current-is-last-p nil))
   "Switch buffer using fuzzy completion.
 Buffers are ordered by last access.
@@ -1361,10 +1363,6 @@ Finally, if nothing else, set the `engine' to the `default-search-engine'."))
       (fallback-url (engine query)))
      (t (query query)))))
 
-(defmethod prompter:object-attributes ((query new-url-query))
-  `(("URL or new query" ,(or (label query) (query query)))
-    ("Search engine?" ,(if (engine query) (shortcut (engine query)) ""))))
-
 (defun make-completion-query (completion &key engine (check-dns-p t))
   (typecase completion
     (string (make-instance 'new-url-query
@@ -1458,6 +1456,11 @@ that a good-enough default suggestion is showed instantaneously.
 DNS to precisely validate domains and returns the search engines suggestions, if
 any.")
   (:metaclass user-class))
+
+(defmethod prompter:object-attributes ((query new-url-query) (source new-url-or-search-source))
+  (declare (ignore source))
+  `(("URL or new query" ,(or (label query) (query query)))
+    ("Search engine?" ,(if (engine query) (shortcut (engine query)) ""))))
 
 (defun pushnew-url-history (history url)
   "URL is not pushed if empty."

--- a/source/command-commands.lisp
+++ b/source/command-commands.lisp
@@ -49,7 +49,7 @@ While disabled-mode commands are not listed, it's still possible to call them
 from a key binding.")
   (:metaclass user-class))
 
-(defmethod prompter:object-attributes ((command command) (source t))
+(defmethod prompter:object-attributes ((command command) (source prompter:source))
   (declare (ignore source))
   (command-attributes command))
 

--- a/source/command-commands.lisp
+++ b/source/command-commands.lisp
@@ -11,13 +11,6 @@
           :documentation "The hook value."))
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((hook-description hook-description))
-  `(("Name" ,(name hook-description))
-    ("Value" ,(princ-to-string (value hook-description)))))
-
-(defmethod prompter:object-attributes ((handler hooks:handler))
-  `(("Name" ,(str:downcase (hooks:name handler)))))
-
 (defun command-attributes (command &optional (buffer (active-buffer (current-window :no-rescan))))
   (let* ((scheme-name (keymap-scheme-name buffer))
          (bindings (keymap:binding-keys
@@ -34,9 +27,6 @@
                  (if (sera:in package-name "nyxt" "nyxt-user")
                      ""
                      (str:replace-first "nyxt/" "" package-name)))))))
-
-(defmethod prompter:object-attributes ((command command))
-  (command-attributes command))
 
 (define-class command-source (prompter:source)
   ((prompter:name "Commands")
@@ -58,6 +48,10 @@ Mode commands of enabled modes are also listed.
 While disabled-mode commands are not listed, it's still possible to call them
 from a key binding.")
   (:metaclass user-class))
+
+(defmethod prompter:object-attributes ((command command) (source t))
+  (declare (ignore source))
+  (command-attributes command))
 
 (define-command execute-command ()
   "Execute a command by name."
@@ -179,6 +173,11 @@ User input is evaluated Lisp."
   ((prompter:name "Hooks")
    (prompter:constructor (get-hooks))))
 
+(defmethod prompter:object-attributes ((hook-description hook-description) (source hook-source))
+  (declare (ignore source))
+  `(("Name" ,(name hook-description))
+    ("Value" ,(princ-to-string (value hook-description)))))
+
 (define-class handler-source (prompter:source)
   ((prompter:name "Handlers")
    (hook :accessor hook
@@ -186,6 +185,10 @@ User input is evaluated Lisp."
          :documentation "The hook for which to retrieve handlers for.")
    (prompter:constructor (lambda (source)
                            (hooks:handlers (hook source))))))
+
+(defmethod prompter:object-attributes ((handler hooks:handler) (source handler-source))
+  (declare (ignore source))
+  `(("Name" ,(str:downcase (hooks:name handler)))))
 
 (define-class disabled-handler-source (handler-source)
   ((prompter:constructor (lambda (source)

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -295,10 +295,6 @@ See `package-symbols' for details on the arguments."
               :type (or symbol null)))
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((slot slot))
-  `(("Name" ,(string (name slot)))
-    ("Class" ,(string (class-sym slot)))))
-
 (defun exported-p (sym)
   (eq :external
       (nth-value 1 (find-symbol (string sym)
@@ -309,6 +305,11 @@ See `package-symbols' for details on the arguments."
   (delete-if
    (complement #'exported-p)
    (mopu:slot-names class-sym)))
+
+(defmethod prompter:object-attributes ((slot slot) (source t))
+  (declare (ignore source))
+  `(("Name" ,(string (name slot)))
+    ("Class" ,(string (class-sym slot)))))
 
 (defun package-slots (&optional (packages (nyxt-packages))
                         (user-packages (nyxt-user-packages)))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -306,7 +306,7 @@ See `package-symbols' for details on the arguments."
    (complement #'exported-p)
    (mopu:slot-names class-sym)))
 
-(defmethod prompter:object-attributes ((slot slot) (source t))
+(defmethod prompter:object-attributes ((slot slot) (source prompter:source))
   (declare (ignore source))
   `(("Name" ,(string (name slot)))
     ("Class" ,(string (class-sym slot)))))

--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -21,7 +21,7 @@
   "Return non-nil if OBJECT has `prompter:object-attributes' specialization."
   (has-method-p object #'prompter:object-attributes))
 
-(defmethod prompter:object-attributes ((symbol symbol) (source t))
+(defmethod prompter:object-attributes ((symbol symbol) (source prompter:source))
   (declare (ignore source))
   `(("Name" ,(write-to-string symbol))
     ("Documentation"
@@ -37,7 +37,7 @@
              (first-line (documentation symbol 'variable))))
           ""))))
 
-(defmethod prompter:object-attributes ((package package) (source t))
+(defmethod prompter:object-attributes ((package package) (source prompter:source))
   (declare (ignore source))
   `(("Name" ,(package-name package))
     ("Nicknames" ,(princ-to-string

--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -21,7 +21,8 @@
   "Return non-nil if OBJECT has `prompter:object-attributes' specialization."
   (has-method-p object #'prompter:object-attributes))
 
-(defmethod prompter:object-attributes ((symbol symbol))
+(defmethod prompter:object-attributes ((symbol symbol) (source t))
+  (declare (ignore source))
   `(("Name" ,(write-to-string symbol))
     ("Documentation"
      ,(or (cond
@@ -36,7 +37,8 @@
              (first-line (documentation symbol 'variable))))
           ""))))
 
-(defmethod prompter:object-attributes ((package package))
+(defmethod prompter:object-attributes ((package package) (source t))
+  (declare (ignore source))
   `(("Name" ,(package-name package))
     ("Nicknames" ,(princ-to-string
                    (append (package-nicknames package)

--- a/source/gpg.lisp
+++ b/source/gpg.lisp
@@ -9,6 +9,7 @@
   ((prompter:name "GPG Private Keys")
    (prompter:constructor (nfiles/gpg:gpg-private-keys))))
 
-(defmethod prompter:object-attributes ((gpg-key nfiles/gpg:gpg-key))
+(defmethod prompter:object-attributes ((gpg-key nfiles/gpg:gpg-key) (source gpg-key-source))
+  (declare (ignore source))
   `(("ID" ,(nfiles/gpg:key-id gpg-key))
     ("Additional" ,(str:join ", " (mapcar #'nfiles/gpg:user-id (nfiles/gpg:uids gpg-key))))))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -45,10 +45,6 @@ It's a list of a form (Y &OPTIONAL X)."))
 Entry for the global history.
 The total number of visit for a given URL is (+ explicit-visits implicit-visits)."))
 
-(defmethod prompter:object-attributes ((entry history-entry))
-  `(("URL" ,(render-url (url entry)))
-    ("Title" ,(title entry))))
-
 (export-always 'equals)
 (defmethod equals ((e1 history-entry) (e2 history-entry))
   (quri:uri= (url e1) (url e2)))
@@ -186,6 +182,11 @@ lot."
                             (> (score-history-entry x)
                                (score-history-entry y))))))))
         owner-less-history-entries)))))
+
+(defmethod prompter:object-attributes ((entry history-entry) (source history-disowned-source))
+  (declare (ignore source))
+  `(("URL" ,(render-url (url entry)))
+    ("Title" ,(title entry))))
 
 (defun history-html-list (&key (limit 100) (separator " → "))
   (let* ((history (buffer-history))

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -286,7 +286,7 @@ For production code, see `find-submode' instead."
   (:export-class-name-p t)
   (:metaclass user-class))
 
-(defmethod prompter:object-attributes ((mode mode) (source t))
+(defmethod prompter:object-attributes ((mode mode) (source prompter:source))
   (declare (ignore source))
   `(("Name" ,(princ-to-string mode))))
 

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -168,9 +168,6 @@ The `mode' superclass is automatically added if not present."
 
 (hooks:define-hook-type mode (function (mode)))
 
-(defmethod prompter:object-attributes ((mode mode))
-  `(("Name" ,(princ-to-string mode))))
-
 (export-always 'glyph)
 (defmethod glyph ((mode mode))
   "Return the glyph for a mode.
@@ -289,7 +286,11 @@ For production code, see `find-submode' instead."
   (:export-class-name-p t)
   (:metaclass user-class))
 
-(define-class active-mode-source (prompter:source)
+(defmethod prompter:object-attributes ((mode mode) (source t))
+  (declare (ignore source))
+  `(("Name" ,(princ-to-string mode))))
+
+(define-class active-mode-source (mode-source)
   ((prompter:name "Active modes")
    (buffers '())
    (prompter:multi-selection-p t)
@@ -303,7 +304,7 @@ For production code, see `find-submode' instead."
   (:export-class-name-p t)
   (:metaclass user-class))
 
-(define-class inactive-mode-source (prompter:source)
+(define-class inactive-mode-source (mode-source)
   ((prompter:name "Inactive modes")
    (buffers '())
    (prompter:multi-selection-p t)

--- a/source/mode/autofill.lisp
+++ b/source/mode/autofill.lisp
@@ -52,13 +52,6 @@ it will be in conflict with common-lisp:fill."))
   (:export-predicate-name-p t)
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((autofill autofill))
-  `(("Name" ,(autofill-name autofill))
-    ("Fill" ,(let ((f (autofill-fill autofill)))
-               (typecase f
-                 (string (write-to-string f))
-                 (t "function"))))))
-
 (define-class autofill-source (prompter:source)
   ((prompter:name "Autofills")
    (prompter:constructor (autofills (find-submode 'autofill-mode)))
@@ -71,6 +64,14 @@ it will be in conflict with common-lisp:fill."))
                      (%paste :input-text (funcall (autofill-fill selected-fill))))))))))
   (:export-class-name-p t)
   (:metaclass user-class))
+
+(defmethod prompter:object-attributes ((autofill autofill) (source t))
+  (declare (ignore source))
+  `(("Name" ,(autofill-name autofill))
+    ("Fill" ,(let ((f (autofill-fill autofill)))
+               (typecase f
+                 (string (write-to-string f))
+                 (t "function"))))))
 
 (define-command autofill ()
   "Fill in a field with a value from a saved list."

--- a/source/mode/autofill.lisp
+++ b/source/mode/autofill.lisp
@@ -65,7 +65,7 @@ it will be in conflict with common-lisp:fill."))
   (:export-class-name-p t)
   (:metaclass user-class))
 
-(defmethod prompter:object-attributes ((autofill autofill) (source t))
+(defmethod prompter:object-attributes ((autofill autofill) (source prompter:source))
   (declare (ignore source))
   `(("Name" ,(autofill-name autofill))
     ("Fill" ,(let ((f (autofill-fill autofill)))

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -114,7 +114,7 @@ Bookmarks can be persisted to disk, see the `bookmarks-file' mode slot."
   (:export-accessor-names-p t)
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((entry bookmark-entry) (source t))
+(defmethod prompter:object-attributes ((entry bookmark-entry) (source prompter:source))
   (declare (ignore source))
   `(("URL" ,(render-url (url entry)))
     ("Title" ,(title entry))

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -114,7 +114,8 @@ Bookmarks can be persisted to disk, see the `bookmarks-file' mode slot."
   (:export-accessor-names-p t)
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((entry bookmark-entry))
+(defmethod prompter:object-attributes ((entry bookmark-entry) (source t))
+  (declare (ignore source))
   `(("URL" ,(render-url (url entry)))
     ("Title" ,(title entry))
     ("Tags" ,(format nil "~{~a ~}" (tags entry)))

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -403,20 +403,6 @@ ID is a buffer `id'."
 (defmethod title ((heading heading))
   (subseq (inner-text heading) 0 (position #\[ (inner-text heading))))
 
-(defmethod prompter:object-attributes ((heading heading))
-  `(("Title" ,(format nil "~a ~a"
-                      (make-string (typecase (element heading)
-                                     (nyxt/dom:h1-element 1)
-                                     (nyxt/dom:h2-element 2)
-                                     (nyxt/dom:h3-element 3)
-                                     (nyxt/dom:h4-element 4)
-                                     (nyxt/dom:h5-element 5)
-                                     (nyxt/dom:h6-element 6)
-                                     (t 0))
-                                   :initial-element #\*)
-                      (title heading)))
-    ("Keywords" ,(format nil "~:{~a~^ ~}" (keywords heading)))))
-
 (defun get-headings (&key (buffer (current-buffer)))
   (pflet ((heading-scroll-position
            (element)
@@ -473,6 +459,21 @@ ID is a buffer `id'."
    (prompter:constructor (lambda (source)
                            (get-headings :buffer (buffer source))))
    (prompter:return-actions (list (lambda-unmapped-command scroll-page-to-heading)))))
+
+(defmethod prompter:object-attributes ((heading heading) (source heading-source))
+  (declare (ignore source))
+  `(("Title" ,(format nil "~a ~a"
+                      (make-string (typecase (element heading)
+                                     (nyxt/dom:h1-element 1)
+                                     (nyxt/dom:h2-element 2)
+                                     (nyxt/dom:h3-element 3)
+                                     (nyxt/dom:h4-element 4)
+                                     (nyxt/dom:h5-element 5)
+                                     (nyxt/dom:h6-element 6)
+                                     (t 0))
+                                   :initial-element #\*)
+                      (title heading)))
+    ("Keywords" ,(format nil "~:{~a~^ ~}" (keywords heading)))))
 
 (define-command jump-to-heading (&key (buffer (current-buffer)))
   "Jump to a particular heading, of type h1, h2, h3, h4, h5, or h6."

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -102,7 +102,7 @@ When the user is unspecified, take the current one."
   (:documentation "Prompt source for user-accessible programs.")
   (:metaclass user-class))
 
-(defmethod prompter:object-attributes ((path pathname) (source t))
+(defmethod prompter:object-attributes ((path pathname) (source prompter:source))
   (declare (ignore source))
   `(("Path" ,(uiop:native-namestring path))
     ("Name" ,(if (uiop:directory-pathname-p path)

--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -102,7 +102,8 @@ When the user is unspecified, take the current one."
   (:documentation "Prompt source for user-accessible programs.")
   (:metaclass user-class))
 
-(defmethod prompter:object-attributes ((path pathname))
+(defmethod prompter:object-attributes ((path pathname) (source t))
+  (declare (ignore source))
   `(("Path" ,(uiop:native-namestring path))
     ("Name" ,(if (uiop:directory-pathname-p path)
                  (enough-namestring path (files:parent path))

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -247,17 +247,17 @@ FUNCTION is the action to perform on the selected elements."
                                ("img" "image")
                                (otherwise (plump:tag-name element)))))))
 
-(defmethod prompter:object-attributes ((input nyxt/dom:input-element) (source t))
+(defmethod prompter:object-attributes ((input nyxt/dom:input-element) (source prompter:source))
   (declare (ignore source))
   (when (nyxt/dom:body input)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body input))))))
 
-(defmethod prompter:object-attributes ((textarea nyxt/dom:textarea-element) (source t))
+(defmethod prompter:object-attributes ((textarea nyxt/dom:textarea-element) (source prompter:source))
   (declare (ignore source))
   (when (nyxt/dom:body textarea)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body textarea))))))
 
-(defmethod prompter:object-attributes ((a nyxt/dom:a-element) (source t))
+(defmethod prompter:object-attributes ((a nyxt/dom:a-element) (source prompter:source))
   (declare (ignore source))
   (append
    (sera:and-let* ((has-href? (plump:has-attribute a "href"))
@@ -266,21 +266,21 @@ FUNCTION is the action to perform on the selected elements."
    (when (nyxt/dom:body a)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body a)))))))
 
-(defmethod prompter:object-attributes ((button nyxt/dom:button-element) (source t))
+(defmethod prompter:object-attributes ((button nyxt/dom:button-element) (source prompter:source))
   (declare (ignore source))
   (when (nyxt/dom:body button)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body button))))))
 
-(defmethod prompter:object-attributes ((details nyxt/dom:details-element) (source t))
+(defmethod prompter:object-attributes ((details nyxt/dom:details-element) (source prompter:source))
   (declare (ignore source))
   (when (nyxt/dom:body details)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body details))))))
 
-(defmethod prompter:object-attributes ((select nyxt/dom:select-element) (source t))
+(defmethod prompter:object-attributes ((select nyxt/dom:select-element) (source prompter:source))
   (declare (ignore source))
   `(("Body" ,(str:shorten 80 (nyxt/dom:body select)))))
 
-(defmethod prompter:object-attributes ((option nyxt/dom:option-element) (source t))
+(defmethod prompter:object-attributes ((option nyxt/dom:option-element) (source prompter:source))
   (declare (ignore source))
   `(("Body" ,(nyxt/dom:body option))
     ,@(when (plump:get-attribute option "value")

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -232,7 +232,7 @@ FUNCTION is the action to perform on the selected elements."
                                                       (remove-hints))))))
     (funcall function result)))
 
-(defmethod prompter:object-attributes :around ((element plump:element))
+(defmethod prompter:object-attributes :around ((element plump:element) (source hint-source))
   `(,@(when (plump:get-attribute element "nyxt-hint")
         `(("Hint" ,(plump:get-attribute element "nyxt-hint"))))
     ;; Ensure that all of Body, URL and Value are there, even if empty.
@@ -247,15 +247,18 @@ FUNCTION is the action to perform on the selected elements."
                                ("img" "image")
                                (otherwise (plump:tag-name element)))))))
 
-(defmethod prompter:object-attributes ((input nyxt/dom:input-element))
+(defmethod prompter:object-attributes ((input nyxt/dom:input-element) (source t))
+  (declare (ignore source))
   (when (nyxt/dom:body input)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body input))))))
 
-(defmethod prompter:object-attributes ((textarea nyxt/dom:textarea-element))
+(defmethod prompter:object-attributes ((textarea nyxt/dom:textarea-element) (source t))
+  (declare (ignore source))
   (when (nyxt/dom:body textarea)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body textarea))))))
 
-(defmethod prompter:object-attributes ((a nyxt/dom:a-element))
+(defmethod prompter:object-attributes ((a nyxt/dom:a-element) (source t))
+  (declare (ignore source))
   (append
    (sera:and-let* ((has-href? (plump:has-attribute a "href"))
                    (url-string (plump:get-attribute a "href")))
@@ -263,23 +266,27 @@ FUNCTION is the action to perform on the selected elements."
    (when (nyxt/dom:body a)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body a)))))))
 
-(defmethod prompter:object-attributes ((button nyxt/dom:button-element))
+(defmethod prompter:object-attributes ((button nyxt/dom:button-element) (source t))
+  (declare (ignore source))
   (when (nyxt/dom:body button)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body button))))))
 
-(defmethod prompter:object-attributes ((details nyxt/dom:details-element))
+(defmethod prompter:object-attributes ((details nyxt/dom:details-element) (source t))
+  (declare (ignore source))
   (when (nyxt/dom:body details)
     `(("Body" ,(str:shorten 80 (nyxt/dom:body details))))))
 
-(defmethod prompter:object-attributes ((select nyxt/dom:select-element))
+(defmethod prompter:object-attributes ((select nyxt/dom:select-element) (source t))
+  (declare (ignore source))
   `(("Body" ,(str:shorten 80 (nyxt/dom:body select)))))
 
-(defmethod prompter:object-attributes ((option nyxt/dom:option-element))
+(defmethod prompter:object-attributes ((option nyxt/dom:option-element) (source t))
+  (declare (ignore source))
   `(("Body" ,(nyxt/dom:body option))
     ,@(when (plump:get-attribute option "value")
         `(("Value" ,(plump:get-attribute option "value"))))))
 
-(defmethod prompter:object-attributes ((img nyxt/dom:img-element))
+(defmethod prompter:object-attributes ((img nyxt/dom:img-element) (source hint-source))
   (append
    (sera:and-let* ((has-href? (plump:has-attribute img "href"))
                    (url-string (plump:get-attribute img "href")))

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -131,7 +131,7 @@ This saves the history to disk when BODY exits."
   (:export-class-name-p t)
   (:metaclass user-class))
 
-(defmethod prompter:object-attributes ((node history-tree:node) (source t))
+(defmethod prompter:object-attributes ((node history-tree:node) (source prompter:source))
   (declare (ignore source))
   (let ((entry (htree:data (history-tree:entry node))))
     `(("URL" ,(render-url (url entry)))

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -131,7 +131,8 @@ This saves the history to disk when BODY exits."
   (:export-class-name-p t)
   (:metaclass user-class))
 
-(defmethod prompter:object-attributes ((node history-tree:node))
+(defmethod prompter:object-attributes ((node history-tree:node) (source t))
+  (declare (ignore source))
   (let ((entry (htree:data (history-tree:entry node))))
     `(("URL" ,(render-url (url entry)))
       ("Title" ,(title entry)))))

--- a/source/mode/no-procrastinate.lisp
+++ b/source/mode/no-procrastinate.lisp
@@ -112,13 +112,6 @@ and that should be blocked.")
   (:export-accessor-names-p t)
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
-(defmethod prompter:object-attributes ((entry no-procrastinate-entry))
-  `(("URL" ,(render-url (url entry)))
-    ("Hostname" ,(quri:uri-host (url entry)))
-    ("Title" ,(title entry))
-    ("Tags" ,(format nil "~{~a ~}" (tags entry)))
-    ("Date" ,(princ-to-string (date entry)))))
-
 (defmethod equals ((e1 no-procrastinate-entry) (e2 no-procrastinate-entry))
   "Entries are equal if the hosts and the paths are equal.
 In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
@@ -157,6 +150,14 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
    (prompter:constructor (files:content (no-procrastinate-hosts-file (current-buffer))))
    (prompter:multi-selection-p t)
    (prompter:active-attributes-keys '("URL" "Title" "Tags"))))
+
+(defmethod prompter:object-attributes ((entry no-procrastinate-entry) (source no-procrastinate-source))
+  (declare (ignore source))
+  `(("URL" ,(render-url (url entry)))
+    ("Hostname" ,(quri:uri-host (url entry)))
+    ("Title" ,(title entry))
+    ("Tags" ,(format nil "~{~a ~}" (tags entry)))
+    ("Date" ,(princ-to-string (date entry)))))
 
 (defun url-no-procrastinate-host-tags (url)
   "Return the list of tags of the host corresponding to URL."

--- a/source/mode/os-package-manager.lisp
+++ b/source/mode/os-package-manager.lisp
@@ -48,7 +48,6 @@
 (defmethod name ((output ospm:os-package-output))
   (format nil "~a~a"
           (ospm:name (ospm:parent-package output))
-          ;; TODO: Make this specializable.
           (if (string= (ospm:name output) "out")
               ""
               (str:concat ":" (ospm:name output)))))

--- a/source/mode/os-package-manager.lisp
+++ b/source/mode/os-package-manager.lisp
@@ -45,16 +45,21 @@
     ("Version" ,(ospm:version pkg))
     ("Synopsis" ,(ospm:synopsis pkg))))
 
+(defmethod name ((output ospm:os-package-output))
+  (format nil "~a~a"
+          (ospm:name (ospm:parent-package output))
+          ;; TODO: Make this specializable.
+          (if (string= (ospm:name output) "out")
+              ""
+              (str:concat ":" (ospm:name output)))))
+
+(defmethod name ((package ospm:os-package))
+  (ospm:name package))
+
 (defmethod prompter:object-attributes ((output ospm:os-package-output) (source prompter:source))
   (declare (ignore source))
-  (let* ((pkg (ospm:parent-package output))
-         (name (format nil "~a~a"
-                       (ospm:name pkg)
-                       ;; TODO: Make this specializable.
-                       (if (string= (ospm:name output) "out")
-                           ""
-                           (str:concat ":" (ospm:name output))))))
-    `(("Name" ,name)
+  (let ((pkg (ospm:parent-package output)))
+    `(("Name" ,(name output))
       ("Version" ,(ospm:version pkg))
       ("Synopsis" ,(ospm:synopsis pkg)))))
 
@@ -234,7 +239,7 @@ PACKAGES is a list of `ospm:package' IDs created by `nyxt::ensure-inspected-id'.
        (:h1 "Package files")
        (:ul
         (dolist (package-or-output packages-or-outputs)
-          (:li (prompter:attributes-default package-or-output)
+          (:li (name package-or-output)
                (:ul
                 (let ((files (mapcar #'uiop:native-namestring (ospm:list-files (list package-or-output)))))
                   (if files
@@ -371,7 +376,7 @@ OBJECTS can be a list of packages, a generation, etc."
                           :onclick (ps:ps (nyxt/ps:lisp-eval
                                            (:title "describe-os-package")
                                            (describe-os-package :packages (list package))))
-                          (prompter:attributes-default package-output))
+                          (name package-output))
                  " " (ospm:version package))))))
      buffer)
     (echo "")

--- a/source/mode/os-package-manager.lisp
+++ b/source/mode/os-package-manager.lisp
@@ -39,13 +39,13 @@
                       (write (ps:lisp (spinneret:with-html-string
                                         (:p "Operation cancelled.")))))))))
 
-(defmethod prompter:object-attributes ((pkg ospm:os-package) (source t))
+(defmethod prompter:object-attributes ((pkg ospm:os-package) (source prompter:source))
   (declare (ignore source))
   `(("Name" ,(ospm:name pkg))
     ("Version" ,(ospm:version pkg))
     ("Synopsis" ,(ospm:synopsis pkg))))
 
-(defmethod prompter:object-attributes ((output ospm:os-package-output) (source t))
+(defmethod prompter:object-attributes ((output ospm:os-package-output) (source prompter:source))
   (declare (ignore source))
   (let* ((pkg (ospm:parent-package output))
          (name (format nil "~a~a"
@@ -58,7 +58,7 @@
       ("Version" ,(ospm:version pkg))
       ("Synopsis" ,(ospm:synopsis pkg)))))
 
-(defmethod prompter:object-attributes ((gen ospm:os-generation) (source t))
+(defmethod prompter:object-attributes ((gen ospm:os-generation) (source prompter:source))
   (declare (ignore source))
   `(("ID" ,(princ-to-string (ospm:id gen)))
     ("Date" ,(local-time:format-timestring nil (ospm:date gen)
@@ -66,7 +66,7 @@
     ("Package count" ,(princ-to-string (ospm:package-count gen)))
     ("Current?" ,(if (ospm:current? gen) "yes" ""))))
 
-(defmethod prompter:object-attributes ((pkg ospm:guix-package) (source t))
+(defmethod prompter:object-attributes ((pkg ospm:guix-package) (source prompter:source))
   (declare (ignore source))
   ;; We could have called `call-next-method', then modify the result, but it's
   ;; too costly for thousands of packages.

--- a/source/mode/os-package-manager.lisp
+++ b/source/mode/os-package-manager.lisp
@@ -39,12 +39,14 @@
                       (write (ps:lisp (spinneret:with-html-string
                                         (:p "Operation cancelled.")))))))))
 
-(defmethod prompter:object-attributes ((pkg ospm:os-package))
+(defmethod prompter:object-attributes ((pkg ospm:os-package) (source t))
+  (declare (ignore source))
   `(("Name" ,(ospm:name pkg))
     ("Version" ,(ospm:version pkg))
     ("Synopsis" ,(ospm:synopsis pkg))))
 
-(defmethod prompter:object-attributes ((output ospm:os-package-output))
+(defmethod prompter:object-attributes ((output ospm:os-package-output) (source t))
+  (declare (ignore source))
   (let* ((pkg (ospm:parent-package output))
          (name (format nil "~a~a"
                        (ospm:name pkg)
@@ -56,14 +58,16 @@
       ("Version" ,(ospm:version pkg))
       ("Synopsis" ,(ospm:synopsis pkg)))))
 
-(defmethod prompter:object-attributes ((gen ospm:os-generation))
+(defmethod prompter:object-attributes ((gen ospm:os-generation) (source t))
+  (declare (ignore source))
   `(("ID" ,(princ-to-string (ospm:id gen)))
     ("Date" ,(local-time:format-timestring nil (ospm:date gen)
                                            :format local-time:+asctime-format+))
     ("Package count" ,(princ-to-string (ospm:package-count gen)))
     ("Current?" ,(if (ospm:current? gen) "yes" ""))))
 
-(defmethod prompter:object-attributes ((pkg ospm:guix-package))
+(defmethod prompter:object-attributes ((pkg ospm:guix-package) (source t))
+  (declare (ignore source))
   ;; We could have called `call-next-method', then modify the result, but it's
   ;; too costly for thousands of packages.
   `(("Name" ,(ospm:name pkg))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -139,7 +139,7 @@
 (defmethod nyxt/hint-mode:identifier ((match search-match))
   (identifier match))
 
-(defmethod prompter:object-attributes ((match search-match))
+(defmethod prompter:object-attributes ((match search-match) (source t))
   `(("Default" ,(body match))
     ("ID" ,(princ-to-string (identifier match)))
     ("Buffer ID" ,(princ-to-string (id (buffer match))))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -139,7 +139,7 @@
 (defmethod nyxt/hint-mode:identifier ((match search-match))
   (identifier match))
 
-(defmethod prompter:object-attributes ((match search-match) (source t))
+(defmethod prompter:object-attributes ((match search-match) (source prompter:source))
   `(("Default" ,(body match))
     ("ID" ,(princ-to-string (identifier match)))
     ("Buffer ID" ,(princ-to-string (id (buffer match))))

--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -90,7 +90,7 @@ marquee, multicol, nobr, s, spacer, strike, tt, u, wbr, code, cite, pre"
   (unlock-page-keypresses)
   (setf (mark-set mode) nil))
 
-(defmethod prompter:object-attributes ((element nyxt/dom:text-element))
+(defmethod prompter:object-attributes ((element nyxt/dom:text-element) (source t))
   `(("Hint" ,(plump:get-attribute element "nyxt-hint"))
     ("Text" ,(plump:text element))))
 

--- a/source/mode/visual.lisp
+++ b/source/mode/visual.lisp
@@ -90,7 +90,7 @@ marquee, multicol, nobr, s, spacer, strike, tt, u, wbr, code, cite, pre"
   (unlock-page-keypresses)
   (setf (mark-set mode) nil))
 
-(defmethod prompter:object-attributes ((element nyxt/dom:text-element) (source t))
+(defmethod prompter:object-attributes ((element nyxt/dom:text-element) (source prompter:source))
   `(("Hint" ,(plump:get-attribute element "nyxt-hint"))
     ("Text" ,(plump:text element))))
 

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -482,7 +482,7 @@ See the documentation of `prompt-buffer' to know more about the options."
    ;; TODO: History?
    ))
 
-(defmethod prompter:object-attributes ((prompt-buffer prompt-buffer) (source t))
+(defmethod prompter:object-attributes ((prompt-buffer prompt-buffer) (source prompter:source))
   (declare (ignore source))
   `(("Prompt" ,(prompter:prompt prompt-buffer))
     ("Input" ,(prompter:input prompt-buffer))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -475,16 +475,17 @@ See the documentation of `prompt-buffer' to know more about the options."
     (declare #.(cons 'ignorable %prompt-args))
     (first (apply #'prompt args))))
 
-(defmethod prompter:object-attributes ((prompt-buffer prompt-buffer))
-  `(("Prompt" ,(prompter:prompt prompt-buffer))
-    ("Input" ,(prompter:input prompt-buffer))))
-
 (define-class resume-prompt-source (prompter:source)
   ((prompter:name "Resume prompters")
    (prompter:constructor (old-prompt-buffers *browser*))
    ;; TODO: Remove duplicates.
    ;; TODO: History?
    ))
+
+(defmethod prompter:object-attributes ((prompt-buffer prompt-buffer) (source t))
+  (declare (ignore source))
+  `(("Prompt" ,(prompter:prompt prompt-buffer))
+    ("Input" ,(prompter:input prompt-buffer))))
 
 (define-command resume-prompt ()
   "Query an older prompt and resume it."

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -72,7 +72,8 @@ Example (Tor-proxied completion function for Wikipedia):
                       (cons (format nil base-url (quri:url-encode input))
                             request-args)))))
 
-(defmethod prompter:object-attributes ((engine search-engine))
+(defmethod prompter:object-attributes ((engine search-engine) (source t))
+  (declare (ignore source))
   `(("Shortcut" ,(shortcut engine))
     ("Search URL" ,(search-url engine))))
 

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -72,7 +72,7 @@ Example (Tor-proxied completion function for Wikipedia):
                       (cons (format nil base-url (quri:url-encode input))
                             request-args)))))
 
-(defmethod prompter:object-attributes ((engine search-engine) (source t))
+(defmethod prompter:object-attributes ((engine search-engine) (source prompter:source))
   (declare (ignore source))
   `(("Shortcut" ,(shortcut engine))
     ("Search URL" ,(search-url engine))))

--- a/source/user-files.lisp
+++ b/source/user-files.lisp
@@ -126,7 +126,7 @@ Example: when passed command line option --with-file foo=bar,
   (let ((*package* (find-package :nyxt)))
     (s-serialization:deserialize-sexp raw-content)))
 
-(defmethod prompter:object-attributes ((file files:file) (source t))
+(defmethod prompter:object-attributes ((file files:file) (source prompter:source))
   `(("Path" ,(uiop:native-namestring (files:expand file)))      ; TODO: Trim if too long?
     ("Exists?" ,(if (uiop:file-exists-p (uiop:ensure-pathname (files:expand file)))
                     "yes"

--- a/source/user-files.lisp
+++ b/source/user-files.lisp
@@ -126,7 +126,7 @@ Example: when passed command line option --with-file foo=bar,
   (let ((*package* (find-package :nyxt)))
     (s-serialization:deserialize-sexp raw-content)))
 
-(defmethod prompter:object-attributes ((file files:file))
+(defmethod prompter:object-attributes ((file files:file) (source t))
   `(("Path" ,(uiop:native-namestring (files:expand file)))      ; TODO: Trim if too long?
     ("Exists?" ,(if (uiop:file-exists-p (uiop:ensure-pathname (files:expand file)))
                     "yes"

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -259,15 +259,16 @@ not try to quit the browser."
                (zerop (hash-table-count (windows *browser*))))
       (quit))))
 
-(defmethod prompter:object-attributes ((window window))
-  `(("ID" ,(id window))
-    ("Active buffer" ,(title (active-buffer window)))))
-
 (define-class window-source (prompter:source)
   ((prompter:name "Windows")
    (prompter:multi-selection-p t)
    (prompter:constructor (window-list))
    (prompter:return-actions (list (lambda-mapped-command window-delete)))))
+
+(defmethod prompter:object-attributes ((window window) (source window-source))
+  (declare (ignore source))
+  `(("ID" ,(id window))
+    ("Active buffer" ,(title (active-buffer window)))))
 
 (define-command delete-window ()
   "Delete the queried window(s)."


### PR DESCRIPTION
# Description

This makes `prompter:object-attributes` to be specialized against `prompter:source`. This way, we prevent the unwanted attributes from other domainds of usage for such multi-use objects as strings and pathnames. It's already saving us some lines on `color-source` shortening in this patch. There's not much other changes, though.

Closes #2363.

# Discussion

What should the default source specializer for `prompter:object-attributes` be? I'm using `t` in most cases, but maybe it should be `prompter:source` to enforce better typing?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [X] I have pulled from master before submitting this PR
- [X] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
  - There's almost no documentation on `prompter:object-atributes`...
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
