### PR TITLE
Default modes as a slot

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -441,7 +441,7 @@ the buffer (which gives us more flexibility)."))
   (:method :around ((buffer buffer))
     "Remove the duplicates from the `default-modes'."
     (remove-duplicates (call-next-method)
-                       ;; Mode at the beginning of the list have higher priorities.
+                       ;; Modes at the beginning of the list have higher priority.
                        :from-end t))
   (:method append ((buffer context-buffer))
     (list

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -19,7 +19,7 @@ This is useful when there is no current buffer.")
 
 (define-class buffer (renderer-buffer)
   ((default-modes
-    '(base-mode)
+    %default-modes
     :accessor nil
     :type list
     :documentation "The symbols of the modes to instantiate on buffer creation.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -13,6 +13,10 @@
   ()
   (:metaclass interface-class))
 
+(defvar %default-modes '(base-mode)
+  "The default modes for unspecialized buffers.
+This is useful when there is no current buffer.")
+
 (define-class buffer (renderer-buffer)
   ((default-modes
     '(base-mode)
@@ -428,8 +432,10 @@ the buffer (which gives us more flexibility)."))
 (export-always 'default-modes)
 (defgeneric default-modes (buffer)
   (:method-combination append)
+  ;; TODO: Add a warning method when passing NIL to guard the current buffer not
+  ;; bound errors?
   (:method append ((buffer t))
-    `(base-mode ,(resolve-symbol :document-mode :mode)))
+    %default-modes)
   (:method append ((buffer buffer))
     (slot-value buffer 'default-modes))
   (:method :around ((buffer buffer))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -14,7 +14,16 @@
   (:metaclass interface-class))
 
 (define-class buffer (renderer-buffer)
-  ((id
+  ((default-modes
+    '(base-mode)
+    :accessor nil
+    :type list
+    :documentation "The symbols of the modes to instantiate on buffer creation.
+The mode instances are stored in the `modes' BUFFER slot.
+
+The default modes returned by this method are appended to the default modes
+inherited from the superclasses.")
+   (id
     (new-id)
     :type unsigned-byte
     :documentation "Unique identifier for a buffer.")
@@ -416,46 +425,35 @@ the buffer (which gives us more flexibility)."))
   (call-next-method)
   (set-window-title))
 
-(defvar %default-modes '(base-mode)
-  "The default modes for unspecialized buffers.
-This is useful when there is no current buffer.")
-
 (export-always 'default-modes)
 (defgeneric default-modes (buffer)
   (:method-combination append)
+  (:method append ((buffer t))
+    `(base-mode ,(resolve-symbol :document-mode :mode)))
   (:method append ((buffer buffer))
-    '())
+    (slot-value buffer 'default-modes))
+  (:method :around ((buffer buffer))
+    "Remove the duplicates from the `default-modes'."
+    (remove-duplicates (call-next-method)
+                       ;; Mode at the beginning of the list have higher priorities.
+                       :from-end t))
   (:method append ((buffer context-buffer))
-    (append
-     (list
-      ;; TODO: No need for `resolve-symbol' if we move `context-buffer'
-      ;; declaration in a separate file, loaded after modes.
-      (resolve-symbol :annotate-mode :mode)
-      (resolve-symbol :bookmark-mode :mode)
-      (resolve-symbol :history-mode :mode)
-      (resolve-symbol :password-mode :mode))
-     %default-modes))
+    (list
+     ;; TODO: No need for `resolve-symbol' if we move `context-buffer'
+     ;; declaration in a separate file, loaded after modes.
+     (resolve-symbol :annotate-mode :mode)
+     (resolve-symbol :bookmark-mode :mode)
+     (resolve-symbol :history-mode :mode)
+     (resolve-symbol :password-mode :mode)))
   (:method append ((buffer document-buffer))
-    (append
-     (list
-      ;; TODO: No need for `resolve-symbol' if we move `document-buffer'
-      ;; declaration in a separate file, loaded after modes.
-      (resolve-symbol :hint-mode :mode)
-      (resolve-symbol :search-buffer-mode :mode)
-      (resolve-symbol :autofill-mode :mode) ; TODO: Remove from default?
-      (resolve-symbol :spell-check-mode :mode))
-     %default-modes))
-  (:documentation "The symbols of the modes to instantiate on buffer creation.
-The mode instances are stored in the `modes' BUFFER slot.
-
-The default modes returned by this method are appended to the default modes
-inherited from the superclasses."))
-
-(defmethod default-modes :around ((buffer buffer))
-  "Remove the duplicates from the `default-modes'."
-  (remove-duplicates (call-next-method)
-                     ;; Mode at the beginning of the list have higher priorities.
-                     :from-end t))
+    (list
+     ;; TODO: No need for `resolve-symbol' if we move `document-buffer'
+     ;; declaration in a separate file, loaded after modes.
+     (resolve-symbol :hint-mode :mode)
+     (resolve-symbol :document-mode :mode)
+     (resolve-symbol :search-buffer-mode :mode)
+     (resolve-symbol :autofill-mode :mode) ; TODO: Remove from default?
+     (resolve-symbol :spell-check-mode :mode))))
 
 (define-class network-buffer (buffer)
   ((status

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -440,7 +440,9 @@ SLY install.")
 (define-version "3.0.0"
   (:ul
    (:li (:code "reduce-tracking-mode") " now cleans widely known tracking query parameters.")
-   (:li "Remove image support from " (:code "hint-mode") "."))
+   (:li "Remove image support from " (:code "hint-mode") ".")
+   (:li (:code "default-modes") " can be configured with " (:code "%slot-value%")
+        " due to finally having an underlying slot."))
 
   (:h3 "Bug fixes")
   (:ul

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -8,7 +8,7 @@
 (-> binding-keys (function-symbol &key (:modes list)) *)
 (defun binding-keys (fn &key (modes (if (current-buffer)
                                         (modes (current-buffer))
-                                        (default-modes nil))))
+                                        (mapcar #'make-instance (default-modes nil)))))
   ;; We can't use `(modes (make-instance 'buffer))' because modes are only
   ;; instantiated after the buffer web view, which is not possible if there is
   ;; no *browser*.

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -8,7 +8,7 @@
 (-> binding-keys (function-symbol &key (:modes list)) *)
 (defun binding-keys (fn &key (modes (if (current-buffer)
                                         (modes (current-buffer))
-                                        (mapcar #'make-instance %default-modes))))
+                                        (default-modes nil))))
   ;; We can't use `(modes (make-instance 'buffer))' because modes are only
   ;; instantiated after the buffer web view, which is not possible if there is
   ;; no *browser*.

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -53,7 +53,7 @@ similar programming language.")
                           "Create configuration file")))))
         (:p "Example:")
         (:pre (:code "(define-configuration buffer
-  ((default-modes (append '(no-script-mode) %slot-default%))))")))
+  ((default-modes (append '(no-script-mode) %slot-value%))))")))
       (:p "The above turns on the 'no-script-mode' (disables JavaScript) by default for
 every buffer.")
       (:p "The " (:code "define-configuration") " macro can be used to customize
@@ -105,10 +105,10 @@ add the following to your configuration:")
         (:ul
          (:li "vi bindings:"
               (:pre (:code "(define-configuration buffer
-  ((default-modes (append '(vi-normal-mode) %slot-default%))))")))
+  ((default-modes (append '(vi-normal-mode) %slot-value%))))")))
          (:li "Emacs bindings:"
               (:pre (:code "(define-configuration buffer
-  ((default-modes (append '(emacs-mode) %slot-default%))))"))))
+  ((default-modes (append '(emacs-mode) %slot-value%))))"))))
         (:p "You can create new scheme names with " (:code "keymaps:make-scheme-name")
             ".  Also see the " (:code "scheme-name") " class and the "
             (:code "define-keyscheme-map") " macro.")
@@ -151,7 +151,7 @@ keymap.")
                    nyxt/keyscheme:vi-normal *my-keymap*))))
 
 \(define-configuration (buffer web-buffer)
-  ((default-modes (append '(my-mode) %slot-default%))))"))
+  ((default-modes (append '(my-mode) %slot-value%))))"))
         (:p "Bindings are subject to various translations as per "
             (:nxref :variable 'nkeymaps:*translator*) ". "
             "By default if it fails to find a binding it tries again with inverted
@@ -494,7 +494,7 @@ small configuration snippet (note that you'd need to have"
             " in your " (:nxref :function 'default-modes "buffer default-modes") " ):")
         (:pre (:code ";; Enable user-script-mode, if you didn't already.
 \(define-configuration web-buffer
-  ((default-modes (append '(nyxt/user-script-mode:user-script-mode) %slot-default%))))
+  ((default-modes (append '(nyxt/user-script-mode:user-script-mode) %slot-value%))))
 
 \(define-configuration nyxt/user-script-mode:user-script-mode
   ((nyxt/user-script-mode:user-scripts

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -714,3 +714,5 @@ of buffers."
 (defun frame-source-selection ()
   (remove-duplicates (mapcar #'url (frame-element-get-selection))
                      :test #'equal))
+
+(pushnew 'document-mode nyxt::%default-modes)

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -714,5 +714,3 @@ of buffers."
 (defun frame-source-selection ()
   (remove-duplicates (mapcar #'url (frame-element-get-selection))
                      :test #'equal))
-
-(pushnew 'document-mode nyxt::%default-modes)

--- a/source/mode/emacs.lisp
+++ b/source/mode/emacs.lisp
@@ -13,6 +13,6 @@ in your configuration file.
 Example:
 
 \(define-configuration buffer
-  ((default-modes (append '(emacs-mode) %slot-default%))))"
+  ((default-modes (append '(emacs-mode) %slot-value%))))"
   ((glyph "ε")
    (keyscheme keyscheme:emacs)))

--- a/source/mode/proxy.lisp
+++ b/source/mode/proxy.lisp
@@ -23,7 +23,7 @@ Example to use Tor as a proxy both for browsing and downloading:
                                          :proxied-downloads-p t))))
 
 \(define-configuration web-buffer
-  ((default-modes (append '(proxy-mode) %slot-default%))))"
+  ((default-modes (append '(proxy-mode) %slot-value%))))"
   ((proxy (make-instance 'nyxt:proxy
                          :url (quri:uri "socks5://localhost:9050")
                          :allowlist '("localhost" "localhost:8080")

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -13,7 +13,7 @@ in your configuration file.
 Example:
 
 \(define-configuration buffer
-  ((default-modes (append '(vi-normal-mode) %slot-default%))))
+  ((default-modes (append '(vi-normal-mode) %slot-value%))))
 
 In `vi-insert-mode', CUA bindings are still available unless
 `passthrough-mode-p' is non-nil in `vi-insert-mode'.

--- a/tests/executable/config.lisp
+++ b/tests/executable/config.lisp
@@ -48,7 +48,7 @@
    "--headless"
    "--eval"
    (write-to-string
-    `(nyxt:once-on nyxt:*after-startup-hook* ()
+    `(hooks:once-on nyxt:*after-startup-hook* ()
        (handler-case (progn ,@args)
          (condition (c)
            (log:error "~a" c)
@@ -82,5 +82,19 @@
     (eval-on-startup
      `(nyxt:quit)))
    1))
+
+(subtest "Default-modes are composable"
+  (prove:is
+   (exec-with-config
+    `(progn
+       (nyxt:define-configuration nyxt:web-buffer
+         ((nyxt:default-modes (append '(nyxt/reading-line-mode:reading-line-mode) nyxt:%slot-value%))))
+       (nyxt:define-configuration nyxt:web-buffer
+         ((nyxt:default-modes (append '(nyxt/style-mode:dark-mode) nyxt:%slot-value%)))))
+    (eval-on-startup
+     `(assert (member 'nyxt/reading-line-mode:reading-line-mode (nyxt:default-modes (nyxt:current-buffer))))
+     `(assert (member 'nyxt/style-mode:dark-mode (nyxt:default-modes (nyxt:current-buffer))))
+     `(nyxt:quit)))
+   0))
 
 (finalize)


### PR DESCRIPTION
# Description

This makes `default-modes` to finally become a slot and to enable to `%slot-value%`-based configuration for it, thus fixing the most cryptic yet fundamental part of Nyxt configuration mechanism -- the fact that `default-modes` can only be configured once per class (see https://github.com/aartaka/nyxt-config/issues/2, )

Fixes #2453.

# Discussion

I've not yet included the `closer-mop:slot-definition-readers` change, as all of our `define-configuration` seems to rely on `slot-value` and I'm not yet sure about what design could be equivalent in functionality. Moreover, if we set `slot-value` to the result of the custom reader for, e.g., `default-modes`, then we'd set the value of the `default-modes` to the result of `append` methods, thus invalidating these methods! Not sure how to untangle this Gordian knot...

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have added new changelog.lisp entries matching the added features.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.