### PR TITLE
Do not rely on .asd location

### DIFF
--- a/libraries/nyxt-asdf/systems.lisp
+++ b/libraries/nyxt-asdf/systems.lisp
@@ -26,19 +26,14 @@ It enables features such as:
   "Perform some last minute tweaks to the final image.
 
 - Register immutable systems to prevent compiled images of Nyxt from
-trying to recompile dependencies.
+trying to recompile Nyxt and its dependencies.
 See `asdf::*immutable-systems*'.
 
 - If on SBCL, include `sb-sprof', the statistical profiler, since it's one of
 the few modules that's not automatically included in the image."
   #+sbcl
   (require :sb-sprof)
-  (map () 'asdf:register-immutable-system
-       (remove-if (lambda (system)
-                    ;; Ensure nyxt-asdf is immutable.
-                    (or (string= "nyxt" system)
-                        (uiop:string-prefix-p "nyxt/" system)))
-                  (asdf:already-loaded-systems))))
+  (map () 'asdf:register-immutable-system (asdf:already-loaded-systems)))
 
 (defun set-new-translation (host logical-directory
                             root-directory

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -99,7 +99,7 @@ This is set globally so that extensions can be loaded even if there is no
 (defun nyxt-source-registry ()
   `(:source-registry
     (:tree ,(files:expand *extensions-directory*))
-    (:tree ,(files:expand *source-directory*))
+    (:tree ,(files:expand *source-directory*)) ; Probably useless since systems are immutable.
     :inherit-configuration))
 
 (defun set-nyxt-source-location (pathname) ; From `sb-ext:set-sbcl-source-location'.

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -316,7 +316,7 @@ By default it is found in the source directory."))
   (let ((system-directory (call-next-method)))
     (if (uiop:directory-exists-p system-directory)
         system-directory
-        (asdf:system-relative-pathname :nyxt "libraries/web-extensions/"))))
+        (files:join (files:expand *source-directory*) "/libraries/web-extensions/"))))
 
 (define-class cookies-file (files:data-file data-manager-file)
   ((files:name "cookies"))
@@ -807,7 +807,7 @@ See `gtk-browser's `modifier-translator' slot."
          (gtk-extensions-path (files:expand (make-instance 'gtk-extensions-directory)))
          (cookie-manager (webkit:webkit-web-context-get-cookie-manager context)))
     (webkit:webkit-web-context-add-path-to-sandbox
-     context (namestring (asdf:system-relative-pathname :nyxt "libraries/web-extensions/")) t)
+     context (namestring gtk-extensions-path) t)
     (unless (uiop:emptyp gtk-extensions-path)
       (log:info "GTK extensions directory: ~s" gtk-extensions-path)
       ;; TODO: Should we also use `connect-signal' here?  Does this yield a memory leak?

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -495,9 +495,10 @@ Examples:
 "))
   (pushnew 'nyxt-source-registry asdf:*default-source-registries*)
   (asdf:clear-configuration)
-  (if (uiop:directory-exists-p (asdf:system-source-directory :nyxt))
-      (set-nyxt-source-location (asdf:system-source-directory :nyxt))
-      (log:debug "Nyxt source directory not found."))
+  (let ((source-directory (files:expand *source-directory*)))
+    (if (uiop:directory-exists-p source-directory)
+        (set-nyxt-source-location source-directory)
+        (log:debug "Nyxt source directory not found.")))
 
   ;; Initialize the lparallel kernel
   (initialize-lparallel-kernel)


### PR DESCRIPTION
# Description

Making `nyxt` mutable was certainly a mistake.
I've reverted this change and instead of relying on `nyxt.asd` location, we rely on the expansion of `*source-directory*`.

Fixes #2416.

# Discussion

There is a suspicious change in `gtk.lisp`:

```diff
          (gtk-extensions-path (files:expand (make-instance 'gtk-extensions-directory)))
          (cookie-manager (webkit:webkit-web-context-get-cookie-manager context)))
     (webkit:webkit-web-context-add-path-to-sandbox
-     context (namestring (asdf:system-relative-pathname :nyxt "libraries/web-extensions/")) t)
+     context (namestring gtk-extensions-path) t)
```

@aartaka Why was `webkit:webkit-web-context-add-path-to-sandbox` not using `gtk-extensions-path` in the first place?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [x] I have pulled from master before submitting this PR
- [x] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
