### PR TITLE
mode/repl: Enable inline debugging.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -566,3 +566,7 @@
 	path = _build/py-configparser
 	url = https://gitlab.common-lisp.net/nyxt/py-configparser
 	shallow = true
+[submodule "_build/dissect"]
+	path = _build/dissect
+	url = https://github.com/Shinmera/dissect
+    shallow = true

--- a/build-scripts/nyxt.scm
+++ b/build-scripts/nyxt.scm
@@ -143,6 +143,7 @@
           cl-cluffer
           cl-custom-hash-table
           cl-dexador
+          cl-dissect
           cl-enchant
           cl-flexi-streams
           cl-fset

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -35,6 +35,7 @@
                cl-tld
                closer-mop
                cl-containers
+               dissect
                moptilities
                dexador
                enchant

--- a/source/debugger.lisp
+++ b/source/debugger.lisp
@@ -95,10 +95,10 @@ the channel, wrapped alongside the condition and its restarts."))
        (cond
          ((stack handler)
           (loop for frame in (stack handler)
-                collect (when (or (dissect:form frame)
+                collect (when (or (dissect:call frame)
                                   (dissect:args frame))
                           (:details
-                           (:summary (:code (sera:ellipsize (princ-to-string (dissect:form frame)) 80)))
+                           (:summary (:code (princ-to-string (dissect:call frame))))
                            (when (dissect:args frame)
                              (:p "Called with:")
                              (:ul (loop for arg in (dissect:args frame)

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -449,6 +449,26 @@ instance must be non-nil.")
       (:pre (:code "nyxt --profile nosave --remote --load foo.lisp --eval '(foo)'")))
 
      (:section
+      :id "repl"
+      (:h3 "Built-in REPL (" (:nxref :package :nyxt/repl-mode) ")")
+      (:p "Nyxt has a built-in REPL, available with "
+          (:nxref :command 'nyxt/repl-mode:lisp-repl "lisp-repl command") "."
+          "The REPL can be used to try out some code snippets for automation or quickly
+make some Lisp calculations. All the packages Nyxt depends on are available in
+repl with convenient nicknames, and all the code is evaluated in "
+          (:nxref :package :nyxt-user) " package.")
+      (:p "Once the REPL is open, there's only one input cell visible. This cell, always
+present at the bottom of the screen, adds new cells to the multi-pane interface
+of Nyxt REPL. You can input " (:code "(print \"Hello, Nyxt!\")") " and invoke "
+(command-markup 'nyxt/repl-mode:evaluate-cell)
+" to evaluate the cell. A new cell will appear at the top of the buffer, with
+input area containing familiar code, with some " (:code "v332 = \"Hello, Nyxt!\"")
+" variable assignment, and with a verbatim text outputted by your code:")
+      (:pre (:code "Hello, Nyxt!"))
+      (:p "This cell-based code evaluation is the basis of the Nyxt REPL. For more features, see "
+          (:nxref :package :nyxt/repl-mode "REPL mode documenation") "."))
+
+     (:section
       :id "user-scripts"
       (:h3 "User scripts")
       (:p "User scripts are a conventional and lightweight way to run arbitrary JavaScript

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -455,13 +455,12 @@ instance must be non-nil.")
           (:nxref :command 'nyxt/repl-mode:lisp-repl "lisp-repl command") "."
           "The REPL can be used to try out some code snippets for automation or quickly
 make some Lisp calculations. All the packages Nyxt depends on are available in
-repl with convenient nicknames, and all the code is evaluated in "
+REPL with convenient nicknames, and all the code is evaluated in "
           (:nxref :package :nyxt-user) " package.")
       (:p "Once the REPL is open, there's only one input cell visible. This cell, always
 present at the bottom of the screen, adds new cells to the multi-pane interface
-of Nyxt REPL. You can input " (:code "(print \"Hello, Nyxt!\")") " and invoke "
-(command-markup 'nyxt/repl-mode:evaluate-cell)
-" to evaluate the cell. A new cell will appear at the top of the buffer, with
+of Nyxt REPL. You can type in " (:code "(print \"Hello, Nyxt!\")")
+" and press C-return to evaluate the cell. A new cell will appear at the top of the buffer, with
 input area containing familiar code, with some " (:code "v332 = \"Hello, Nyxt!\"")
 " variable assignment, and with a verbatim text outputted by your code:")
       (:pre (:code "Hello, Nyxt!"))

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -50,6 +50,7 @@ Supports:
   (run-thread "repl cell evaluation"
     (let ((nyxt::*interactive-p* t)
           (*standard-output* (make-string-output-stream))
+          (*package* (find-package :nyxt-user))
           (*debugger-hook*
             (lambda (condition hook)
               (let* ((*debugger-hook* hook)

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -341,7 +341,7 @@ Features:
                   collect (when (or (dissect:form frame)
                                     (dissect:args frame))
                             (:details
-                             (:summary (:code (sera:ellipsize (princ-to-string (dissect:form frame)) 80)))
+                             (:summary (:code (princ-to-string (dissect:call frame))))
                              (when (dissect:args frame)
                                (:p "Called with:")
                                (:ul (loop for arg in (dissect:args frame)

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -334,22 +334,7 @@ Features:
                                                    (setf (raised-condition evaluation) nil)
                                                    (calispel:! (nyxt::channel wrapper) restart)))
                                   (format nil "[~d] ~a" i (restart-name restart)))))
-         ;; TODO: SLIME and SLY provide introspectable backtraces. How?
-         (cond
-           ((nyxt::stack wrapper)
-            (loop for frame in (nyxt::stack wrapper)
-                  collect (when (or (dissect:form frame)
-                                    (dissect:args frame))
-                            (:details
-                             (:summary (:code (princ-to-string (dissect:call frame))))
-                             (when (dissect:args frame)
-                               (:p "Called with:")
-                               (:ul (loop for arg in (dissect:args frame)
-                                          when (or (typep arg 'dissect:unknown-arguments)
-                                                   (typep arg 'dissect:unavailable-argument))
-                                            collect (:li (:code "Unknown argument"))
-                                          else collect (:li (:raw (value->html arg t))))))))))
-           (t (:pre (nyxt::backtrace wrapper))))))
+         (:raw (nyxt::backtrace->html wrapper))))
       ((ready-p evaluation)
        (loop
          for result in (results evaluation)

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -4,16 +4,16 @@
 (nyxt:define-package :nyxt/repl-mode
     (:documentation "Mode for programming in Common Lisp.
 
-Has a multi-cell/panel/input environment that evaluates the inputted code on `evaluate-cell'.
+It has a multi-cell/panel/input environment that evaluates the inputted code on `evaluate-cell'.
 
-Supports:
+Features:
 - Creating additional cells using the bottom cell.
 - Moving cells with `move-cell-down', `move-cell-up', and dedicated cell UI buttons.
 - Basic tab-completion of the inputted symbols.
 - Multiple evaluation results.
 - Standard output recording.
 - Binding results to the automatically-generated variables.
-- Inline debugging (similar no Nyxt-native debugging with `*debug-on-error*' on.)"))
+- Inline debugging (similar to Nyxt-native debugging with `*debug-on-error*' on.)"))
 (in-package :nyxt/repl-mode)
 
 (define-class evaluation ()

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -2,7 +2,18 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/repl-mode
-    (:documentation "Mode for programming in Common Lisp."))
+    (:documentation "Mode for programming in Common Lisp.
+
+Has a multi-cell/panel/input environment that evaluates the inputted code on `evaluate-cell'.
+
+Supports:
+- Creating additional cells using the bottom cell.
+- Moving cells with `move-cell-down', `move-cell-up', and dedicated cell UI buttons.
+- Basic tab-completion of the inputted symbols.
+- Multiple evaluation results.
+- Standard output recording.
+- Binding results to the automatically-generated variables.
+- Inline debugging (similar no Nyxt-native debugging with `*debug-on-error*' on.)"))
 (in-package :nyxt/repl-mode)
 
 (define-class evaluation ()

--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -19,8 +19,7 @@
   (let ((symbol (or package variable function command slot class-name))
         (printable (or (first body) package variable function command slot class-name)))
     `(:a :href ,(cond
-                  (package `(nyxt:nyxt-url (read-from-string "nyxt:describe-package")
-                                           :universal t :package ,package))
+                  (package `(nyxt:nyxt-url (read-from-string "nyxt:describe-package") :package ,package))
                   (variable `(nyxt:nyxt-url (read-from-string "nyxt:describe-variable")
                                             :universal t :variable ,variable))
                   (function `(nyxt:nyxt-url (read-from-string "nyxt:describe-function")


### PR DESCRIPTION
# Description

This adds inline debugger to our `lisp-repl`. It's quite simple in its functionality, and is mostly a drop-in replacement, but it raises some architectural questions regarding our internal debugging library.

Additionally, this includes documentation for REPL functionality, both in manual and `nyxt/repl` package.

# Discussion

A debatable change in this PR is the use of `nyxt-user` package for _all_ REPL evaluations. I don't like it, but it seems to be the best way to ensure package uniformity for REPL evaluations, except per-cell package designation (which might be there someday, but not today).

The future of our debugger.lisp library (not even deserving a dedicated package yet) that I envision is:
- We publish it as a separate repository (`ndebug`?).
- We make it a separate ASDF system dependent on `swank` and `calispel`.
  - Maybe even make two systems: `ndebug/swank` and `ndebug/slynk` so that the ones preferring Slynk (like myself) don't have to bear with Swank.
    - Maybe even drop Swank/Slynk once we understand how their function-invoking streams work.
  - Export the `make-debugger-hook` function that would:
    - Wrap the raised condition into its handler with a restart-accepting-channel and other auxiliary information.
    - Create a two-way stream to interact with the app-specific prompting mechanisms (`:query-in-callback` & `:query-out-callback` keyword args).
    - Call the UI function to display the condition and the actions to resolve it (`:ui-display-callback`).
    - Once the channel returns (should we depend on Calispel here? Maybe use some `bt:semaphore`, which seems to be a bit more lightweight), call the dedicated cleanup action (`:ui-cleanup-callback`).
    - And that's all that's required from a debugger hook. Not much, huh?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [X] I have pulled from master before submitting this PR
- [X] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [X] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
