### PR TITLE
Headless doc

### DIFF
--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -8,9 +8,8 @@ The classes are generated for every HTML element, including `h1-element',
 `div-element', `img-element' and others.
 
 Classes corresponding to non-HTML elements, such as `text-element',
-`semantic-element', or `h-element', act as higher hierarchical
-entities of element classes.  For instance, every `h<n>-element' inherits from
-`h-element'.
+`semantic-element', or `h-element', act as higher hierarchical entities of
+element classes.  For instance, every `h<n>-element' inherits from `h-element'.
 
 The most useful functions are:
 - `named-html-parse' and `named-json-parse' to turn HTML and JSON documents into

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -2,7 +2,23 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/dom
-  (:documentation "Nyxt-specific DOM classes and functions operating on them."))
+  (:documentation "Nyxt-specific DOM classes and functions operating on them.
+
+The classes are generated for every HTML element tag name, including (but not
+limited to) `h1-element', `div-element', `img-element', and others. There are
+also some non-HTML classes, like `text-element', `semantic-element',
+`h-element', and `input-element' being umbrella classes for groups of tag
+classes.
+
+The most useful functions are:
+- `named-html-parse' and `named-json-parse' turning the HTML and JSON page
+representations into the proper `plump:root' with all the HTML elements being
+converted to the matching class.
+- `parents', `url', and `body' to get access to the features that may be
+  element-specific, in a unified fashion.
+- `click-element', `focus-select-element', `select-option-element' and others,
+  as a way to interact with the page using the `nyxt/dom' elements as
+  proxies/representatives of the actual DOM elements."))
 (in-package :nyxt/dom)
 
 ;; TODO: Factor out into a library?

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -4,21 +4,23 @@
 (nyxt:define-package :nyxt/dom
   (:documentation "Nyxt-specific DOM classes and functions operating on them.
 
-The classes are generated for every HTML element tag name, including (but not
-limited to) `h1-element', `div-element', `img-element', and others. There are
-also some non-HTML classes, like `text-element', `semantic-element',
-`h-element', and `input-element' being umbrella classes for groups of tag
-classes.
+The classes are generated for every HTML element, including `h1-element',
+`div-element', `img-element' and others.
+
+Classes corresponding to non-HTML elements, such as `text-element',
+`semantic-element', `h-element' or `input-element', act as higher hierarchical
+entities of element classes.  For instance, every `h<n>-ement' inherits from
+`h-element'.
 
 The most useful functions are:
-- `named-html-parse' and `named-json-parse' turning the HTML and JSON page
-representations into the proper `plump:root' with all the HTML elements being
-converted to the matching class.
-- `parents', `url', and `body' to get access to the features that may be
-  element-specific, in a unified fashion.
-- `click-element', `focus-select-element', `select-option-element' and others,
-  as a way to interact with the page using the `nyxt/dom' elements as
-  proxies/representatives of the actual DOM elements."))
+- `named-html-parse' and `named-json-parse' to turn HTML and JSON documents into
+  a representation of type `plump:root', converting elements into its matching
+  classes.
+- `parents', `url' and `body' to access element-specific features in a unified
+  fashion.
+- `click-element', `focus-select-element', `select-option-element' and others to
+  interact with the page using `nyxt/dom' elements as representations of the
+  actual DOM elements."))
 (in-package :nyxt/dom)
 
 ;; TODO: Factor out into a library?

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -8,8 +8,8 @@ The classes are generated for every HTML element, including `h1-element',
 `div-element', `img-element' and others.
 
 Classes corresponding to non-HTML elements, such as `text-element',
-`semantic-element', `h-element' or `input-element', act as higher hierarchical
-entities of element classes.  For instance, every `h<n>-ement' inherits from
+`semantic-element', or `h-element', act as higher hierarchical
+entities of element classes.  For instance, every `h<n>-element' inherits from
 `h-element'.
 
 The most useful functions are:

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -421,7 +421,7 @@ instance must be non-nil.")
     (:pre (:code "nyxt --profile nosave --remote --load foo.lisp --eval '(foo)'"))
 
     (:h3 "Headless mode")
-    (:p "Much like with scripting functionality, you can use Nyxt in headless (without
+    (:p "Much like a scripting functionality, you can use Nyxt in headless (without
 graphical interface) mode. Possible use-cases for this mode are web scraping,
 automations and web page analysis.")
     (:p "To enable headless mode, simply start Nyxt with the "
@@ -478,13 +478,14 @@ hooks. Things you'd most probably want to put there are: ")
      (:li "Hook bindings, using the " (:nxref :package 'nhooks)
           " library and hooks provided by Nyxt.")
      (:li "Operations with the page. For those, we have a whole "
-          (:nxref :package 'nyxt/dom) " library and " (:nxref :function 'document-model)
-          "buffer slot.")
+          (:nxref :package 'nyxt/dom) " library and the " (:nxref :function 'document-model)
+          "method.")
      (:ul
-      (:li (:nxref :function 'document-model) " method of " (:nxref :class 'buffer)
-           " has a reasonably fresh copy of the page DOM (Document Object Model, reflects
-the dynamic structure of the page). It is a " (:nxref :package 'plump) " DOM, which means that all "
-(:nxref :package 'plump "Plump") " (and " (:nxref :package 'clss "CLSS") ") functions can be used on it.")
+      (:li "The " (:nxref :function 'document-model)
+           " method has a reasonably fresh copy of the page DOM (Document Object Model,
+reflects the dynamic structure of the page). It is a " (:nxref :package 'plump "Plump")
+" DOM, which means that all " (:nxref :package 'plump "Plump") " (and "
+(:nxref :package 'clss "CLSS") ") functions can be used on it.")
       (:li (:nxref :function 'update-document-model)
            " is a function to force DOM re-parsing for the cases when you consider the
 current " (:nxref :function 'document-model) " too outdated.")
@@ -509,9 +510,11 @@ traversal order.")
           ", then Nyxt starts as usual and allows you to see the changes that happen to
 the page because of your script. A good way to debug and check script behavior,
 isn't it?")
-     (:li (:code "--no-socket") " flag allows starting as much Nyxt instances as your computer allows you
+     (:li (:code "--no-socket")
+          " flag allows starting as many Nyxt instances as your computer allows you
 to. Useful to start several instances of Nyxt and do your thing in parallel.")
-     (:li (:code "--profile nosave") " to not pollute your history and cache with the script-accessed pages."))
+     (:li (:code "--profile nosave")
+          " to not pollute your history and cache with the script-accessed pages."))
 
     (:h2 "Extensions")
     (:p "To install an extension, copy inside the "

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -464,7 +464,9 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
     ;; Click the star button.
     (nyxt/dom:click-element
      :nyxt-identifier
-     (get-nyxt-id (elt (clss:select \"[aria-label=\\\"Star this repository\\\"]\" (document-model buffer)) 0)))
+     (get-nyxt-id (elt (clss:select \"[aria-label=\\\"Star this repository\\\"]\"
+                         (document-model buffer))
+                       0)))
     (echo \"Clicked the star.\")
     ;; It's good tone to `nyxt:quit' after you're done, but if you use nyxt
     ;; --no-socket, you don't have to. Just be ready for some RAM eating :)

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -490,16 +490,18 @@ reflects the dynamic structure of the page). It is a " (:nxref :package 'plump "
            " is a function to force DOM re-parsing for the cases when you consider the
 current " (:nxref :function 'document-model) " too outdated.")
       (:li (:nxref :function 'clss:select)
-           " is a CLSS function to find elements using CSS selectors (a terse notation for web page element description).")
+           " is a CLSS function to find elements using CSS selectors (a terse
+           notation for web page element description).")
       ;; FIXME: Make a nxref once we update CLSS submodule.
       (:li (:code"clss:ordered-select") " is the same as "
            (:nxref :function 'clss:select)
-           ", except it guarantees that all the elements are returned in a depth-first
-traversal order.")
+           ", except it guarantees that all the elements are returned in a
+           depth-first traversal order.")
       (:li (:nxref :function 'nyxt/dom:click-element)
            " to programmatically click a certain element (including the ones returned by "
            (:nxref :function 'clss:select) ".)")
-      (:li (:nxref :function 'nyxt/dom:focus-select-element) " to focus an input field, for example.")
+      (:li (:nxref :function 'nyxt/dom:focus-select-element) " to focus an input
+           field, for example.")
       (:li (:nxref :function 'nyxt/dom:check-element) " to check a checkbox or a radio button.")
       (:li (:nxref :function 'nyxt/dom:select-option-element) " to select an option from the "
            (:code "<select>") " element options.")))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -69,7 +69,7 @@ run " (command-markup 'describe-command) " and type 'mode'.")
     (:p "Slots store values that can be either accessed (get) or changed
 (set). Setting new values for slots allows many possibilities of customization.
 For instance, keyboard layouts vary across the world. The slot "
-        (:nxref :slot-of nyxt/hint-mode:hint-mode nyxt/hint-mode:hints-alphabet)
+        (:nxref :slot-of 'nyxt/hint-mode:hint-mode 'nyxt/hint-mode:hints-alphabet)
         " has the default value of "
         (:code "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         ". If the user has an American keyboard, they can do:")
@@ -81,28 +81,28 @@ For instance, keyboard layouts vary across the world. The slot "
      (:li "Insert the string \"asfdghjkl\"") ".")
     (:p "This will make link-hinting more comfortable for this user. In
 addition, other similar approaches of customization can be applied to slots
-such as " (:nxref :slot-of nyxt/spell-check-mode:spell-check-mode nyxt/spell-check-mode:spell-check-language)
+such as " (:nxref :slot-of 'nyxt/spell-check-mode:spell-check-mode 'nyxt/spell-check-mode:spell-check-language)
 ", which can be expanded to do the spelling-check of other languages besides English.")
     (:h3 "Different types of buffers")
     (:p "There are multiple buffer classes, such as "
-        (:nxref :class t document-buffer) " (for structured documents) and "
-        (:nxref :class t input-buffer) " (for buffers that can receive user input).  A "
-        (:nxref :class t web-buffer) " class is used for web pages," (:nxref :class t prompt-buffer)
+        (:nxref :class 'document-buffer) " (for structured documents) and "
+        (:nxref :class 'input-buffer) " (for buffers that can receive user input).  A "
+        (:nxref :class 'web-buffer) " class is used for web pages," (:nxref :class 'prompt-buffer)
         " for, well,the prompt buffer.  Some buffer classes may inherit from multiple other classes.
-For instance " (:nxref :class t web-buffer) " and " (:nxref :class t prompt-buffer)
-        " both inherit from" (:nxref :class t input-buffer) ".")
-    (:p "You can configure one of the parent " (:nxref :class t buffer) " classes slots and the new
+For instance " (:nxref :class 'web-buffer) " and " (:nxref :class 'prompt-buffer)
+        " both inherit from" (:nxref :class 'input-buffer) ".")
+    (:p "You can configure one of the parent " (:nxref :class 'buffer) " classes slots and the new
 values will automatically cascade down as a new default for all child classes-
 unless this slot is specialized by these child classes.
-For instance if you configure the " (:nxref :slot-of override-map input-buffer)
-" slot in " (:nxref :class t input-buffer) ", both " (:nxref :class t panel-buffer) " and "
-(:nxref :class t web-buffer) " classes will inherit from the new value.")
+For instance if you configure the " (:nxref :slot-of 'input-buffer 'override-map)
+" slot in " (:nxref :class 'input-buffer) ", both " (:nxref :class 'panel-buffer) " and "
+(:nxref :class 'web-buffer) " classes will inherit from the new value.")
 
     (:h3 "Keybinding configuration")
     (:p "Nyxt supports multiple " (:i "bindings schemes") " such as CUA (the
     default), Emacs or vi.  Changing scheme is as simple as setting the
     corresponding mode as default, e.g. "
-        (:nxref :class t nyxt/emacs-mode:emacs-mode) ".  To make the change persistent across sessions,
+        (:nxref :class 'nyxt/emacs-mode:emacs-mode) ".  To make the change persistent across sessions,
 add the following to your configuration:")
     (:ul
      (:li "vi bindings:"
@@ -123,7 +123,7 @@ add the following to your configuration:")
       keyscheme:vi-normal
       (list \"g b\" (make-command switch-buffer* ()
                     (switch-buffer :current-is-last-p t)))))))"))
-    (:p "The " (:nxref :slot-of override-map input-buffer) " is a keymap that has priority over
+    (:p "The " (:nxref :slot-of 'input-buffer 'override-map) " is a keymap that has priority over
 all other keymaps.  By default, it has few bindings like the one
 for " (command-markup 'execute-command) ".  You can use it to set keys globally:")
     (:pre (:code "(define-configuration buffer
@@ -131,7 +131,7 @@ for " (command-markup 'execute-command) ".  You can use it to set keys globally:
                    (define-key map
                      \"M-x\" 'execute-command
                      \"C-space\" 'nothing)))))"))
-    (:p "The " (:nxref  :command t nothing) " command is useful to override bindings to do
+    (:p "The " (:nxref  :command 'nothing) " command is useful to override bindings to do
 nothing. Note that it's possible to bind any command, including those of
 disabled modes that are not listed in " (command-markup 'execute-command) ".")
     (:p "In addition, a more flexible approach is to create your own mode with
@@ -156,16 +156,16 @@ keymap.")
   ((default-modes (append '(my-mode) %slot-default%))))"))
 
     (:p "Bindings are subject to various translations as per "
-        (:nxref :variable t keymaps:*translator*) ". "
+        (:nxref :variable 'nkeymaps:*translator*) ". "
         "By default if it fails to find a binding it tries again with inverted
 shifts.  For instance if " (:code "C-x C-F") " fails to match anything " (:code "C-x C-f")
         " is tried."
-        "See the default value of " (:nxref :variable t keymaps:*translator*) " to learn how to
+        "See the default value of " (:nxref :variable 'nkeymaps:*translator*) " to learn how to
          custsomize it or set it to " (:code "nil") " to disable all forms of
          translation.")
 
     (:h3 "Search engines")
-    (:p "See the " (:nxref :slot-of context-buffer search-engines) " buffer slot
+    (:p "See the " (:nxref :slot-of 'context-buffer 'search-engines) " buffer slot
 documentation.  Bookmarks can also be used as search engines, see the
 corresponding section.")
     (:p "Nyxt comes with some default search engines for "
@@ -202,22 +202,22 @@ follows.")
     (:h3 "URL-dispatchers")
     (:p "You can configure which actions to take depending on the URL to be
 loaded.  For instance, you can configure which Torrent program to start to load
-magnet links.  See the" (:nxref :function t url-dispatching-handler) " function
+magnet links.  See the" (:nxref :function 'url-dispatching-handler) " function
 documentation.")
 
     (:h3 "Downloads")
     (:p "See the " (command-markup 'nyxt/download-mode:list-downloads) " command and the "
-        (:nxref :slot-of buffer download-path) " buffer slot documentation.")
+        (:nxref :slot-of 'buffer 'download-path) " buffer slot documentation.")
 
     (:h3 "Proxy and Tor")
-    (:p "See the " (:nxref :class t nyxt/proxy-mode:proxy-mode) " documentation.")
+    (:p "See the " (:nxref :class 'nyxt/proxy-mode:proxy-mode) " documentation.")
 
     (:h3 "Blocker mode")
     (:p "This mode blocks access to websites related to especific hosts. To see
 all hosts being blocked, execute command " (:code "describe-variable") ", choose variable "
 (:code "NYXT/BLOCKER-MODE:*DEFAULT-HOSTLIST*") ", and read data on "
 (:code "nyxt/blocker-mode:url-body") " slot." " To customize host blocking, read the "
-(:nxref :class t nyxt/blocker-mode:blocker-mode) " documentation.")
+(:nxref :class 'nyxt/blocker-mode:blocker-mode) " documentation.")
 
     (:h3 "Custom commands")
     (:p "Creating your own invocable commands is similar to creating a Common
@@ -231,7 +231,7 @@ Lisp function, except the form is " (:code "define-command") " instead of "
               :prompt \"Bookmark URL\"
               :sources (make-instance 'prompter:raw-source))))
     (bookmark-add url)))"))
-    (:p "See the " (:nxref :class t prompt-buffer) " class documentation for how
+    (:p "See the " (:nxref :class 'prompt-buffer) " class documentation for how
 to write custom prompt-buffers.")
 
     (:h3 "Hooks")
@@ -241,7 +241,7 @@ events that occur in the context of windows, buffers, modes, etc.")
 typed functions.  Each hook has a dedicated handler constructor.")
     (:p
      "Hooks can be 'run', that is, their handlers are run according to
-the " (:nxref :slot-of nhooks:hook nhooks:combination) " slot of the hook.  This combination is a function
+the " (:nxref :slot-of 'nhooks:hook 'nhooks:combination) " slot of the hook.  This combination is a function
 of the handlers.  Depending on the combination, a hook can run the handlers
 either in parallel, or in order until one fails, or even " (:i "compose")
      " them (pass the result of one as the input of the next).  The handler types
@@ -249,7 +249,7 @@ specify which input and output values are expected.")
     (:p "Many hooks are executed at different points in Nyxt, among others:
 ")
     (:ul
-     (:li "Global hooks, such as " (:nxref :variable t *after-init-hook*) ".")
+     (:li "Global hooks, such as " (:nxref :variable '*after-init-hook*) ".")
      (:li "Window- or buffer-related hooks.")
      (:li "Commands 'before' and 'after' hooks.")
      (:li "Modes 'enable' and 'disable' hooks."))
@@ -269,7 +269,7 @@ can set a hook like the following in your configuration file:")
 \(define-configuration web-buffer
   ((request-resource-hook
     (hooks:add-hook %slot-default% 'old-reddit-handler))))"))
-    (:p "(See " (:nxref :function t url-dispatching-handler)
+    (:p "(See " (:nxref :function 'url-dispatching-handler)
         " for a simpler way to achieve the same result.)")
     (:p "Or, if you want to set multiple handlers at once,")
     (:pre (:code "(define-configuration web-buffer
@@ -278,13 +278,13 @@ can set a hook like the following in your configuration file:")
             '(old-reddit-handler auto-proxy-handler)
             :initial-value %slot-default%))))"))
     (:p "Some hooks like the above example expect a return value, so it's
-important to make sure we return " (:nxref :class t request-data) " here.  See the
+important to make sure we return " (:nxref :class 'request-data) " here.  See the
 documentation of the respective hooks for more details.")
 
     (:h3 "Data paths and data profiles")
     (:p "Nyxt provides a uniform configuration interface for all data files
 persisted to disk (bookmarks, cookies, etc.).  To each file corresponds
-a " (:nxref :class t nyxt-file) " object. An " (:nxref :class t nyxt-profile) " is a
+a " (:nxref :class 'nyxt-file) " object. An " (:nxref :class 'nyxt-profile) " is a
 customizable object that helps define general rules for data storage.  Both
 nyxt-file and nyxt-profile compose, so it's possible to define general rules
 for all files (even for those not known in advance) while it's also
@@ -344,18 +344,18 @@ the " (:code "define-configuration") " macro.")
     (:h3 "Appearance")
     (:p "Much of the visual style can be configured by the user.  Search the
 class slots for 'style'.  To customize the status buffer, see
-the " (:nxref :slot-of window status-buffer) " window slot.")
+the " (:nxref :slot-of 'window 'status-buffer) " window slot.")
 
     (:h3 "Advanced configuration")
     (:p "While " (:code "define-configuration") " is convenient, it is mostly
 restricted to class slot configuration.  If you want to do anything else on
 class instantiation, you'll have to specialize the
-lower-level " (:nxref :function t customize-instance) " generic function.  Example:"
+lower-level " (:nxref :function 'customize-instance) " generic function.  Example:"
 (:pre (:code "(defmethod customize-instance ((buffer buffer) &key)
   (echo \"Buffer ~a created.\" buffer))")))
-    (:p "All classes with metaclass " (:nxref :class t user-class) " call "
-        (:nxref :function t customize-instance) " on instantiation,
-after " (:nxref :function t initialize-instance)(:code " :after") ".  The primary method is reserved
+    (:p "All classes with metaclass " (:nxref :class 'user-class) " call "
+        (:nxref :function 'customize-instance) " on instantiation,
+after " (:nxref :function 'initialize-instance)(:code " :after") ".  The primary method is reserved
 to the user, however the " (:code ":after") " method is reserved to the Nyxt
 core to finalize the instance.")
 
@@ -440,58 +440,58 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
 to make Nyxt perform some actions to the opened pages and/or on certain
 events. Things you'd most probably want to put there are: ")
     (:ul
-     (:li "Hook bindings, using the " (:nxref :package t nhooks)
+     (:li "Hook bindings, using the " (:nxref :package 'nhooks)
           " library and hooks provided by Nyxt, with notable mentions being:")
      (:ul
-      (:li (:nxref :slot-of network-buffer buffer-load-hook) " for when there's a new page loading in the buffer.")
-      (:li (:nxref :slot-of network-buffer buffer-loaded-hook)
+      (:li (:nxref :slot-of 'network-buffer 'buffer-load-hook) " for when there's a new page loading in the buffer.")
+      (:li (:nxref :slot-of 'network-buffer 'buffer-loaded-hook)
            " for when this page is mostly done loading (some scripts/image/styles may not
 be fully loaded yet, so you may need to wait a bit after it fires.)")
-      (:li (:nxref :slot-of network-buffer request-resource-hook)
+      (:li (:nxref :slot-of 'network-buffer 'request-resource-hook)
            " for when a new request happens. Allows redirecting and blocking requests, and
 is a good place to do something conditioned on the links being loaded.")
-      (:li (:nxref :variable t *after-startup-hook*)
+      (:li (:nxref :variable '*after-startup-hook*)
            " is the best place to start instrumenting Nyxt, as this hook fires when Nyxt is
 ready for interaction.")
-      (:li (:nxref :slot-of prompt-buffer prompt-buffer-ready-hook)
+      (:li (:nxref :slot-of 'prompt-buffer 'prompt-buffer-ready-hook)
            " fires when the prompt buffer is ready for user input. You may need to call "
-           (:nxref :function t prompter:all-ready-p)
+           (:nxref :function 'prompter:all-ready-p)
            " on the prompt to ensure all the sources it contains are ready too, and then
 you can safely set new inputs and select the necessary suggestions.")
-      (:li (:nxref :function t nhooks:add-hook) " (also known as "
+      (:li (:nxref :function 'nhooks:add-hook) " (also known as "
            (:code "hooks:add-hook")
            ") allows you to add a handler to a hook,for it to be invoked when the hook fires.")
       (:li (:code "nhooks:on") " (also available as " (:code "hooks:on")
            ") as a shorthand for the " (:code "nhooks:add-hook") ".")
-      (:li (:nxref :function t nhooks:remove-hook) " (also available as "
+      (:li (:nxref :function 'nhooks:remove-hook) " (also available as "
            (:code "hooks:remove-hook") ") that removes the handler from a certain hook.")
       (:li (:code "hnooks:once-on") " (also available as " (:code "hooks:once-on")
            ") as a one-shot version of " (:code "nhooks:on")
            " that removes the handler right after it's completed."))
      (:li "Operations with the page. For those, we have a whole "
-          (:nxref :package t nyxt/dom) " library and " (:nxref :function t document-model)
+          (:nxref :package 'nyxt/dom) " library and " (:nxref :function 'document-model)
           "buffer slot.")
      (:ul
-      (:li (:nxref :function t document-model) " method of " (:nxref :class t buffer)
+      (:li (:nxref :function 'document-model) " method of " (:nxref :class 'buffer)
            " has a reasonably fresh copy of the page DOM (Document Object Model, reflects
 the dynamic structure of the page). It is a Plump DOM, which means that all
 Plump (and CLSS) functions can be used on it.")
-      (:li (:nxref :function t update-document-model)
+      (:li (:nxref :function 'update-document-model)
            " is a function to force DOM re-parsing for the cases when you consider the
-current " (:nxref :function t document-model) " too outdated.")
-      (:li (:nxref :function t clss:select)
+current " (:nxref :function 'document-model) " too outdated.")
+      (:li (:nxref :function 'clss:select)
            " is a CLSS function to find elements using CSS selectors (a terse notation for web page element description).")
       ;; FIXME: Make a nxref once we update CLSS submodule.
       (:li (:code"clss:ordered-select") " is the same as "
-           (:nxref :function t clss:select)
+           (:nxref :function 'clss:select)
            ", except it guarantees that all the elements are returned in a depth-first
 traversal order.")
-      (:li (:nxref :function t nyxt/dom:click-element)
+      (:li (:nxref :function 'nyxt/dom:click-element)
            " to programmatically click a certain element (including the ones returned by "
-           (:nxref :function t clss:select) ".)")
-      (:li (:nxref :function t nyxt/dom:focus-select-element) " to focus an input field, for example.")
-      (:li (:nxref :function t nyxt/dom:check-element) " to check a checkbox or a radio button.")
-      (:li (:nxref :function t nyxt/dom:select-option-element) " to select an option from the "
+           (:nxref :function 'clss:select) ".)")
+      (:li (:nxref :function 'nyxt/dom:focus-select-element) " to focus an input field, for example.")
+      (:li (:nxref :function 'nyxt/dom:check-element) " to check a checkbox or a radio button.")
+      (:li (:nxref :function 'nyxt/dom:select-option-element) " to select an option from the "
            (:code "<select>") " element options.")))
     (:p "Additionally, headless mode interacts in useful way with other CLI toggles the Nyxt has:")
     (:ul
@@ -506,7 +506,7 @@ to. Useful to start several instances of Nyxt and do your thing in parallel.")
 
     (:h2 "Extensions")
     (:p "To install an extension, copy inside the "
-        (:nxref :variable t *extensions-directory*) " (default to "
+        (:nxref :variable '*extensions-directory*) " (default to "
         (:code "~/.local/share/nyxt/extensions")").")
     (:p "Extensions are regular Common Lisp systems.")
     (:p "A catalogue of extensions is available in the "

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -482,7 +482,7 @@ hooks. Things you'd most probably want to put there are: ")
      (:ul
       (:li "The " (:nxref :function 'document-model)
            " method has a reasonably fresh copy of the page DOM (Document Object Model,
-reflects the dynamic structure of the page). It is a " (:nxref :package 'plump "Plump")
+reflecting the dynamic structure of the page). It is a " (:nxref :package 'plump "Plump")
 " DOM, which means that all " (:nxref :package 'plump "Plump") " (and "
 (:nxref :package 'clss "CLSS") ") functions can be used on it.")
       (:li (:nxref :function 'update-document-model)

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -504,13 +504,12 @@ current " (:nxref :function 'document-model) " too outdated.")
       (:li (:nxref :function 'nyxt/dom:check-element) " to check a checkbox or a radio button.")
       (:li (:nxref :function 'nyxt/dom:select-option-element) " to select an option from the "
            (:code "<select>") " element options.")))
-    (:p "Additionally, headless mode interacts in useful way with other CLI toggles the Nyxt has:")
+    (:p "Additionally, headless mode gracefully interacts with other CLI toggles the
+Nyxt has:")
     (:ul
-     (:li (:code "--headless") " itself. If you provide it, Nyxt runs headless. If you don't provide "
-          (:code "--headless")
-          ", then Nyxt starts as usual and allows you to see the changes that happen to
-the page because of your script. A good way to debug and check script behavior,
-isn't it?")
+     (:li (:code "--headless") " itself! Notice that you can debug your script
+by omitting this CLI flag.  When you're confident enough about it, put it back
+in. A good debugging tip, isn't it?")
      (:li (:code "--no-socket")
           " flag allows starting as many Nyxt instances as your machine can
 handle. Useful to parallelize computations.")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -385,6 +385,98 @@ instance must be non-nil.")
 `foo' function:")
     (:pre (:code "nyxt --profile nosave --remote --load foo.lisp --eval '(foo)'"))
 
+    (:h3 "Headless mode")
+    (:p "Much like with scripting functionality, you can use Nyxt in headless (=
+    with no graphical interface appearing) mode. Possible use-cases for this
+    mode are web scraping, repetitive actions automation, and web page
+    analysis.")
+    (:p "Enabling the headless mode is easy: just start Nyxt with --headless CLI
+    flag and provide a script file as a configuration file:")
+    (:pre (:code "nyxt --headless --config /path/to/your/headless-config.lisp"))
+    (:p "Note that you pass it a " (:i "configuration file") "—headless mode is
+    only different from the regular Nyxt functions in that it has no GUI, and is
+    all the same otherwise, contrary to all the seeming similarities to
+    the " (:code "--script") " flag usage.")
+    (:p "An example of headless configuration file could be this small snippet
+    showcasing most headless mode idioms:")
+    (:pre (:code "#!/bin/sh
+#|
+exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
+|#
+
+;; TODO!!!"))
+    (:p "The thing to put into the headless-config.lisp is a set of
+    configuration forms to make Nyxt automatically perform some actions to the
+    pages opened and/or on certain events. Things you'd most probably want to
+    put there are: ")
+    (:ul
+     (:li "Hook bindings, using the " (:nxref :package t nhooks) " library and hooks
+     provided by Nyxt, with notable mentions being:")
+     (:ul
+      (:li (:nxref :slot-of network-buffer buffer-load-hook) " for when there's a new page loading in the buffer.")
+      (:li (:nxref :slot-of network-buffer buffer-loaded-hook) " for when this page is mostly done
+      loading (some scripts/image/styles may not be fully loaded yet, so you may
+      need to wait a bit after it fires.)")
+      (:li (:nxref :slot-of network-buffer request-resource-hook) " for when a new request
+      happens. Allows redirecting and blocking requests, and is a good place to
+      do something conditioned on the links being loaded.")
+      (:li (:nxref :variable t *after-startup-hook*) " is the best place to start
+      instrumenting Nyxt, as this hook fires when Nyxt is ready for
+      interaction.")
+      (:li (:nxref :slot-of prompt-buffer prompt-buffer-ready-hook) " fires when the prompt buffer is
+      ready for user input. You may need to
+      call " (:nxref :function t prompter:all-ready-p) " on the prompt to ensure all the
+      sources it contains are ready too, and then you can safely set new inputs
+      and select the necessary suggestions.")
+      (:li (:nxref :function t nhooks:add-hook) " (also known
+      as " (:code "hooks:add-hook") ") allows you to add a handler to a hook,
+      for it to be invoked when the hook fires.")
+      (:li (:code "nhooks:on") " (also available
+      as " (:code "hooks:on") ") as a shorthand for the " (:code "nhooks:add-hook") ".")
+      (:li (:nxref :function t nhooks:remove-hook) " (also available
+      as " (:code "hooks:remove-hook") ") that removes the handler from a
+      certain hook.")
+      (:li (:code "hnooks:once-on") " (also available
+      as " (:code "hooks:once-on") ") as a one-shot version
+      of " (:code "nhooks:on") " that removes the handler right after it's
+      completed."))
+     (:li "Operations with the page. For those, we have a whole "
+          (:nxref :package t nyxt/dom) " library and " (:nxref :function t document-model)
+          "buffer slot.")
+     (:ul
+      (:li (:nxref :function t document-model) " method of " (:nxref :class t buffer) " has a
+      reasonably fresh copy of the page DOM (Document Object Model, reflects the
+      dynamic structure of the page). It is a Plump DOM, which means that all
+      Plump (and CLSS) functions can be used on it.")
+      (:li (:nxref :function t update-document-model) " is a function to force DOM
+      re-parsing for the cases when you consider the
+      current " (:nxref :function t document-model) " too outdated.")
+      (:li (:nxref :function t clss:select) " is a CLSS function to find elements using CSS
+      selectors (a terse notation for web page element description).")
+      ;; FIXME: Make a nxref once we update CLSS submodule.
+      (:li (:code"clss:ordered-select") " is the same
+      as " (:nxref :function t clss:select) ", except it guarantees that all the elements
+      are returned in a depth-first traversal order.")
+      (:li (:nxref :function t nyxt/dom:click-element) " to programmatically click a
+      certain element (including the ones returned
+      by " (:nxref :function t clss:select) ".)")
+      (:li (:nxref :function t nyxt/dom:focus-select-element) " to focus an input field, for example.")
+      (:li (:nxref :function t nyxt/dom:check-element) " to check a checkbox or a radio button.")
+      (:li (:nxref :function t nyxt/dom:select-option-element) " to select an option from the "
+           (:code "<select>") " element options.")))
+    (:p "Additionally, headless mode interacts in useful way with other CLI
+    toggles the Nyxt has:")
+    (:ul
+     (:li (:code "--headless") " itself. If you provide it, Nyxt runs
+     headless. If you don't provide " (:code "--headless") ", then Nyxt starts
+     as usual and allows you to see the changes that happen to the page because
+     of your script. A good way to debug and check script behavior, isn't it?")
+     (:li (:code "--no-socket") " flag allows starting as much Nyxt instances as
+     your computer allows you to. Useful to start several instances of Nyxt and
+     do your thing in parallel.")
+     (:li (:code "--profile nosave") " to not pollute your history and cache
+     with the script-accessed pages."))
+
     (:h2 "Extensions")
     (:p "To install an extension, copy inside the "
         (:nxref :variable t *extensions-directory*) " (default to "

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -421,8 +421,8 @@ instance must be non-nil.")
     (:pre (:code "nyxt --profile nosave --remote --load foo.lisp --eval '(foo)'"))
 
     (:h3 "Headless mode")
-    (:p "Much like a scripting functionality, you can use Nyxt in headless (without
-graphical interface) mode. Possible use-cases for this mode are web scraping,
+    (:p "Similarly to Nyxt's scripting functionality, headless mode runs without a
+graphical user interface. Possible use-cases for this mode are web scraping,
 automations and web page analysis.")
     (:p "To enable headless mode, simply start Nyxt with the "
         (:code "--headless")
@@ -432,8 +432,8 @@ automations and web page analysis.")
         "—headless mode is only different from the regular Nyxt functions in that it has
 no GUI, and is all the same otherwise, contrary to all the seeming similarities
 to the " (:code "--script") " flag usage.")
-    (:p "An example of headless configuration file could be this small snippet
-showcasing most headless mode idioms:")
+    (:p "The example below showcases frequent idioms that are found in the
+mode's configuration file:")
     (:pre (:code "#!/bin/sh
 #|
 exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
@@ -511,8 +511,8 @@ traversal order.")
 the page because of your script. A good way to debug and check script behavior,
 isn't it?")
      (:li (:code "--no-socket")
-          " flag allows starting as many Nyxt instances as your computer allows you
-to. Useful to start several instances of Nyxt and do your thing in parallel.")
+          " flag allows starting as many Nyxt instances as your machine can
+handle. Useful to parallelize computations.")
      (:li (:code "--profile nosave")
           " to not pollute your history and cache with the script-accessed pages."))
 

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -477,9 +477,8 @@ on certain hooks. Things you'd most probably want to put there are: ")
     (:ul
      (:li "Hook bindings, using the " (:nxref :package 'nhooks)
           " library and hooks provided by Nyxt.")
-     (:li "Operations with the page. For those, we have a whole "
-          (:nxref :package 'nyxt/dom) " library and the " (:nxref :function 'document-model)
-          "method.")
+     (:li "Operations on the page. Check the " (:nxref :package 'nyxt/dom) "
+          library and the " (:nxref :function 'document-model) "method.")
      (:ul
       (:li "The " (:nxref :function 'document-model)
            " method has a reasonably fresh copy of the page DOM (Document Object Model,

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -386,19 +386,19 @@ instance must be non-nil.")
     (:pre (:code "nyxt --profile nosave --remote --load foo.lisp --eval '(foo)'"))
 
     (:h3 "Headless mode")
-    (:p "Much like with scripting functionality, you can use Nyxt without a
-    graphical interface (GUI). Possible use-cases for this mode are web
-    scraping, automations and web page analysis.")
-    (:p "To enable headless mode, simply start Nyxt with
-    the " (:code "--headless") " CLI flag and provide a script file to serve as
-    the configuration file:")
+    (:p "Much like with scripting functionality, you can use Nyxt in headless (without
+graphical interface) mode. Possible use-cases for this mode are web scraping,
+automations and web page analysis.")
+    (:p "To enable headless mode, simply start Nyxt with the "
+        (:code "--headless")
+        " CLI flag and provide a script file to serve as the configuration file:")
     (:pre (:code "nyxt --headless --config /path/to/your/headless-config.lisp"))
-    (:p "Note that you pass it a " (:i "configuration file") "—headless mode is only
-    different from the regular Nyxt functions in that it has no GUI, and is all
-    the same otherwise, contrary to all the seeming similarities to
-    the " (:code "--script") " flag usage.")
+    (:p "Note that you pass it a " (:i "configuration file")
+        "—headless mode is only different from the regular Nyxt functions in that it has
+no GUI, and is all the same otherwise, contrary to all the seeming similarities
+to the " (:code "--script") " flag usage.")
     (:p "An example of headless configuration file could be this small snippet
-    showcasing most headless mode idioms:")
+showcasing most headless mode idioms:")
     (:pre (:code "#!/bin/sh
 #|
 exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
@@ -436,77 +436,73 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
     ;; use nyxt --no-socket, you don't have to. Just be ready for some
     ;; RAM eating :)
     (nyxt:quit)))"))
-    (:p "The thing to put into the headless-config.lisp is a set of
-    configuration forms to make Nyxt perform some actions to the opened pages
-    and/or on certain events. Things you'd most probably want to put there
-    are: ")
+    (:p "The thing to put into the headless-config.lisp is a set of configuration forms
+to make Nyxt perform some actions to the opened pages and/or on certain
+events. Things you'd most probably want to put there are: ")
     (:ul
-     (:li "Hook bindings, using the " (:nxref :package t nhooks) " library and hooks
-     provided by Nyxt, with notable mentions being:")
+     (:li "Hook bindings, using the " (:nxref :package t nhooks)
+          " library and hooks provided by Nyxt, with notable mentions being:")
      (:ul
       (:li (:nxref :slot-of network-buffer buffer-load-hook) " for when there's a new page loading in the buffer.")
-      (:li (:nxref :slot-of network-buffer buffer-loaded-hook) " for when this page is mostly done
-      loading (some scripts/image/styles may not be fully loaded yet, so you may
-      need to wait a bit after it fires.)")
-      (:li (:nxref :slot-of network-buffer request-resource-hook) " for when a new request
-      happens. Allows redirecting and blocking requests, and is a good place to
-      do something conditioned on the links being loaded.")
-      (:li (:nxref :variable t *after-startup-hook*) " is the best place to start
-      instrumenting Nyxt, as this hook fires when Nyxt is ready for
-      interaction.")
-      (:li (:nxref :slot-of prompt-buffer prompt-buffer-ready-hook) " fires when the prompt buffer is
-      ready for user input. You may need to
-      call " (:nxref :function t prompter:all-ready-p) " on the prompt to ensure all the
-      sources it contains are ready too, and then you can safely set new inputs
-      and select the necessary suggestions.")
-      (:li (:nxref :function t nhooks:add-hook) " (also known
-      as " (:code "hooks:add-hook") ") allows you to add a handler to a hook,
-      for it to be invoked when the hook fires.")
-      (:li (:code "nhooks:on") " (also available
-      as " (:code "hooks:on") ") as a shorthand for the " (:code "nhooks:add-hook") ".")
-      (:li (:nxref :function t nhooks:remove-hook) " (also available
-      as " (:code "hooks:remove-hook") ") that removes the handler from a
-      certain hook.")
-      (:li (:code "hnooks:once-on") " (also available
-      as " (:code "hooks:once-on") ") as a one-shot version
-      of " (:code "nhooks:on") " that removes the handler right after it's
-      completed."))
+      (:li (:nxref :slot-of network-buffer buffer-loaded-hook)
+           " for when this page is mostly done loading (some scripts/image/styles may not
+be fully loaded yet, so you may need to wait a bit after it fires.)")
+      (:li (:nxref :slot-of network-buffer request-resource-hook)
+           " for when a new request happens. Allows redirecting and blocking requests, and
+is a good place to do something conditioned on the links being loaded.")
+      (:li (:nxref :variable t *after-startup-hook*)
+           " is the best place to start instrumenting Nyxt, as this hook fires when Nyxt is
+ready for interaction.")
+      (:li (:nxref :slot-of prompt-buffer prompt-buffer-ready-hook)
+           " fires when the prompt buffer is ready for user input. You may need to call "
+           (:nxref :function t prompter:all-ready-p)
+           " on the prompt to ensure all the sources it contains are ready too, and then
+you can safely set new inputs and select the necessary suggestions.")
+      (:li (:nxref :function t nhooks:add-hook) " (also known as "
+           (:code "hooks:add-hook")
+           ") allows you to add a handler to a hook,for it to be invoked when the hook fires.")
+      (:li (:code "nhooks:on") " (also available as " (:code "hooks:on")
+           ") as a shorthand for the " (:code "nhooks:add-hook") ".")
+      (:li (:nxref :function t nhooks:remove-hook) " (also available as "
+           (:code "hooks:remove-hook") ") that removes the handler from a certain hook.")
+      (:li (:code "hnooks:once-on") " (also available as " (:code "hooks:once-on")
+           ") as a one-shot version of " (:code "nhooks:on")
+           " that removes the handler right after it's completed."))
      (:li "Operations with the page. For those, we have a whole "
           (:nxref :package t nyxt/dom) " library and " (:nxref :function t document-model)
           "buffer slot.")
      (:ul
-      (:li (:nxref :function t document-model) " method of " (:nxref :class t buffer) " has a
-      reasonably fresh copy of the page DOM (Document Object Model, reflects the
-      dynamic structure of the page). It is a Plump DOM, which means that all
-      Plump (and CLSS) functions can be used on it.")
-      (:li (:nxref :function t update-document-model) " is a function to force DOM
-      re-parsing for the cases when you consider the
-      current " (:nxref :function t document-model) " too outdated.")
-      (:li (:nxref :function t clss:select) " is a CLSS function to find elements using CSS
-      selectors (a terse notation for web page element description).")
+      (:li (:nxref :function t document-model) " method of " (:nxref :class t buffer)
+           " has a reasonably fresh copy of the page DOM (Document Object Model, reflects
+the dynamic structure of the page). It is a Plump DOM, which means that all
+Plump (and CLSS) functions can be used on it.")
+      (:li (:nxref :function t update-document-model)
+           " is a function to force DOM re-parsing for the cases when you consider the
+current " (:nxref :function t document-model) " too outdated.")
+      (:li (:nxref :function t clss:select)
+           " is a CLSS function to find elements using CSS selectors (a terse notation for web page element description).")
       ;; FIXME: Make a nxref once we update CLSS submodule.
-      (:li (:code"clss:ordered-select") " is the same
-      as " (:nxref :function t clss:select) ", except it guarantees that all the elements
-      are returned in a depth-first traversal order.")
-      (:li (:nxref :function t nyxt/dom:click-element) " to programmatically click a
-      certain element (including the ones returned
-      by " (:nxref :function t clss:select) ".)")
+      (:li (:code"clss:ordered-select") " is the same as "
+           (:nxref :function t clss:select)
+           ", except it guarantees that all the elements are returned in a depth-first
+traversal order.")
+      (:li (:nxref :function t nyxt/dom:click-element)
+           " to programmatically click a certain element (including the ones returned by "
+           (:nxref :function t clss:select) ".)")
       (:li (:nxref :function t nyxt/dom:focus-select-element) " to focus an input field, for example.")
       (:li (:nxref :function t nyxt/dom:check-element) " to check a checkbox or a radio button.")
       (:li (:nxref :function t nyxt/dom:select-option-element) " to select an option from the "
            (:code "<select>") " element options.")))
-    (:p "Additionally, headless mode interacts in useful way with other CLI
-    toggles the Nyxt has:")
+    (:p "Additionally, headless mode interacts in useful way with other CLI toggles the Nyxt has:")
     (:ul
-     (:li (:code "--headless") " itself. If you provide it, Nyxt runs
-     headless. If you don't provide " (:code "--headless") ", then Nyxt starts
-     as usual and allows you to see the changes that happen to the page because
-     of your script. A good way to debug and check script behavior, isn't it?")
-     (:li (:code "--no-socket") " flag allows starting as much Nyxt instances as
-     your computer allows you to. Useful to start several instances of Nyxt and
-     do your thing in parallel.")
-     (:li (:code "--profile nosave") " to not pollute your history and cache
-     with the script-accessed pages."))
+     (:li (:code "--headless") " itself. If you provide it, Nyxt runs headless. If you don't provide "
+          (:code "--headless")
+          ", then Nyxt starts as usual and allows you to see the changes that happen to
+the page because of your script. A good way to debug and check script behavior,
+isn't it?")
+     (:li (:code "--no-socket") " flag allows starting as much Nyxt instances as your computer allows you
+to. Useful to start several instances of Nyxt and do your thing in parallel.")
+     (:li (:code "--profile nosave") " to not pollute your history and cache with the script-accessed pages."))
 
     (:h2 "Extensions")
     (:p "To install an extension, copy inside the "

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -386,16 +386,16 @@ instance must be non-nil.")
     (:pre (:code "nyxt --profile nosave --remote --load foo.lisp --eval '(foo)'"))
 
     (:h3 "Headless mode")
-    (:p "Much like with scripting functionality, you can use Nyxt in headless (=
-    with no graphical interface appearing) mode. Possible use-cases for this
-    mode are web scraping, repetitive actions automation, and web page
-    analysis.")
-    (:p "Enabling the headless mode is easy: just start Nyxt with --headless CLI
-    flag and provide a script file as a configuration file:")
+    (:p "Much like with scripting functionality, you can use Nyxt without a
+    graphical interface (GUI). Possible use-cases for this mode are web
+    scraping, automations and web page analysis.")
+    (:p "To enable headless mode, simply start Nyxt with
+    the " (:code "--headless") " CLI flag and provide a script file to serve as
+    the configuration file:")
     (:pre (:code "nyxt --headless --config /path/to/your/headless-config.lisp"))
-    (:p "Note that you pass it a " (:i "configuration file") "—headless mode is
-    only different from the regular Nyxt functions in that it has no GUI, and is
-    all the same otherwise, contrary to all the seeming similarities to
+    (:p "Note that you pass it a " (:i "configuration file") "—headless mode is only
+    different from the regular Nyxt functions in that it has no GUI, and is all
+    the same otherwise, contrary to all the seeming similarities to
     the " (:code "--script") " flag usage.")
     (:p "An example of headless configuration file could be this small snippet
     showcasing most headless mode idioms:")
@@ -421,8 +421,8 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
     ;; resources and scripts are done loading yet. Give it some time
     ;; there.
     (sleep 0.5)
-    ;; All the Nyxt reporting is on in headless mode, you may want to
-    ;; log thing with `echo' and `echo-warning'.
+    ;; All the Nyxt reporting happens in headless mode, so you may want to log
+    ;; it with `echo' and `echo-warning'.
     (echo \"Nyxt GitHub repo open.\")
     ;; Updating the `document-model' so that it includes the most
     ;; relevant information about the page.
@@ -432,14 +432,14 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
      :nyxt-identifier
      (get-nyxt-id (elt (clss:select \"[aria-label=\\\"Star this repository\\\"]\" (document-model buffer)) 0)))
     (echo \"Clicked the star.\")
-    ;; It's a good tone to `nyxt:quit' after you're done, but if you
+    ;; It's good tone to `nyxt:quit' after you're done, but if you
     ;; use nyxt --no-socket, you don't have to. Just be ready for some
     ;; RAM eating :)
     (nyxt:quit)))"))
     (:p "The thing to put into the headless-config.lisp is a set of
-    configuration forms to make Nyxt automatically perform some actions to the
-    pages opened and/or on certain events. Things you'd most probably want to
-    put there are: ")
+    configuration forms to make Nyxt perform some actions to the opened pages
+    and/or on certain events. Things you'd most probably want to put there
+    are: ")
     (:ul
      (:li "Hook bindings, using the " (:nxref :package t nhooks) " library and hooks
      provided by Nyxt, with notable mentions being:")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -69,7 +69,7 @@ run " (command-markup 'describe-command) " and type 'mode'.")
     (:p "Slots store values that can be either accessed (get) or changed
 (set). Setting new values for slots allows many possibilities of customization.
 For instance, keyboard layouts vary across the world. The slot "
-        (:nxref :slot-of 'nyxt/hint-mode:hint-mode 'nyxt/hint-mode:hints-alphabet)
+        (:nxref :slot 'nyxt/hint-mode:hints-alphabet :class 'nyxt/hint-mode:hint-mode)
         " has the default value of "
         (:code "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         ". If the user has an American keyboard, they can do:")
@@ -81,7 +81,7 @@ For instance, keyboard layouts vary across the world. The slot "
      (:li "Insert the string \"asfdghjkl\"") ".")
     (:p "This will make link-hinting more comfortable for this user. In
 addition, other similar approaches of customization can be applied to slots
-such as " (:nxref :slot-of 'nyxt/spell-check-mode:spell-check-mode 'nyxt/spell-check-mode:spell-check-language)
+such as " (:nxref :slot 'nyxt/spell-check-mode:spell-check-language :class 'nyxt/spell-check-mode:spell-check-mode)
 ", which can be expanded to do the spelling-check of other languages besides English.")
     (:h3 "Different types of buffers")
     (:p "There are multiple buffer classes, such as "
@@ -94,7 +94,7 @@ For instance " (:nxref :class 'web-buffer) " and " (:nxref :class 'prompt-buffer
     (:p "You can configure one of the parent " (:nxref :class 'buffer) " classes slots and the new
 values will automatically cascade down as a new default for all child classes-
 unless this slot is specialized by these child classes.
-For instance if you configure the " (:nxref :slot-of 'input-buffer 'override-map)
+For instance if you configure the " (:nxref :slot 'override-map :class 'input-buffer)
 " slot in " (:nxref :class 'input-buffer) ", both " (:nxref :class 'panel-buffer) " and "
 (:nxref :class 'web-buffer) " classes will inherit from the new value.")
 
@@ -123,7 +123,7 @@ add the following to your configuration:")
       keyscheme:vi-normal
       (list \"g b\" (make-command switch-buffer* ()
                     (switch-buffer :current-is-last-p t)))))))"))
-    (:p "The " (:nxref :slot-of 'input-buffer 'override-map) " is a keymap that has priority over
+    (:p "The " (:nxref :slot 'override-map :class 'input-buffer) " is a keymap that has priority over
 all other keymaps.  By default, it has few bindings like the one
 for " (command-markup 'execute-command) ".  You can use it to set keys globally:")
     (:pre (:code "(define-configuration buffer
@@ -165,7 +165,7 @@ shifts.  For instance if " (:code "C-x C-F") " fails to match anything " (:code 
          translation.")
 
     (:h3 "Search engines")
-    (:p "See the " (:nxref :slot-of 'context-buffer 'search-engines) " buffer slot
+    (:p "See the " (:nxref :slot 'search-engines :class 'context-buffer) " buffer slot
 documentation.  Bookmarks can also be used as search engines, see the
 corresponding section.")
     (:p "Nyxt comes with some default search engines for "
@@ -207,7 +207,7 @@ documentation.")
 
     (:h3 "Downloads")
     (:p "See the " (command-markup 'nyxt/download-mode:list-downloads) " command and the "
-        (:nxref :slot-of 'buffer 'download-path) " buffer slot documentation.")
+        (:nxref :slot 'download-path :class 'buffer) " buffer slot documentation.")
 
     (:h3 "Proxy and Tor")
     (:p "See the " (:nxref :class 'nyxt/proxy-mode:proxy-mode) " documentation.")
@@ -241,14 +241,14 @@ events that occur in the context of windows, buffers, modes, etc.")
 typed functions.  Each hook has a dedicated handler constructor.")
     (:p
      "Hooks can be 'run', that is, their handlers are run according to
-the " (:nxref :slot-of 'nhooks:hook 'nhooks:combination) " slot of the hook.  This combination is a function
+the " (:nxref :slot 'nhooks:combination :class 'nhooks:hook) " slot of the hook.  This combination is a function
 of the handlers.  Depending on the combination, a hook can run the handlers
 either in parallel, or in order until one fails, or even " (:i "compose")
      " them (pass the result of one as the input of the next).  The handler types
 specify which input and output values are expected.")
     (:p "To add or delete a hook, you only need to know a couple of functions:"
         (:ul
-         (:li (:xnref :class 'nhooks:handler) " a class to wrap hook handlers in.")
+         (:li (:nxref :class 'nhooks:handler) " a class to wrap hook handlers in.")
          (:li (:nxref :function 'nhooks:add-hook) " (also known as "
               (:code "hooks:add-hook")
               ") allows you to add a handler to a hook,for it to be invoked when the hook fires.")
@@ -265,19 +265,19 @@ specify which input and output values are expected.")
           " or " (:nxref :variable '*after-startup-hook*) ".")
      (:li "Window- or buffer-related hooks.")
      (:ul
-      (:li (:nxref :slot-of 'window 'window-make-hook) " for when a new window is created.")
-      (:li (:nxref :slot-of 'window 'window-delete-hook) " for when a window is deleted.")
-      (:li (:nxref :slot-of 'window 'window-set-buffer-hook)
+      (:li (:nxref :slot 'window-make-hook :class 'window) " for when a new window is created.")
+      (:li (:nxref :slot 'window-delete-hook :class 'window) " for when a window is deleted.")
+      (:li (:nxref :slot 'window-set-buffer-hook :class 'window)
            " for when the " (:nxref :function 'current-buffer) " changes in the window.")
-      (:li (:nxref :slot-of 'network-buffer 'buffer-load-hook)
+      (:li (:nxref :slot 'buffer-load-hook :class 'network-buffer)
            " for when there's a new page loading in the buffer.")
-      (:li (:nxref :slot-of 'network-buffer 'buffer-loaded-hook)
+      (:li (:nxref :slot 'buffer-loaded-hook :class 'network-buffer)
            " for when this page is mostly done loading (some scripts/image/styles may not
 be fully loaded yet, so you may need to wait a bit after it fires.)")
-      (:li (:nxref :slot-of 'network-buffer 'request-resource-hook)
+      (:li (:nxref :slot 'request-resource-hook :class 'network-buffer)
            " for when a new request happens. Allows redirecting and blocking requests, and
 is a good place to do something conditioned on the links being loaded.")
-      (:li (:nxref :slot-of 'prompt-buffer 'prompt-buffer-ready-hook)
+      (:li (:nxref :slot 'prompt-buffer-ready-hook :class 'prompt-buffer)
            " fires when the prompt buffer is ready for user input. You may need to call "
            (:nxref :function 'prompter:all-ready-p)
            " on the prompt to ensure all the sources it contains are ready too, and then
@@ -379,7 +379,7 @@ the " (:code "define-configuration") " macro.")
     (:h3 "Appearance")
     (:p "Much of the visual style can be configured by the user.  Search the
 class slots for 'style'.  To customize the status buffer, see
-the " (:nxref :slot-of 'window 'status-buffer) " window slot.")
+the " (:nxref :slot 'status-buffer :class 'window) " window slot.")
 
     (:h3 "Advanced configuration")
     (:p "While " (:code "define-configuration") " is convenient, it is mostly

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -451,29 +451,27 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
 \(hooks:on *after-startup-hook* ()
   ;; Once the page's done loading, do your thing.
   (once-on (buffer-loaded-hook (current-buffer)) (buffer)
-    ;; It's sometimes necessary to sleep, as `buffer-loaded-hook'
-    ;; fires when the page is loaded, which does not mean that all the
-    ;; resources and scripts are done loading yet. Give it some time
-    ;; there.
+    ;; It's sometimes necessary to sleep, as `buffer-loaded-hook' fires when the
+    ;; page is loaded, which does not mean that all the resources and scripts
+    ;; are done loading yet. Give it some time there.
     (sleep 0.5)
     ;; All the Nyxt reporting happens in headless mode, so you may want to log
     ;; it with `echo' and `echo-warning'.
     (echo \"Nyxt GitHub repo open.\")
-    ;; Updating the `document-model' so that it includes the most
-    ;; relevant information about the page.
+    ;; Updating the `document-model' so that it includes the most relevant
+    ;; information about the page.
     (nyxt:update-document-model)
     ;; Click the star button.
     (nyxt/dom:click-element
      :nyxt-identifier
      (get-nyxt-id (elt (clss:select \"[aria-label=\\\"Star this repository\\\"]\" (document-model buffer)) 0)))
     (echo \"Clicked the star.\")
-    ;; It's good tone to `nyxt:quit' after you're done, but if you
-    ;; use nyxt --no-socket, you don't have to. Just be ready for some
-    ;; RAM eating :)
+    ;; It's good tone to `nyxt:quit' after you're done, but if you use nyxt
+    ;; --no-socket, you don't have to. Just be ready for some RAM eating :)
     (nyxt:quit)))"))
-    (:p "The thing to put into the headless-config.lisp is a set of configuration forms
-to make Nyxt perform some actions to the opened pages and/or on certain
-hooks. Things you'd most probably want to put there are: ")
+    (:p "The thing to put into the headless-config.lisp is a set of
+configuration forms to make Nyxt perform some actions to the opened pages and/or
+on certain hooks. Things you'd most probably want to put there are: ")
     (:ul
      (:li "Hook bindings, using the " (:nxref :package 'nhooks)
           " library and hooks provided by Nyxt.")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -471,9 +471,9 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
     ;; It's good tone to `nyxt:quit' after you're done, but if you use nyxt
     ;; --no-socket, you don't have to. Just be ready for some RAM eating :)
     (nyxt:quit)))"))
-    (:p "The thing to put into the headless-config.lisp is a set of
-configuration forms to make Nyxt perform some actions to the opened pages and/or
-on certain hooks. Things you'd most probably want to put there are: ")
+    (:p "The contents of headless-config.lisp feature configuration forms that
+make Nyxt perform some actions to the opened pages and/or on certain
+hooks. Things you'd most probably want to put there are: ")
     (:ul
      (:li "Hook bindings, using the " (:nxref :package 'nhooks)
           " library and hooks provided by Nyxt.")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -69,7 +69,7 @@ run " (command-markup 'describe-command) " and type 'mode'.")
     (:p "Slots store values that can be either accessed (get) or changed
 (set). Setting new values for slots allows many possibilities of customization.
 For instance, keyboard layouts vary across the world. The slot "
-        (:nxref :slot 'nyxt/hint-mode:hints-alphabet :class 'nyxt/hint-mode:hint-mode)
+        (:nxref :slot 'nyxt/hint-mode:hints-alphabet :class-name 'nyxt/hint-mode:hint-mode)
         " has the default value of "
         (:code "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         ". If the user has an American keyboard, they can do:")
@@ -81,28 +81,28 @@ For instance, keyboard layouts vary across the world. The slot "
      (:li "Insert the string \"asfdghjkl\"") ".")
     (:p "This will make link-hinting more comfortable for this user. In
 addition, other similar approaches of customization can be applied to slots
-such as " (:nxref :slot 'nyxt/spell-check-mode:spell-check-language :class 'nyxt/spell-check-mode:spell-check-mode)
+such as " (:nxref :slot 'nyxt/spell-check-mode:spell-check-language :class-name 'nyxt/spell-check-mode:spell-check-mode)
 ", which can be expanded to do the spelling-check of other languages besides English.")
     (:h3 "Different types of buffers")
     (:p "There are multiple buffer classes, such as "
-        (:nxref :class 'document-buffer) " (for structured documents) and "
-        (:nxref :class 'input-buffer) " (for buffers that can receive user input).  A "
-        (:nxref :class 'web-buffer) " class is used for web pages," (:nxref :class 'prompt-buffer)
+        (:nxref :class-name 'document-buffer) " (for structured documents) and "
+        (:nxref :class-name 'input-buffer) " (for buffers that can receive user input).  A "
+        (:nxref :class-name 'web-buffer) " class is used for web pages," (:nxref :class-name 'prompt-buffer)
         " for, well,the prompt buffer.  Some buffer classes may inherit from multiple other classes.
-For instance " (:nxref :class 'web-buffer) " and " (:nxref :class 'prompt-buffer)
-        " both inherit from" (:nxref :class 'input-buffer) ".")
-    (:p "You can configure one of the parent " (:nxref :class 'buffer) " classes slots and the new
+For instance " (:nxref :class-name 'web-buffer) " and " (:nxref :class-name 'prompt-buffer)
+        " both inherit from" (:nxref :class-name 'input-buffer) ".")
+    (:p "You can configure one of the parent " (:nxref :class-name 'buffer) " classes slots and the new
 values will automatically cascade down as a new default for all child classes-
 unless this slot is specialized by these child classes.
-For instance if you configure the " (:nxref :slot 'override-map :class 'input-buffer)
-" slot in " (:nxref :class 'input-buffer) ", both " (:nxref :class 'panel-buffer) " and "
-(:nxref :class 'web-buffer) " classes will inherit from the new value.")
+For instance if you configure the " (:nxref :slot 'override-map :class-name 'input-buffer)
+" slot in " (:nxref :class-name 'input-buffer) ", both " (:nxref :class-name 'panel-buffer) " and "
+(:nxref :class-name 'web-buffer) " classes will inherit from the new value.")
 
     (:h3 "Keybinding configuration")
     (:p "Nyxt supports multiple " (:i "bindings schemes") " such as CUA (the
     default), Emacs or vi.  Changing scheme is as simple as setting the
     corresponding mode as default, e.g. "
-        (:nxref :class 'nyxt/emacs-mode:emacs-mode) ".  To make the change persistent across sessions,
+        (:nxref :class-name 'nyxt/emacs-mode:emacs-mode) ".  To make the change persistent across sessions,
 add the following to your configuration:")
     (:ul
      (:li "vi bindings:"
@@ -123,7 +123,7 @@ add the following to your configuration:")
       keyscheme:vi-normal
       (list \"g b\" (make-command switch-buffer* ()
                     (switch-buffer :current-is-last-p t)))))))"))
-    (:p "The " (:nxref :slot 'override-map :class 'input-buffer) " is a keymap that has priority over
+    (:p "The " (:nxref :slot 'override-map :class-name 'input-buffer) " is a keymap that has priority over
 all other keymaps.  By default, it has few bindings like the one
 for " (command-markup 'execute-command) ".  You can use it to set keys globally:")
     (:pre (:code "(define-configuration buffer
@@ -165,7 +165,7 @@ shifts.  For instance if " (:code "C-x C-F") " fails to match anything " (:code 
          translation.")
 
     (:h3 "Search engines")
-    (:p "See the " (:nxref :slot 'search-engines :class 'context-buffer) " buffer slot
+    (:p "See the " (:nxref :slot 'search-engines :class-name 'context-buffer) " buffer slot
 documentation.  Bookmarks can also be used as search engines, see the
 corresponding section.")
     (:p "Nyxt comes with some default search engines for "
@@ -207,17 +207,17 @@ documentation.")
 
     (:h3 "Downloads")
     (:p "See the " (command-markup 'nyxt/download-mode:list-downloads) " command and the "
-        (:nxref :slot 'download-path :class 'buffer) " buffer slot documentation.")
+        (:nxref :slot 'download-path :class-name 'buffer) " buffer slot documentation.")
 
     (:h3 "Proxy and Tor")
-    (:p "See the " (:nxref :class 'nyxt/proxy-mode:proxy-mode) " documentation.")
+    (:p "See the " (:nxref :class-name 'nyxt/proxy-mode:proxy-mode) " documentation.")
 
     (:h3 "Blocker mode")
     (:p "This mode blocks access to websites related to especific hosts. To see
 all hosts being blocked, execute command " (:code "describe-variable") ", choose variable "
 (:code "NYXT/BLOCKER-MODE:*DEFAULT-HOSTLIST*") ", and read data on "
 (:code "nyxt/blocker-mode:url-body") " slot." " To customize host blocking, read the "
-(:nxref :class 'nyxt/blocker-mode:blocker-mode) " documentation.")
+(:nxref :class-name 'nyxt/blocker-mode:blocker-mode) " documentation.")
 
     (:h3 "Custom commands")
     (:p "Creating your own invocable commands is similar to creating a Common
@@ -231,7 +231,7 @@ Lisp function, except the form is " (:code "define-command") " instead of "
               :prompt \"Bookmark URL\"
               :sources (make-instance 'prompter:raw-source))))
     (bookmark-add url)))"))
-    (:p "See the " (:nxref :class 'prompt-buffer) " class documentation for how
+    (:p "See the " (:nxref :class-name 'prompt-buffer) " class documentation for how
 to write custom prompt-buffers.")
 
     (:h3 "Hooks")
@@ -241,14 +241,14 @@ events that occur in the context of windows, buffers, modes, etc.")
 typed functions.  Each hook has a dedicated handler constructor.")
     (:p
      "Hooks can be 'run', that is, their handlers are run according to
-the " (:nxref :slot 'nhooks:combination :class 'nhooks:hook) " slot of the hook.  This combination is a function
+the " (:nxref :slot 'nhooks:combination :class-name 'nhooks:hook) " slot of the hook.  This combination is a function
 of the handlers.  Depending on the combination, a hook can run the handlers
 either in parallel, or in order until one fails, or even " (:i "compose")
      " them (pass the result of one as the input of the next).  The handler types
 specify which input and output values are expected.")
     (:p "To add or delete a hook, you only need to know a couple of functions:"
         (:ul
-         (:li (:nxref :class 'nhooks:handler) " a class to wrap hook handlers in.")
+         (:li (:nxref :class-name 'nhooks:handler) " a class to wrap hook handlers in.")
          (:li (:nxref :function 'nhooks:add-hook) " (also known as "
               (:code "hooks:add-hook")
               ") allows you to add a handler to a hook,for it to be invoked when the hook fires.")
@@ -265,19 +265,19 @@ specify which input and output values are expected.")
           " or " (:nxref :variable '*after-startup-hook*) ".")
      (:li "Window- or buffer-related hooks.")
      (:ul
-      (:li (:nxref :slot 'window-make-hook :class 'window) " for when a new window is created.")
-      (:li (:nxref :slot 'window-delete-hook :class 'window) " for when a window is deleted.")
-      (:li (:nxref :slot 'window-set-buffer-hook :class 'window)
+      (:li (:nxref :slot 'window-make-hook :class-name 'window) " for when a new window is created.")
+      (:li (:nxref :slot 'window-delete-hook :class-name 'window) " for when a window is deleted.")
+      (:li (:nxref :slot 'window-set-buffer-hook :class-name 'window)
            " for when the " (:nxref :function 'current-buffer) " changes in the window.")
-      (:li (:nxref :slot 'buffer-load-hook :class 'network-buffer)
+      (:li (:nxref :slot 'buffer-load-hook :class-name 'network-buffer)
            " for when there's a new page loading in the buffer.")
-      (:li (:nxref :slot 'buffer-loaded-hook :class 'network-buffer)
+      (:li (:nxref :slot 'buffer-loaded-hook :class-name 'network-buffer)
            " for when this page is mostly done loading (some scripts/image/styles may not
 be fully loaded yet, so you may need to wait a bit after it fires.)")
-      (:li (:nxref :slot 'request-resource-hook :class 'network-buffer)
+      (:li (:nxref :slot 'request-resource-hook :class-name 'network-buffer)
            " for when a new request happens. Allows redirecting and blocking requests, and
 is a good place to do something conditioned on the links being loaded.")
-      (:li (:nxref :slot 'prompt-buffer-ready-hook :class 'prompt-buffer)
+      (:li (:nxref :slot 'prompt-buffer-ready-hook :class-name 'prompt-buffer)
            " fires when the prompt buffer is ready for user input. You may need to call "
            (:nxref :function 'prompter:all-ready-p)
            " on the prompt to ensure all the sources it contains are ready too, and then
@@ -313,13 +313,13 @@ can set a hook like the following in your configuration file:")
             '(old-reddit-handler auto-proxy-handler)
             :initial-value %slot-default%))))"))
     (:p "Some hooks like the above example expect a return value, so it's
-important to make sure we return " (:nxref :class 'request-data) " here.  See the
+important to make sure we return " (:nxref :class-name 'request-data) " here.  See the
 documentation of the respective hooks for more details.")
 
     (:h3 "Data paths and data profiles")
     (:p "Nyxt provides a uniform configuration interface for all data files
 persisted to disk (bookmarks, cookies, etc.).  To each file corresponds
-a " (:nxref :class 'nyxt-file) " object. An " (:nxref :class 'nyxt-profile) " is a
+a " (:nxref :class-name 'nyxt-file) " object. An " (:nxref :class-name 'nyxt-profile) " is a
 customizable object that helps define general rules for data storage.  Both
 nyxt-file and nyxt-profile compose, so it's possible to define general rules
 for all files (even for those not known in advance) while it's also
@@ -379,7 +379,7 @@ the " (:code "define-configuration") " macro.")
     (:h3 "Appearance")
     (:p "Much of the visual style can be configured by the user.  Search the
 class slots for 'style'.  To customize the status buffer, see
-the " (:nxref :slot 'status-buffer :class 'window) " window slot.")
+the " (:nxref :slot 'status-buffer :class-name 'window) " window slot.")
 
     (:h3 "Advanced configuration")
     (:p "While " (:code "define-configuration") " is convenient, it is mostly
@@ -388,7 +388,7 @@ class instantiation, you'll have to specialize the
 lower-level " (:nxref :function 'customize-instance) " generic function.  Example:"
 (:pre (:code "(defmethod customize-instance ((buffer buffer) &key)
   (echo \"Buffer ~a created.\" buffer))")))
-    (:p "All classes with metaclass " (:nxref :class 'user-class) " call "
+    (:p "All classes with metaclass " (:nxref :class-name 'user-class) " call "
         (:nxref :function 'customize-instance) " on instantiation,
 after " (:nxref :function 'initialize-instance)(:code " :after") ".  The primary method is reserved
 to the user, however the " (:code ":after") " method is reserved to the Nyxt

--- a/source/migration.lisp
+++ b/source/migration.lisp
@@ -118,36 +118,36 @@ major versions."
 
 (define-migration "3"
   (download-directory)
-  (:p (:nxref :slot-of context-buffer download-directory)
-      " is in " (:nxref :class t context-buffer) ".")
+  (:p (:nxref :slot 'download-directory :class 'context-buffer)
+      " is in " (:nxref :class 'context-buffer) ".")
 
   (history-file)
-  (:p (:nxref :slot-of context-buffer history-file)
-      " is in " (:nxref :class t context-buffer) ".")
+  (:p (:nxref :slot 'history-file :class 'context-buffer)
+      " is in " (:nxref :class 'context-buffer) ".")
 
   (standard-output-file standard-error-file)
-  (:p (:nxref :slot-of context-buffer nyxt:standard-output-file) " and "
-      (:nxref :slot-of context-buffer nyxt:error-output-file)
-      " are in " (:nxref :class t context-buffer) ".")
+  (:p (:nxref :slot 'nyxt:standard-output-file :class 'context-buffer) " and "
+      (:nxref :slot 'nyxt:error-output-file :class 'context-buffer)
+      " are in " (:nxref :class 'context-buffer) ".")
 
   (annotations-file)
-  (:p (:nxref :slot-of nyxt/annotate-mode:annotate-mode nyxt/annotate-mode:annotations-file)
-      " is in " (:nxref :class t nyxt/annotate-mode:annotate-mode) ".")
+  (:p (:nxref :slot 'nyxt/annotate-mode:annotations-file :class 'nyxt/annotate-mode:annotate-mode)
+      " is in " (:nxref :class 'nyxt/annotate-mode:annotate-mode) ".")
 
   (auto-mode-rules-file)
-  (:p (:nxref :slot-of nyxt/auto-mode:auto-mode auto-mode-rules-file)
-      " is in " (:nxref :class t nyxt/auto-mode:auto-mode) ".")
+  (:p (:nxref :slot 'nyxt/auto-mode:auto-mode-rules-file :class 'nyxt/auto-mode:auto-mode)
+      " is in " (:nxref :class 'nyxt/auto-mode:auto-mode) ".")
 
   (bookmarks-file)
-  (:p (:nxref :slot-of nyxt/bookmark-mode:bookmark-mode nyxt/bookmark-mode:bookmarks-file)
-      " is in " (:nxref :class t nyxt/bookmark-mode:bookmark-mode) ".")
+  (:p (:nxref :slot 'nyxt/bookmark-mode:bookmarks-file :class 'nyxt/bookmark-mode:bookmark-mode)
+      " is in " (:nxref :class 'nyxt/bookmark-mode:bookmark-mode) ".")
 
   (expand-path)
-  (:p (:code "expand-path") " is replaced by " (:nxref :function t nfiles:expand) ".")
+  (:p (:code "expand-path") " is replaced by " (:nxref :function 'nfiles:expand) ".")
 
   (get-data get-user-data)
   (:p (:code "get-data") " and " (:code "get-user-data") " are replaced by "
-      (:nxref :function t nfiles:content) ".")
+      (:nxref :function 'nfiles:content) ".")
 
   (with-data-access with-data-unsafe)
   (:p (:code "with-data-access") " and " (:code "with-data-unsafe")

--- a/source/migration.lisp
+++ b/source/migration.lisp
@@ -118,29 +118,29 @@ major versions."
 
 (define-migration "3"
   (download-directory)
-  (:p (:nxref :slot 'download-directory :class 'context-buffer)
-      " is in " (:nxref :class 'context-buffer) ".")
+  (:p (:nxref :slot 'download-directory :class-name 'context-buffer)
+      " is in " (:nxref :class-name 'context-buffer) ".")
 
   (history-file)
-  (:p (:nxref :slot 'history-file :class 'context-buffer)
-      " is in " (:nxref :class 'context-buffer) ".")
+  (:p (:nxref :slot 'history-file :class-name 'context-buffer)
+      " is in " (:nxref :class-name 'context-buffer) ".")
 
   (standard-output-file standard-error-file)
-  (:p (:nxref :slot 'nyxt:standard-output-file :class 'context-buffer) " and "
-      (:nxref :slot 'nyxt:error-output-file :class 'context-buffer)
-      " are in " (:nxref :class 'context-buffer) ".")
+  (:p (:nxref :slot 'nyxt:standard-output-file :class-name 'context-buffer) " and "
+      (:nxref :slot 'nyxt:error-output-file :class-name 'context-buffer)
+      " are in " (:nxref :class-name 'context-buffer) ".")
 
   (annotations-file)
-  (:p (:nxref :slot 'nyxt/annotate-mode:annotations-file :class 'nyxt/annotate-mode:annotate-mode)
-      " is in " (:nxref :class 'nyxt/annotate-mode:annotate-mode) ".")
+  (:p (:nxref :slot 'nyxt/annotate-mode:annotations-file :class-name 'nyxt/annotate-mode:annotate-mode)
+      " is in " (:nxref :class-name 'nyxt/annotate-mode:annotate-mode) ".")
 
   (auto-mode-rules-file)
-  (:p (:nxref :slot 'nyxt/auto-mode:auto-mode-rules-file :class 'nyxt/auto-mode:auto-mode)
-      " is in " (:nxref :class 'nyxt/auto-mode:auto-mode) ".")
+  (:p (:nxref :slot 'nyxt/auto-mode:auto-mode-rules-file :class-name 'nyxt/auto-mode:auto-mode)
+      " is in " (:nxref :class-name 'nyxt/auto-mode:auto-mode) ".")
 
   (bookmarks-file)
-  (:p (:nxref :slot 'nyxt/bookmark-mode:bookmarks-file :class 'nyxt/bookmark-mode:bookmark-mode)
-      " is in " (:nxref :class 'nyxt/bookmark-mode:bookmark-mode) ".")
+  (:p (:nxref :slot 'nyxt/bookmark-mode:bookmarks-file :class-name 'nyxt/bookmark-mode:bookmark-mode)
+      " is in " (:nxref :class-name 'nyxt/bookmark-mode:bookmark-mode) ".")
 
   (expand-path)
   (:p (:code "expand-path") " is replaced by " (:nxref :function 'nfiles:expand) ".")

--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -46,4 +46,4 @@
                   (remf attr :package)
                   attr)
               (let ((*print-case* :downcase))
-                (format nil "~a" ,(or package variable function command class (first body)))))))
+                (format nil "~a" ,(or (first body) package variable function command class))))))

--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -15,7 +15,7 @@
 (deftag :nscript (body attrs &key &allow-other-keys)
   `(:script ,@attrs (:raw ,@body)))
 
-(spinneret:deftag :nxref (body attr &key slot class function command variable package &allow-other-keys)
+(spinneret:deftag :nxref (body attr &key slot class-name function command variable package &allow-other-keys)
   `(:a :href ,(cond
                 (package `(nyxt:nyxt-url (read-from-string "nyxt:describe-package")
                                          :universal t :package ,package))
@@ -26,9 +26,9 @@
                 (command `(nyxt:nyxt-url (read-from-string "nyxt:describe-command")
                                          :universal t :command ,command))
                 (slot `(nyxt:nyxt-url (read-from-string "nyxt:describe-slot")
-                                      :universal t :name ,slot :class ,class))
-                (class `(nyxt:nyxt-url (read-from-string "nyxt:describe-class")
-                                       :universal t :class ,class))
+                                      :universal t :name ,slot :class ,class-name))
+                (class-name `(nyxt:nyxt-url (read-from-string "nyxt:describe-class")
+                                       :universal t :class ,class-name))
                 (t `(nyxt:javascript-url
                      (ps:ps (nyxt/ps:lisp-eval
                              (:title "describe-any")
@@ -38,7 +38,7 @@
        ;; TODO: Add :title so that documentation is available on hover.
        ;; TODO: Add keybindings for commands, like in `nyxt::command-markup'.
        (:code ,@(progn
-                  (remf attr :class)
+                  (remf attr :class-name)
                   (remf attr :slot)
                   (remf attr :function)
                   (remf attr :command)
@@ -46,4 +46,4 @@
                   (remf attr :package)
                   attr)
               (let ((*print-case* :downcase))
-                (format nil "~a" ,(or (first body) package variable function command slot class))))))
+                (format nil "~a" ,(or (first body) package variable function command slot class-name))))))

--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -15,7 +15,7 @@
 (deftag :nscript (body attrs &key &allow-other-keys)
   `(:script ,@attrs (:raw ,@body)))
 
-(spinneret:deftag :nxref (body attr &key class slot-of function command variable package &allow-other-keys)
+(spinneret:deftag :nxref (body attr &key slot class function command variable package &allow-other-keys)
   `(:a :href ,(cond
                 (package `(nyxt:nyxt-url (read-from-string "nyxt:describe-package")
                                          :universal t :package ,package))
@@ -25,10 +25,10 @@
                                           :universal t :fn ,function))
                 (command `(nyxt:nyxt-url (read-from-string "nyxt:describe-command")
                                          :universal t :command ,command))
+                (slot `(nyxt:nyxt-url (read-from-string "nyxt:describe-slot")
+                                      :universal t :name ,slot :class ,class))
                 (class `(nyxt:nyxt-url (read-from-string "nyxt:describe-class")
                                        :universal t :class ,class))
-                (slot-of `(nyxt:nyxt-url (read-from-string "nyxt:describe-slot")
-                                         :universal t :name ,(first body) :class ,slot-of))
                 (t `(nyxt:javascript-url
                      (ps:ps (nyxt/ps:lisp-eval
                              (:title "describe-any")
@@ -39,11 +39,11 @@
        ;; TODO: Add keybindings for commands, like in `nyxt::command-markup'.
        (:code ,@(progn
                   (remf attr :class)
-                  (remf attr :slot-of)
+                  (remf attr :slot)
                   (remf attr :function)
                   (remf attr :command)
                   (remf attr :variable)
                   (remf attr :package)
                   attr)
               (let ((*print-case* :downcase))
-                (format nil "~a" ,(or (first body) package variable function command class))))))
+                (format nil "~a" ,(or (first body) package variable function command slot class))))))

--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -15,26 +15,26 @@
 (deftag :nscript (body attrs &key &allow-other-keys)
   `(:script ,@attrs (:raw ,@body)))
 
-(spinneret:deftag :nxref (symbol attr &key class slot-of function command variable package &allow-other-keys)
+(spinneret:deftag :nxref (body attr &key class slot-of function command variable package &allow-other-keys)
   `(:a :href ,(cond
                 (package `(nyxt:nyxt-url (read-from-string "nyxt:describe-package")
-                                         :universal t :package (quote ,@symbol)))
+                                         :universal t :package ,package))
                 (variable `(nyxt:nyxt-url (read-from-string "nyxt:describe-variable")
-                                          :universal t :variable (quote ,@symbol)))
+                                          :universal t :variable ,variable))
                 (function `(nyxt:nyxt-url (read-from-string "nyxt:describe-function")
-                                          :universal t :fn (quote ,@symbol)))
+                                          :universal t :fn ,function))
                 (command `(nyxt:nyxt-url (read-from-string "nyxt:describe-command")
-                                         :universal t :command (quote ,@symbol)))
+                                         :universal t :command ,command))
                 (class `(nyxt:nyxt-url (read-from-string "nyxt:describe-class")
-                                       :universal t :class (quote ,@symbol)))
+                                       :universal t :class ,class))
                 (slot-of `(nyxt:nyxt-url (read-from-string "nyxt:describe-slot")
-                                         :universal t :name (quote ,@symbol) :class (quote ,slot-of)))
+                                         :universal t :name ,(first body) :class ,slot-of))
                 (t `(nyxt:javascript-url
                      (ps:ps (nyxt/ps:lisp-eval
                              (:title "describe-any")
                              ;; Not defined yet:
                              (funcall (nyxt:resolve-symbol :describe-any :function)
-                                      (princ-to-string ,@symbol)))))))
+                                      (princ-to-string ,@body)))))))
        ;; TODO: Add :title so that documentation is available on hover.
        ;; TODO: Add keybindings for commands, like in `nyxt::command-markup'.
        (:code ,@(progn
@@ -45,5 +45,5 @@
                   (remf attr :variable)
                   (remf attr :package)
                   attr)
-              ,(let ((*print-case* :downcase))
-                 (format nil "~a" (first symbol))))))
+              (let ((*print-case* :downcase))
+                (format nil "~a" ,(or package variable function command class (first body)))))))


### PR DESCRIPTION
# Description

This adds headless mode section to the manual and showcases the `:nxref` tag usage in its full power.

There's also documentation for `nyxt/dom` package now.

# Discussion

Some meta-things to discuss while we're at it (not required for merging):
- Should `:nxref` actually get quoted symbols, instead of the unquoted ones it currently gets? This way we can pass variables to it, instead of passing plain class/slot/function/command symbols. More typing, though.
- We should probably be as verbose as this PR is, when we add a new feature. That's why there's a "I have made corresponding changes to the documentation" flag below in the checklist. Because undocumented feature is the feature no one will use.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [X] I have pulled from master before submitting this PR
- [X] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [X] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
