### PR TITLE
Hint UI style improvement

### DIFF
--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -6,7 +6,7 @@
 (in-package :nyxt/hint-mode)
 
 (define-mode hint-mode ()
-  "Mode to interact with links using keyword only."
+  "Interact with elements by typing a short character sequence."
   ((visible-in-status-p nil)
    (rememberable-p nil)
    (auto-follow-hints-p

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -19,8 +19,8 @@
        :background-color theme:primary
        :color theme:on-primary
        :font-family "monospace,monospace"
-       :padding "0px 3px 0px 3px"
-       :border-radius "2px"
+       :padding "0px 0.3em"
+       :border-radius "0.3em"
        :z-index #.(1- (expt 2 31))))
     :documentation "The style of the boxes, e.g. link hints.")
    (highlighted-box-style

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -13,31 +13,34 @@
     nil
     :type boolean
     :documentation "Whether the hints are automatically followed when matching user input.")
-   (box-style (theme:themed-css (theme *browser*)
-                (".nyxt-hint"
-                 :background-color theme:primary
-                 :color theme:on-primary
-                 :font-family "monospace,monospace"
-                 :padding "0px 3px 0px 3px"
-                 :border-radius "2px"
-                 :z-index #.(1- (expt 2 31))))
-              :documentation "The style of the boxes, e.g. link hints.")
-   (highlighted-box-style (theme:themed-css (theme *browser*)
-                            (".nyxt-hint.nyxt-highlight-hint"
-                             :background-color theme:accent
-                             :color theme:on-accent))
-                          :documentation "The style of highlighted boxes, e.g. link hints.")
-
-   (hints-alphabet "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                   :type string
-                   :documentation "The alphabet (charset) to use for hints.
-Order matters -- the ones that go first are more likely to appear more often
-and to index the top of the page.")
-   (hints-selector "a, button, input, textarea, details, select, img:not([alt=\"\"])"
-                   :type string
-                   :documentation "Defines which elements are to be hinted. The
-hints-selector syntax is that of CLSS, and broadly, that of CSS. Use it to
-define which elements are picked up by element hinting.")
+   (box-style
+    (theme:themed-css (theme *browser*)
+      (".nyxt-hint"
+       :background-color theme:primary
+       :color theme:on-primary
+       :font-family "monospace,monospace"
+       :padding "0px 3px 0px 3px"
+       :border-radius "2px"
+       :z-index #.(1- (expt 2 31))))
+    :documentation "The style of the boxes, e.g. link hints.")
+   (highlighted-box-style
+    (theme:themed-css (theme *browser*)
+      (".nyxt-hint.nyxt-highlight-hint"
+       :background-color theme:accent
+       :color theme:on-accent))
+    :documentation "The style of highlighted boxes, e.g. link hints.")
+   (hints-alphabet
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    :type string
+    :documentation "The alphabet (charset) to use for hints.
+Order matters -- the ones that go first are more likely to appear more often and
+to index the top of the page.")
+   (hints-selector
+    "a, button, input, textarea, details, select, img:not([alt=\"\"])"
+    :type string
+    :documentation "Defines which elements are to be hinted. The hints-selector
+syntax is that of CLSS, and broadly, that of CSS. Use it to define which
+elements are picked up by element hinting.")
    (keyscheme-map
     (define-keyscheme-map "hint" ()
       keyscheme:cua

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -38,9 +38,9 @@ to index the top of the page.")
    (hints-selector
     "a, button, input, textarea, details, select, img:not([alt=\"\"])"
     :type string
-    :documentation "Defines which elements are to be hinted. The hints-selector
-syntax is that of CLSS, and broadly, that of CSS. Use it to define which
-elements are picked up by element hinting.")
+    :documentation "The elements to be hinted.
+The hints-selector syntax is that of CLSS, and broadly, that of CSS. Use it to
+define which elements are picked up by element hinting.")
    (keyscheme-map
     (define-keyscheme-map "hint" ()
       keyscheme:cua

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -36,7 +36,7 @@
 Order matters -- the ones that go first are more likely to appear more often and
 to index the top of the page.")
    (hints-selector
-    "a, button, input, textarea, details, select, img:not([alt=\"\"])"
+    "a, button, input, textarea, details, select"
     :type string
     :documentation "The elements to be hinted.
 The hints-selector syntax is that of CLSS, and broadly, that of CSS. Use it to

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -17,7 +17,7 @@
                 (".nyxt-hint"
                  :background-color theme:primary
                  :color theme:on-primary
-                 :font-weight "bold"
+                 :font-family "monospace,monospace"
                  :padding "0px 3px 0px 3px"
                  :border-radius "2px"
                  :z-index #.(1- (expt 2 31))))


### PR DESCRIPTION
# Description

The relevant commit is f51a5594.



# Discussion

Rationale:

- No need to show the hints in bold, since they already attract too much attention (due to background/on-background color inversion).
- Monospaced fonts ensure that each char occupies constant space.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [x] I have pulled from master before submitting this PR
- [x] My code follows the style guidelines for Common Lisp code
  - See [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf) and [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml).
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
