### PR TITLE
nyxt-user-systems

### DIFF
--- a/documents/README.org
+++ b/documents/README.org
@@ -394,8 +394,7 @@ be configured in the respective configuration files.
 #+begin_src lisp
 (load (merge-pathnames #p"quicklisp/setup.lisp" (user-homedir-pathname)))
 (ql:quickload 'slynk)
-;; Note: (nyxt-config-file) points to path/to/your/nyxt/config/directory
-(load-after-system :slynk (nyxt-config-file "my-slynk.lisp"))
+(define-nyxt-user-system-and-load :depends-on (slynk) :components ("my-slynk"))
 #+end_src
 
 2. Create a file called =my-slynk.lisp= where you will specify your
@@ -455,7 +454,7 @@ server with the following steps.
 #+end_src
 
 2. Create a file called =my-slynk.lisp= in your Nyxt configuration directory
-   (see =(nyxt-config-file)= where you will create a =start-slynk= command.
+   where you will create a =start-slynk= command.
 
 #+NAME: nyxt/my-slynk.lisp
 #+begin_src lisp

--- a/libraries/nyxt-asdf/user-systems.lisp
+++ b/libraries/nyxt-asdf/user-systems.lisp
@@ -1,0 +1,9 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nyxt-asdf)
+
+(export-always 'nyxt-user-system)
+(defclass nyxt-user-system (asdf:system) ()
+  (:documentation "Specialized systems for Nyxt users."))
+(import 'nyxt-user-system  :asdf-user)

--- a/nyxt-asdf.asd
+++ b/nyxt-asdf.asd
@@ -14,4 +14,5 @@
                (:file "install")
                (:file "submodules")
                (:file "systems")
-               (:file "tests")))
+               (:file "tests")
+               (:file "user-systems")))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -12,6 +12,13 @@
 ;; instead.
 (setf (logical-pathname-translations "NYXT") nil)
 
+(defsystem nyxt/user
+  :defsystem-depends-on (nyxt-asdf)
+  :class :nyxt-user-system
+  :description "Parent system of user systems.
+It is required that all Nyxt user-defined systems start with nyxt/user/ to avoid clashes.
+This system does nothing in particular.")
+
 (defsystem "nyxt"
   :defsystem-depends-on (nyxt-asdf)
   :class :nyxt-system

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -341,31 +341,6 @@ Call this function from your initialization file to re-enable the default ASDF r
           asdf/source-registry:default-system-source-registry))
   (asdf:clear-configuration))
 
-;; TODO: Remove `load-after-system'!
-(export-always 'load-after-system)
-(defun load-after-system (system &optional file)
-  "Load Common Lisp SYSTEM, then on success load FILE.
-Use Quicklisp if possible.
-See also `reset-asdf-registries'.
-
-Example:
-
-  (load-after-system :xyz \"configure-xyz.lisp\")"
-  (flet ((load-system (system)
-           (handler-case
-               (progn
-                 #+quicklisp
-                 (ql:quickload system :silent t)
-                 #-quicklisp
-                 (asdf:load-system system))
-             (error (c)
-               (echo-warning "Could not load system ~a: ~a" system c)
-               (log:warn "Maybe you want to use `reset-asdf-registries'?")
-               (log:warn "Current ASDF registries: ~{~a~^, ~}"
-                         asdf:*default-source-registries*)
-               nil))))
-    (when (and (load-system system) file)
-      (load file))))
 
 
 ;; TODO: Report compilation errors.

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -345,9 +345,11 @@ Call this function from your initialization file to re-enable the default ASDF r
 
 ;; TODO: Report compilation errors.
 
+(export-always 'nyxt-user-system)
 (defclass nyxt-user-system (asdf:system) ()
   (:documentation "Specialized systems for Nyxt users.
-This automatically default :pathname to the `*config-file*' directory."))
+This automatically defaults :pathname to the `*config-file*' directory.
+See `define-nyxt-user-system' and `define-nyxt-user-system-and-load'."))
 
 (defvar *nyxt-user-systems-with-missing-dependencies* '())
 
@@ -357,6 +359,7 @@ This automatically default :pathname to the `*config-file*' directory."))
     (or path
         (nfiles:expand (make-instance 'config-directory-file)))))
 
+(export-always 'load-system*)
 (defun load-system* (system &rest keys &key force force-not verbose version &allow-other-keys)
   "Like `asdf:load-system' but, instead of signaling an error on missing
 dependency, it warns the user, skips the load gracefully and returns NIL.
@@ -390,6 +393,7 @@ to load and attempts to load them if their dependencies now seem to be met."
       component-designator
       (list :file (sera:drop-suffix ".lisp" component-designator :test #'string-equal))))
 
+(export-always 'define-nyxt-user-system)
 (defmacro define-nyxt-user-system (name &rest args &key depends-on components
                                    &allow-other-keys)
   "Define a user system, usually meant to load configuration files.
@@ -428,6 +432,7 @@ to use the full syntax."
      :components ,(mapcar #'ensure-component
                           components)))
 
+(export-always 'define-nyxt-user-system-and-load)
 (defmacro define-nyxt-user-system-and-load (name &rest args &key depends-on components
                                             &allow-other-keys)
   "Like `define-nyxt-user-system' but immediately call `load-system*' on the system.

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -423,7 +423,7 @@ to use the full syntax."
   ;; We cannot call `make-instance 'asdf:system' because we need to register the
   ;; system, and `register-system' is unexported.
   `(asdf:defsystem ,name
-     :class :nyxt-user-system
+     :class nyxt-user-system
      ,@(uiop:remove-plist-key :components args)
      :components ,(mapcar #'ensure-component
                           components)))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -35,22 +35,6 @@ to set and use the socket without parsing any file.  Instead, the socket can be
 set from the corresponding command line option or the NYXT_SOCKET environment
 variable.")
 
-;; TODO: Remove `nyxt-config-file'.
-(export-always 'nyxt-config-file)
-(defun nyxt-config-file (&optional subpath)
-  "Return SUBPATH relative to `*config-file*'.
-Return #p\"\" if `*config-file*' expands to #p\"\".
-
-The .lisp extension is automatically appended.
-
-For instance, if we want to load some Slynk configuration code that lives in
-/PATH/TO/NYXT/CONFIG/DIRECTORY/my-slink.lisp:
-
-  (load-after-system :slynk (nyxt-config-file \"my-slink\"))"
-  (if subpath
-      (files:expand (make-instance 'config-directory-file :base-path subpath))
-      (files:expand *config-file*)))
-
 (defun handle-malformed-cli-arg (condition)
   (format t "Error parsing argument ~a: ~a.~&" (opts:option condition) condition)
   (opts:describe)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -35,6 +35,7 @@ to set and use the socket without parsing any file.  Instead, the socket can be
 set from the corresponding command line option or the NYXT_SOCKET environment
 variable.")
 
+;; TODO: Remove `nyxt-config-file'.
 (export-always 'nyxt-config-file)
 (defun nyxt-config-file (&optional subpath)
   "Return SUBPATH relative to `*config-file*'.


### PR DESCRIPTION
# Description

This replaces the poorly designed `load-after-system` with an ASDF-based API:
- `define-nyxt-user-system` and `define-nyxt-user-system-and-load` to define and load a system.  The syntax is the same as with `asdf:defsystem` with some adjustments to make it easier for newcomers to list files.  See example below.
- `load-system*` is like `asdf:load-system` but it instead of failing on missing dep, it warns and skips the load.

Example:

```lisp
(define-nyxt-user-system-and-load "nyxt/user/foosystem"
  :depends-on (foo-dep)
  :components ("foo" "sub/blah.lisp")) ; ".lisp" extension is optional so as to not trip the user.
```

Result:
- If `foo-dep` does not exist, a warning is emitted, but no error and the files are _not_ loaded.
- If `foo-dep` is found, then the files "foo.lisp" and "sub/blah.lisp" in the Nyxt user config directory are loaded.

Fixes #2384.

# Discussion

- [x] A great addition would be to enable Emacs-style `with-eval-after-load` lazy loading.  I do not know if ASDF supports this.

  One approach would be to keep the `load-system*` failures in a list, and every time `load-system*` is done, loop through the list and check if the newly loaded system satisfies the dep of some failed systems.  If so, try to load it again.

- [x]  Fix bug called from a package other than `:nyxt`.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [x] I have pulled from master before submitting this PR
- [x] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
