### PR TITLE
Add start-slynk command

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -558,3 +558,6 @@
 	path = _build/nkeymaps
 	url = https://github.com/atlas-engineer/nkeymaps
 	shallow = true
+[submodule "_build/sly"]
+	path = _build/sly
+	url = https://github.com/joaotavora/sly

--- a/build-scripts/nyxt.scm
+++ b/build-scripts/nyxt.scm
@@ -172,6 +172,7 @@
           cl-spinneret
           cl-str
           cl-slime-swank
+          cl-slynk
           cl-tld
           cl-trivia
           cl-trivial-clipboard

--- a/documents/README.org
+++ b/documents/README.org
@@ -384,40 +384,9 @@ be configured in the respective configuration files.
 
 [[https://github.com/joaotavora/sly][=SLY=]] is a fork of =SLIME= with additional functionality.
 
-**** Quicklisp Setup
+1. Run the command =start-slynk= in Nyxt.
 
-*Steps:*
-1. Add the following lines to your Nyxt configuration file. If your Quicklisp directory
-   differs, change it accordingly:
-
-#+NAME: nyxt/config.lisp
-#+begin_src lisp
-(load (merge-pathnames #p"quicklisp/setup.lisp" (user-homedir-pathname)))
-(ql:quickload 'slynk)
-(define-nyxt-user-system-and-load nyxt-user/slynk :depends-on (slynk) :components ("my-slynk"))
-#+end_src
-
-2. Create a file called =my-slynk.lisp= where you will specify your
-   =start-slynk= command:
-
-#+NAME: nyxt/my-slynk.lisp
-#+begin_src lisp
-(define-command-global start-slynk (&optional (slynk-port *swank-port*))
-  "Start a Slynk server.
-
-Waits for incoming connections, e.g. from SLY.
-
-    Warning: This allows Nyxt to be controlled remotely, that is, to execute
-    arbitrary code with the privileges of the user running Nyxt.  Make sure
-    you understand the security risks associated with this before running
-    this command."
-  (slynk:create-server :port slynk-port :dont-close t)
-  (echo "Slynk server started at port ~a" slynk-port))
-#+end_src
-
-3. Run the command =start-slynk= in Nyxt.
-
-4. Proceed as in the previous SLIME section by replacing ~slime-connect~ with
+2. Proceed as in the previous SLIME section by replacing ~slime-connect~ with
    ~sly-connect~.
 
 **** Non-Quicklisp Setup

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -64,6 +64,7 @@ This system does nothing in particular.")
                plump
                clss
                spinneret
+               slynk
                swank
                trivia
                trivial-clipboard

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -73,6 +73,11 @@ be blocked by prompt buffer prompts.")
   "The port that Swank will open a new server on (default Emacs SLIME port
 is 4005, default set to 4006 in Nyxt to avoid collisions).")
 
+(export-always '*slynk-port*)
+(defvar *slynk-port* 4006
+  "The port that Slynk will open a new server on (default Emacs Sly port
+is 4005, default set to 4006 in Nyxt to avoid collisions).")
+
 (defparameter +renderer+ nil "The renderer used by Nyxt. This value is meant to
 be set to a string by the renderer itself. This variable exists to allow for
 reporting by users, it does not create any functional differences in the

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -196,6 +196,17 @@ before running this command."
   (swank:create-server :port swank-port :dont-close t)
   (echo "Swank server started at port ~a" swank-port))
 
+(define-command start-slynk (&optional (slynk-port *slynk-port*))
+  "Start a Slynk server that can be connected to, for instance, in
+Emacs via Sly.
+
+Warning: This allows Nyxt to be controlled remotely, that is, to
+execute arbitrary code with the privileges of the user running Nyxt.
+Make sure you understand the security risks associated with this
+before running this command."
+  (slynk:create-server :port slynk-port :dont-close t)
+  (echo "Slynk server started at port ~a" slynk-port))
+
 ;; From sbcl/src/code/load.lisp
 (defun maybe-skip-shebang-line (stream)
   (let ((p (file-position stream)))


### PR DESCRIPTION
# Description

This PR add a `start-slynk` command to nyxt. The motivation for this is not having to specify extra config in order to get emacs, sly, and nyxt working together. This PR closes #2422 

# Discussion

I could use more testers.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [x] I have pulled from master before submitting this PR
- [x] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
