### PR TITLE
Lispy search-buffer

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -816,24 +816,18 @@ Return the created buffer."
   dead-buffer)
 
 (defmethod document-model ((buffer buffer))
-  (pflet ((%count-dom-elements
+  (pflet ((%count-identified-elements
            ()
-           (defvar dom-counter 0)
-           (defun count-dom-elements (node)
-             (incf dom-counter)
-             (dolist (child (ps:chain node children))
-               (count-dom-elements child))
-             dom-counter)
-           (setf dom-counter 0)
-           (count-dom-elements (nyxt/ps:qs document "html"))))
+           (ps:@ (nyxt/ps:qsa document "[nyxt-identifier]") length)))
     (if (dead-buffer-p buffer)
         (slot-value buffer 'document-model)
         (with-current-buffer buffer
           (let ((value (slot-value buffer 'document-model))
-                (element-count (%count-dom-elements)))
+                (element-count (%count-identified-elements)))
             (if (and value element-count
                      ;; Check whether the difference in element count is significant.
-                     (< (abs (- (length (clss:select "*" value)) (truncate element-count)))
+                     (< (abs (- (length (clss:select "[nyxt-identifier]" value))
+                                (truncate element-count)))
                         (document-model-delta-threshold buffer)))
                 value
                 (update-document-model :buffer buffer)))))))

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -219,7 +219,8 @@ Return two values:
                                       (str:starts-with-p "data-" attribute)
                                       (str:starts-with-p "nyxt-" attribute)))
                                 (alex:hash-table-keys (plump:attributes element))))
-         (classes (when raw-classes (remove-if #'str:blankp (str:split " " raw-classes))))
+         (classes (when raw-classes (mapcar #'clss:css-escape
+                                            (remove-if #'str:blankp (str:split " " raw-classes)))))
          (parents (parents element))
          (family (plump:family-elements element))
          ;; Is it guaranteed that the topmost ancestor of a node is
@@ -234,7 +235,7 @@ Return two values:
              (selreturn ()
                (return-from get-unique-selector (values selector (unique-p selector)))))
       ;; ID should be globally unique, so we check it first.
-      (when (and identifier (sera:single (clss:select (selconcat :sel "#" identifier)  root)))
+      (when (and identifier (sera:single (clss:select (selconcat :sel "#" (clss:css-escape identifier))  root)))
         (selreturn))
       ;; selconcat hack doesn't look nice here, but should work for cases of
       ;; both empty selector and ID selector.
@@ -247,8 +248,9 @@ Return two values:
               classes))
       (when attributes
         (mapc (lambda (attribute)
-                (when (unique-p (selconcat :sel "[" attribute "=\""
-                                            (plump:attribute element attribute) "\"]"))
+                (when (unique-p (selconcat :sel "[" (clss:css-escape attribute) "='"
+                                           (clss:css-escape (plump:attribute element attribute))
+                                           "']"))
                   (selreturn)))
               attributes))
       ;; Check for short and nice parent-child relations, like :only-child,

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -293,6 +293,7 @@ Return two values:
   (defmethod plump:text :around ((node plump:nesting-node))
     (alex:ensure-gethash node text-memo-table (call-next-method))))
 
+(export-always 'find-text)
 (defmethod find-text ((text string) (element plump:nesting-node)
                       &key (test #'search))
   "Find all the matches for the TEXT in ELEMENT and its children.

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -187,6 +187,20 @@ JSON should have the format like what `get-document-body-json' produces:
   (:documentation "Get the recursive parents of the NODE.
 The closest parent goes first, the furthest one goes last."))
 
+(export-always 'ordered-select)
+(defmethod ordered-select (selector (root plump:nesting-node))
+  "A re-implementation of `clss:select' with the goal of preserving elements order.
+
+SELECTOR is any selector acceptable to `clss', including the compiled one and
+string one."
+  (let ((matched-nodes '()))
+    (labels ((collect-if-match (element)
+               (when (clss:node-matches-p selector element)
+                 (push element matched-nodes))
+               (map nil #'collect-if-match (plump:child-elements element))))
+      (collect-if-match root)
+      (coerce (nreverse matched-nodes) 'vector))))
+
 (export-always 'get-unique-selector)
 (-> get-unique-selector (plump:element) t)
 (defmemo get-unique-selector (element)

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -2,6 +2,8 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/dom
+  ;; FIXME: This is because window causes conflicts with buffer.lisp (somewhy?).
+  (:shadow #:window)
   (:documentation "Nyxt-specific DOM classes and functions operating on them.
 
 The classes are generated for every HTML element, including `h1-element',
@@ -202,6 +204,10 @@ string one."
                (map nil #'collect-if-match (plump:child-elements element))))
       (collect-if-match root)
       matched-nodes)))
+
+(export-always 'get-nyxt-id)
+(defmethod get-nyxt-id ((element plump:element))
+  (plump:get-attribute element "nyxt-identifier"))
 
 (export-always 'get-unique-selector)
 (-> get-unique-selector (plump:element) t)

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -311,7 +311,11 @@ TEST should be a function of two arguments comparing TEXT with element's
   (flet ((matches (elem)
            (find-text text elem :test test)))
     (when (funcall test text (plump:text element))
-      (or (alex:mappend #'matches (coerce (plump:child-elements element) 'list))
+      (or (remove-if
+           ;; Remove those to not clutter the output.
+           ;; TODO: More tags/attributes?
+           (alex:curry #'clss:node-matches-p "style, script")
+           (alex:mappend #'matches (coerce (plump:child-elements element) 'list)))
           (list element)))))
 
 ;; REVIEW: Export to :nyxt? We are forced to use it with nyxt/dom: prefix.

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -202,7 +202,7 @@ Rely (in the order of importance) on:
 - Tag name.
 - CSS Classes.
 - Attributes.
-- Parent and sibling node selectors (recursively).
+- Parent node selectors (recursively).
 
 If none of those provides the unique selector, return the most specific selector
 calculated.
@@ -278,10 +278,6 @@ Return two values:
              (unique-p (selconcat
                         :sel ":nth-child("
                         (princ-to-string (1+ (position element family))) ")")))
-        (selreturn))
-      ;; Then check for previous siblings.
-      (when (and previous
-                 (unique-p (selconcat (get-unique-selector previous)  " ~ " :sel)))
         (selreturn))
       ;; Finally, go up the hierarchy.
       (when (and parents

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -2,8 +2,6 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/dom
-  ;; FIXME: This is because window causes conflicts with buffer.lisp (somewhy?).
-  (:shadow #:window)
   (:documentation "Nyxt-specific DOM classes and functions operating on them.
 
 The classes are generated for every HTML element, including `h1-element',

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -209,7 +209,7 @@ calculated.
 
 Return two values:
 - The selector for the value.
-- A boolean for whether this selector is unique (no other nodes matching it)."
+- Whether this selector is unique (no other nodes matching it)."
   (let* ((tag-name (plump:tag-name element))
          (identifier (plump:get-attribute element "id"))
          (raw-classes (plump:get-attribute element "class"))

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -239,7 +239,7 @@ Return two values:
                                 (alex:hash-table-keys (plump:attributes element))))
          (classes (when raw-classes (remove-if #'str:blankp (str:split " " raw-classes))))
          (parents (parents element))
-         (family (plump:family element))
+         (family (plump:family-elements element))
          (previous (ignore-errors (plump:previous-element element)))
          ;; Is it guaranteed that the topmost ancestor of a node is
          ;; `plump:root'? Anyway, it should work even if there's a single
@@ -293,7 +293,7 @@ Return two values:
              (not (eq element (elt family (1- (length family)))))
              (unique-p (selconcat
                         :sel ":nth-child("
-                        (princ-to-string (1+ (position element (plump:family-elements element)))) ")")))
+                        (princ-to-string (1+ (position element family))) ")")))
         (selreturn))
       ;; Then check for previous siblings.
       (when (and previous

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -189,22 +189,6 @@ JSON should have the format like what `get-document-body-json' produces:
   (:documentation "Get the recursive parents of the NODE.
 The closest parent goes first, the furthest one goes last."))
 
-(export-always 'ordered-select)
-(defun ordered-select (selector root)
-  "A re-implementation of `clss:select' with the goal of preserving elements order.
-
-SELECTOR is any selector acceptable to `clss', including the compiled one and
-string one."
-  (declare (optimize speed))
-  (let ((matched-nodes (make-array 0 :adjustable t :fill-pointer 0))
-        (selector (clss::ensure-selector selector)))
-    (labels ((collect-if-match (element)
-               (when (clss:node-matches-p selector element)
-                 (vector-push-extend element matched-nodes))
-               (map nil #'collect-if-match (plump:child-elements element))))
-      (collect-if-match root)
-      matched-nodes)))
-
 (export-always 'get-nyxt-id)
 (defmethod get-nyxt-id ((element plump:element))
   (plump:get-attribute element "nyxt-identifier"))

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -224,7 +224,6 @@ Return two values:
          (classes (when raw-classes (remove-if #'str:blankp (str:split " " raw-classes))))
          (parents (parents element))
          (family (plump:family-elements element))
-         (previous (ignore-errors (plump:previous-element element)))
          ;; Is it guaranteed that the topmost ancestor of a node is
          ;; `plump:root'? Anyway, it should work even if there's a single
          ;; `plump:element' as a root.

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -399,7 +399,7 @@ TEST should be a function of two arguments comparing TEXT with element's
 (export-always 'scroll-to-element)
 (define-parenscript scroll-to-element (element)
   (ps:chain (nyxt/ps:qs-nyxt-id document (ps:lisp (get-nyxt-id element)))
-            (scroll-into-view t)))
+            (scroll-into-view)))
 
 (export-always 'set-caret-on-start)
 (define-parenscript set-caret-on-start (element)

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -215,7 +215,7 @@ Return two values:
          ;; and type are reliable and are unlikely to change, while data-*
          ;; attributes are unreliable and can change any moment.
          (attributes (remove-if (lambda (attribute)
-                                  (or (member attribute '("class" "id") :test #'string=)
+                                  (or (str:s-member '("class" "id") attribute)
                                       (str:starts-with-p "data-" attribute)
                                       (str:starts-with-p "nyxt-" attribute)))
                                 (alex:hash-table-keys (plump:attributes element))))

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -287,9 +287,9 @@ Return two values:
                  (unique-p (selconcat :sel ":last-child")))
         (selreturn))
       ;; Then check for previous siblings.
-      ;; (when (and previous
-      ;;            (unique-p (selconcat (get-unique-selector previous)  " ~ " :sel)))
-      ;;   (selreturn))
+      (when (and previous
+                 (unique-p (selconcat (get-unique-selector previous)  " ~ " :sel)))
+        (selreturn))
       ;; Finally, go up the hierarchy.
       (when (and parents
                  (unique-p (selconcat (get-unique-selector (first parents)) " > " :sel)))

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -289,6 +289,10 @@ Return two values:
   (when (plump:has-attribute img "src")
     (quri:uri (plump:get-attribute img "src"))))
 
+(let ((text-memo-table (tg:make-weak-hash-table :weakness :key)))
+  (defmethod plump:text :around ((node plump:nesting-node))
+    (alex:ensure-gethash node text-memo-table (call-next-method))))
+
 ;; REVIEW: Export to :nyxt? We are forced to use it with nyxt/dom: prefix.
 (export-always 'body)
 (defmethod body ((element plump:element))

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -293,6 +293,18 @@ Return two values:
   (defmethod plump:text :around ((node plump:nesting-node))
     (alex:ensure-gethash node text-memo-table (call-next-method))))
 
+(defmethod find-text ((text string) (element plump:nesting-node)
+                      &key (test #'search))
+  "Find all the matches for the TEXT in ELEMENT and its children.
+
+TEST should be a function of two arguments comparing TEXT with element's
+`plump:text' and returning a boolean for whether there's a match."
+  (flet ((matches (elem)
+           (find-text text elem :test test)))
+    (when (funcall test text (plump:text element))
+      (or (alex:mappend #'matches (coerce (plump:child-elements element) 'list))
+          (list element)))))
+
 ;; REVIEW: Export to :nyxt? We are forced to use it with nyxt/dom: prefix.
 (export-always 'body)
 (defmethod body ((element plump:element))

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -409,17 +409,16 @@ ID is a buffer `id'."
            (ps:chain (nyxt/ps:qs-nyxt-id document (ps:lisp (nyxt/dom:get-nyxt-id element)))
                      (get-bounding-client-rect) y)))
     (with-current-buffer buffer
-      (sort (map 'list
-                 (lambda (e)
-                   (make-instance 'heading :inner-text (plump:text e)
-                                           :element e
-                                           :buffer buffer
-                                           :keywords (ignore-errors
-                                                      (analysis:extract-keywords
-                                                       (plump:text (plump:next-element e))))
-                                           :scroll-position (heading-scroll-position e)))
-                 (clss:select "h1, h2, h3, h4, h5, h6" (document-model buffer)))
-            #'< :key (compose #'parse-integer #'nyxt/dom:get-nyxt-id #'element)))))
+      (map 'list
+           (lambda (e)
+             (make-instance 'heading :inner-text (plump:text e)
+                                     :element e
+                                     :buffer buffer
+                                     :keywords (ignore-errors
+                                                (analysis:extract-keywords
+                                                 (plump:text (plump:next-element e))))
+                                     :scroll-position (heading-scroll-position e)))
+           (clss:ordered-select "h1, h2, h3, h4, h5, h6" (document-model buffer))))))
 
 (defun current-heading (&optional (buffer (current-buffer)))
   (alex:when-let* ((scroll-position (document-scroll-position buffer))

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -13,7 +13,7 @@
     nil
     :type boolean
     :documentation "Whether the hints are automatically followed when matching user input.")
-   (box-style
+   (style
     (theme:themed-css (theme *browser*)
       (".nyxt-hint"
        :background-color theme:primary
@@ -21,14 +21,11 @@
        :font-family "monospace,monospace"
        :padding "0px 0.3em"
        :border-radius "0.3em"
-       :z-index #.(1- (expt 2 31))))
-    :documentation "The style of the boxes, e.g. link hints.")
-   (highlighted-box-style
-    (theme:themed-css (theme *browser*)
+       :z-index #.(1- (expt 2 31)))
       (".nyxt-hint.nyxt-highlight-hint"
        :background-color theme:accent
        :color theme:on-accent))
-    :documentation "The style of highlighted boxes, e.g. link hints.")
+    :documentation "The style of the boxes (link hints), including the highlighted ones.")
    (hints-alphabet
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     :type string
@@ -77,12 +74,10 @@ For instance, to include images:
   (unless (nyxt/ps:qs document "#nyxt-stylesheet")
     (ps:try
      (ps:let* ((style-element (ps:chain document (create-element "style")))
-               (box-style (ps:lisp (box-style (find-submode 'nyxt/hint-mode:hint-mode))))
-               (highlighted-style (ps:lisp (highlighted-box-style (find-submode 'nyxt/hint-mode:hint-mode)))))
+               (style (ps:lisp (style (find-submode 'nyxt/hint-mode:hint-mode)))))
        (setf (ps:@ style-element id) "nyxt-stylesheet")
-       (ps:chain document head (append-child style-element))
-       (ps:chain style-element sheet (insert-rule box-style 0))
-       (ps:chain style-element sheet (insert-rule highlighted-style 1)))
+       (setf (ps:@ style-element inner-text) style)
+       (ps:chain document head (append-child style-element)))
      (:catch (error)))))
 
 (define-parenscript hint-elements (nyxt-identifiers hints)

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -6,7 +6,7 @@
 (in-package :nyxt/search-buffer-mode)
 
 (define-mode search-buffer-mode (nyxt/hint-mode:hint-mode)
-  "Mode for searching text withing."
+  "Mode for searching text within the buffer."
   ((visible-in-status-p nil)
    (rememberable-p nil)
    (test-function

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -21,7 +21,7 @@
    (test-function
     (lambda (sub string)
       (search sub string :test #'equalp))
-    :documentation "The function to match text with the text on the page while searching.
+    :documentation "The function to match text with the body of the page while searching.
 
 Takes two string arguments: search input and the page element text.
 

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -70,7 +70,9 @@ You can redefine it to enable regex-based search, for example:
                   "...")
                 (subseq (body match)
                         (if long-match
-                            (1+ (position #\Space (body match) :end (- (pos match) 20) :from-end t))
+                            (alex:if-let ((pos (position #\Space (body match) :end (- (pos match) 20) :from-end t)))
+                              (1+ pos)
+                              0)
                             0)))))
     ("Buffer ID" ,(princ-to-string (id (buffer match))))
     ("Buffer title" ,(title (buffer match)))))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -9,18 +9,18 @@
   "Mode for searching text within the buffer."
   ((visible-in-status-p nil)
    (rememberable-p nil)
-   (style (theme:themed-css (theme *browser*)
-            ("mark.nyxt-search-hint"
-             :background-color theme:primary
-             :color theme:on-primary
-             :font-weight "bold"
-             :padding "0px 3px 0px 3px"
-             :border-radius "2px"
-             :z-index #.(1- (expt 2 31)))
-            ("mark.nyxt-highlight-search-hint"
-             :background-color theme:accent
-             :color theme:on-accent))
-          :documentation "The style of the search marks, including the highlighted ones.")
+   (style
+    (theme:themed-css (theme *browser*)
+      (mark
+       :all "unset"
+       :opacity "0.5")
+      (".nyxt-search-hint"
+       :background-color (str:concat theme:primary " !important")
+       :color (str:concat theme:on-primary " !important"))
+      (".nyxt-highlight-search-hint"
+       :background-color (str:concat theme:accent " !important")
+       :color (str:concat theme:on-accent " !important")))
+    :documentation "The style of the search marks, including the highlighted ones.")
    (test-function
     (lambda (sub string)
       (search sub string :test #'equalp))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -119,7 +119,7 @@ You can redefine it to enable regex-based search, for example:
     (remove-search-hints)
     (with-current-buffer buffer
       (add-stylesheet)
-      (hint-elements (coerce (mapcar #'identifier search-matches) 'vector))
+      (hint-elements (map 'vector #'identifier search-matches))
       search-matches)))
 
 (define-class search-buffer-source (prompter:source)

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -73,13 +73,14 @@ You can redefine it to enable regex-based search, for example:
     (create-marks selector)))
 
 (define-parenscript highlight-selected-hint (&key element scroll)
-  (ps:let* ((new-element (nyxt/ps:qs document (ps:lisp (identifier element)))))
+  (ps:let* ((new-element (ps:@ (nyxt/ps:qs-nyxt-id document (ps:lisp (nyxt/dom:get-nyxt-id (element element))))
+                               parent)))
     (when new-element
       (unless ((ps:@ new-element class-list contains) "nyxt-highlight-search-hint")
         (ps:let ((old-elements (nyxt/ps:qsa document ".nyxt-highlight-search-hint")))
           (ps:dolist (e old-elements)
             (setf (ps:@ e class-name) "nyxt-search-hint"))))
-      (setf (ps:@ new-element class-name) "nyxt-highlight-hint")
+      (setf (ps:@ new-element class-name) "nyxt-highlight-search-hint")
       (when (ps:lisp scroll)
         (ps:chain new-element (scroll-into-view (ps:create block "nearest")))))))
 
@@ -108,7 +109,7 @@ You can redefine it to enable regex-based search, for example:
             (and (slot-exists-p hint 'buffer)
                  (equal (buffer hint) buffer)))
         (with-current-buffer buffer
-          (nyxt/hint-mode::highlight-selected-hint :element hint :scroll scroll))
+          (highlight-selected-hint :element hint :scroll scroll))
         (remove-focus))))
 
 (define-command remove-search-hints ()
@@ -160,8 +161,7 @@ You can redefine it to enable regex-based search, for example:
    (prompter:destructor (lambda (prompter source)
                           (declare (ignore prompter source))
                           (unless (keep-search-hints-p (current-buffer))
-                            (remove-search-hints))
-                          (nyxt/hint-mode:remove-focus))))
+                            (remove-search-hints)))))
   (:export-accessor-names-p t)
   (:export-class-name-p t)
   (:accessor-name-transformer (class*:make-name-transformer name))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -14,6 +14,8 @@
       (search sub string :test #'equalp))
     :documentation "The function to match text with the text on the page while searching.
 
+Takes two string arguments: search input and the page element text.
+
 You can redefine it to enable regex-based search, for example:
 \(define-configuration nyxt/search-buffer-mode:search-buffer-mode
   ((nyxt/search-buffer-mode:test-function #'cl-ppcre:scan)))")

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -87,7 +87,8 @@ You can redefine it to enable regex-based search, for example:
 (define-command remove-search-hints ()
   "Remove all search hints."
   (peval (ps:dolist (node (nyxt/ps:qsa document "mark.nyxt-hint"))
-           (ps:chain node (replace-with (ps:chain node first-child))))))
+           (let ((original (ps:chain node first-child)))
+             (ps:chain node (replace-with original))))))
 
 (defun add-search-hints (input buffer)
   (let* ((input (str:replace-all " " " " input))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -35,18 +35,6 @@ You can redefine it to enable regex-based search, for example:
        "/" 'search-buffer
        "?" 'remove-search-hints)))))
 
-(define-parenscript add-stylesheet ()
-  (unless (nyxt/ps:qs document "#nyxt-stylesheet")
-    (ps:try
-     (ps:let* ((style-element (ps:chain document (create-element "style")))
-               (box-style (ps:lisp (nyxt/hint-mode:box-style (find-submode 'search-buffer-mode))))
-               (highlighted-style (ps:lisp (nyxt/hint-mode:highlighted-box-style (find-submode 'search-buffer-mode)))))
-       (setf (ps:@ style-element id) "nyxt-stylesheet")
-       (ps:chain document head (append-child style-element))
-       (ps:chain style-element sheet (insert-rule box-style 0))
-       (ps:chain style-element sheet (insert-rule highlighted-style 1)))
-     (:catch (error)))))
-
 (define-class search-match ()
   ((identifier)
    (element)
@@ -117,7 +105,7 @@ You can redefine it to enable regex-based search, for example:
     (remove-search-hints)
     (with-current-buffer buffer
       (run-thread "stylesheet adder"
-        (add-stylesheet))
+        (nyxt/hint-mode::add-stylesheet))
       (run-thread "search hint drawing"
         (hint-elements (coerce (mapcar #'identifier search-matches) 'vector)))
       search-matches)))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -115,8 +115,7 @@ You can redefine it to enable regex-based search, for example:
       search-matches)))
 
 (define-class search-buffer-source (prompter:source)
-  ((case-sensitive-p nil)
-   (buffer (current-buffer))
+  ((buffer (current-buffer))
    (minimum-search-length 3)
    (prompter:name "Search buffer")
    (prompter:selection-actions-enabled-p t)
@@ -149,7 +148,7 @@ You can redefine it to enable regex-based search, for example:
                 (prompter:name source)
                 (minimum-search-length source))))
 
-(define-command search-buffer (&key case-sensitive-p)
+(define-command search-buffer ()
   "Search on the current buffer.
 If you want to remove the search hints when you close the search
 prompt, Set BUFFER's `keep-search-hints-p' slot to nil.
@@ -160,14 +159,13 @@ Example:
     ((keep-search-hints-p nil)))"
   (prompt :prompt "Search text"
           :sources (make-instance 'search-buffer-source
-                                  :case-sensitive-p case-sensitive-p
                                   :return-actions
                                   (list (lambda (search-match)
                                           (unless (keep-search-hints-p (current-buffer))
                                             (remove-search-hints))
                                           search-match)))))
 
-(define-command search-buffers (&key case-sensitive-p)
+(define-command search-buffers ()
   "Search multiple buffers."
   (let ((buffers (prompt :prompt "Search buffer(s)"
                          :sources (make-instance 'buffer-source ; TODO: Define class?
@@ -180,6 +178,5 @@ Example:
                                        :name (format nil "Search ~a" (if (url-empty-p (url buffer))
                                                                          (title buffer)
                                                                          (url buffer)))
-                                       :case-sensitive-p case-sensitive-p
                                        :buffer buffer))
                       buffers))))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -73,7 +73,7 @@ You can redefine it to enable regex-based search, for example:
       (ps:try
        (ps:chain element class-list (add "nyxt-search-hint"))
        (:catch (err)
-         (setf (ps:chain element class)
+         (setf (ps:@ element class)
                "nyxt-search-hint"))))))
 
 (define-parenscript highlight-selected-hint (&key element scroll)

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -55,6 +55,7 @@ You can redefine it to enable regex-based search, for example:
 (define-class search-match ()
   ((identifier)
    (element)
+   (pos)
    (body)
    (buffer))
   (:accessor-name-transformer (class*:make-name-transformer name)))
@@ -63,7 +64,14 @@ You can redefine it to enable regex-based search, for example:
   (identifier match))
 
 (defmethod prompter:object-attributes ((match search-match) (source prompter:source))
-  `(("Text" ,(body match))
+  `(("Text" ,(let ((long-match (> (pos match) 40)))
+               (uiop:strcat
+                (when long-match
+                  "...")
+                (subseq (body match)
+                        (if long-match
+                            (1+ (position #\Space (body match) :end (- (pos match) 20) :from-end t))
+                            0)))))
     ("Buffer ID" ,(princ-to-string (id (buffer match))))
     ("Buffer title" ,(title (buffer match)))))
 
@@ -109,6 +117,7 @@ You can redefine it to enable regex-based search, for example:
                                    (make-instance 'search-match
                                                   :identifier (nyxt/dom:get-unique-selector element)
                                                   :element element
+                                                  :pos (funcall test input (plump:text element))
                                                   :body (plump:text element)
                                                   :buffer buffer))
                                  elements)))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -96,6 +96,11 @@ You can redefine it to enable regex-based search, for example:
           (nyxt/hint-mode::highlight-selected-hint :element hint :scroll scroll))
         (nyxt/hint-mode:remove-focus))))
 
+(define-command remove-search-hints ()
+  "Remove all search hints."
+  (peval (ps:dolist (node (nyxt/ps:qsa document "mark.nyxt-hint"))
+           (ps:chain node (replace-with (ps:chain node first-child))))))
+
 (defun add-search-hints (input buffer)
   (let* ((input (str:replace-all " " " " input))
          (test (test-function (find-submode 'search-buffer-mode buffer)))
@@ -109,17 +114,13 @@ You can redefine it to enable regex-based search, for example:
                                                   :body (plump:text element)
                                                   :buffer buffer))
                                  elements)))
+    (remove-search-hints)
     (with-current-buffer buffer
       (run-thread "stylesheet adder"
         (add-stylesheet))
       (run-thread "search hint drawing"
         (hint-elements (coerce (mapcar #'identifier search-matches) 'vector)))
       search-matches)))
-
-(define-command remove-search-hints ()
-  "Remove all search hints."
-  (peval (ps:dolist (node (nyxt/ps:qsa document "mark.nyxt-hint"))
-           (ps:chain node (replace-with (ps:chain node first-child))))))
 
 (define-class search-buffer-source (prompter:source)
   ((case-sensitive-p nil)

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -70,7 +70,11 @@ You can redefine it to enable regex-based search, for example:
 (define-parenscript hint-elements (selectors)
   (dolist (selector (ps:lisp selectors))
     (ps:let* ((element (nyxt/ps:qs document selector)))
-      (ps:chain element class-list (add "nyxt-search-hint")))))
+      (ps:try
+       (ps:chain element class-list (add "nyxt-search-hint"))
+       (:catch (err)
+         (setf (ps:chain element class)
+               "nyxt-search-hint"))))))
 
 (define-parenscript highlight-selected-hint (&key element scroll)
   (ps:let* ((element (ps:@ (nyxt/ps:qs document (ps:lisp (nyxt/dom:get-unique-selector element))))))

--- a/source/mode/tts.lisp
+++ b/source/mode/tts.lisp
@@ -34,14 +34,13 @@ Example:
   "Fetch the text in buffer that matches `selector` and send it off to the TTS."
   (if (executable mode)
       (let* ((tags
-               (sort (handler-case
-                         (coerce
-                          (clss:select (selector mode) (document-model (buffer mode)))
-                          'list)
-                       (error ()
-                         (log:warn "tts-mode: no document-model available.")
-                         nil))
-                     #'< :key (compose #'parse-integer #'nyxt/dom:get-nyxt-id)))
+               (handler-case
+                   (coerce
+                    (clss:ordered-select (selector mode) (document-model (buffer mode)))
+                    'list)
+                 (error ()
+                   (log:warn "tts-mode: no document-model available.")
+                   nil)))
              ;; TODO properly handle punctuation like Emacspeak does
              (text (str:remove-punctuation
                     (with-output-to-string (s)


### PR DESCRIPTION
# Description

This changes our search functionality to depend on Plump and Lisp-side calculations. 
Pros:
- More controllable and extensible (for example, for #2230 (CC @aadcg) and search-based annotations).
- Stores most data on the Lisp side, thus saves lots of JavaScript calls.
- Adds a neat set of changes to `nyxt/dom` that can be used for libraries and extensions.

Cons:
- Highlighting is less exact, as it highlights the smallest element containing the search text, and this element may not be exactly small.
- May be slower than JS-based search, but, given how fast we made our hints, this is a solvable problem.

This also includes quite some changes to the existing functions that make working with Plump DOM even easier!

# Discussion

- Is the element-level highlighting enough for text search? I feel like it adds more context, but I can foresee the opposing arguments too :)
- Should we reuse the same `nyxt/dom:get-unique-selector` in hint mode? This way, we don't need to alter tha page structure anymore. But then, it may be not unique enough...

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [X] I have pulled from master before submitting this PR
- [X] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

How does it look?