### PR TITLE
Fix status loading

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -454,7 +454,6 @@ inherited from the superclasses."))
                   :finished
                   :unloaded
                   :failed)
-    :accessor nil
     :export nil ; TODO: Need to decide if we want progress / errors before exposing to the user.
     :documentation "The status of the buffer.
 - `:loading' when loading a web resource.

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -168,7 +168,7 @@ optimizing the use of space."
 (defun tls-help (buffer url)
   "This function is invoked upon TLS certificate errors to give users
 help on how to proceed."
-  (setf (slot-value buffer 'status) :failed)
+  (setf (status buffer) :failed)
   (html-set
    (spinneret:with-html-string
      (:h1 (format nil "TLS Certificate Error: ~a" (render-url url)))

--- a/source/mode/force-https.lisp
+++ b/source/mode/force-https.lisp
@@ -9,7 +9,7 @@
 (defun https->http-loop-help (buffer url) ; TODO: Factor with tls-help?
   "This function is invoked upon TLS certificate errors to give users
 help on how to proceed."
-  (setf (slot-value buffer 'nyxt::status) :failed)
+  (setf (nyxt::status buffer) :failed)
   (nyxt::html-set
    (spinneret:with-html-string
      (:h1 (format nil "HTTPS → HTTP loop: ~a" (render-url url)))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1048,7 +1048,7 @@ See `finalize-buffer'."
                     (url buffer)
                     url)))
       (cond ((eq load-event :webkit-load-started)
-             (setf (slot-value buffer 'status) :loading)
+             (setf (status buffer) :loading)
              (nyxt/web-extensions::tabs-on-updated buffer '(("status" . "loading")))
              (nyxt/web-extensions::tabs-on-updated buffer `(("url" . ,(render-url url))))
              (on-signal-load-started buffer url)
@@ -1066,7 +1066,7 @@ See `finalize-buffer'."
             ((eq load-event :webkit-load-finished)
              (setf (loading-webkit-history-p buffer) nil)
              (unless (eq (slot-value buffer 'status) :failed)
-               (setf (slot-value buffer 'status) :finished))
+               (setf (status buffer) :finished))
              (nyxt/web-extensions::tabs-on-updated buffer '(("status" . "complete")))
              (nyxt/web-extensions::tabs-on-updated buffer `(("url" . ,(render-url url))))
              (on-signal-load-finished buffer url)
@@ -1472,7 +1472,7 @@ See `finalize-buffer'."
        nil)
       (t
        (echo "Failed to load URL ~a in buffer ~a." failing-url (id buffer))
-       (setf (slot-value buffer 'status) :failed)
+       (setf (status buffer) :failed)
        (html-set
         (spinneret:with-html-string
           (:h1 "Page could not be loaded.")
@@ -1561,7 +1561,7 @@ local anyways, and it's better to refresh it if a load was queried."
     ;; don't try to reload if they are called before the "load-changed" signal
     ;; is emitted.
     (when (web-buffer-p buffer)
-      (setf (slot-value buffer 'status) :loading))
+      (setf (status buffer) :loading))
     (if (and entry
              (not (internal-url-p url))
              (not (quri:uri= url (url buffer))))

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -186,4 +186,9 @@ See also `define-setf-handler'."
   (define-setf-handler window active-buffer status-buffer
     (lambda (window)
       (when (eq window (window status-buffer))
-        (print-status (window status-buffer))))))
+        (print-status (window status-buffer)))))
+  (define-setf-handler network-buffer status status-buffer
+    (lambda (buffer)
+      (when (window status-buffer)
+        (when (eq buffer (active-buffer (window status-buffer)))
+          (print-status (window status-buffer)))))))


### PR DESCRIPTION
# Description

This makes it so that when a page finishes loading, the loading bar will go away from the status area.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [x] I have pulled from master before submitting this PR
- [x] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
