### PR TITLE
Add toggle-maximize command

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -442,7 +442,8 @@ SLY install.")
    (:li (:code "reduce-tracking-mode") " now cleans widely known tracking query parameters.")
    (:li "Remove image support from " (:code "hint-mode") ".")
    (:li (:code "default-modes") " can be configured with " (:code "%slot-value%")
-        " due to finally having an underlying slot."))
+        " due to finally having an underlying slot.")
+   (:li "New " (:code "toggle-maximize") " command for maximizing a window."))
 
   (:h3 "Bug fixes")
   (:ul

--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -31,6 +31,9 @@ After this call, the window should not be displayed."))
 (define-ffi-generic ffi-window-fullscreen (window))
 (define-ffi-generic ffi-window-unfullscreen (window))
 
+(define-ffi-generic ffi-window-maximize (window))
+(define-ffi-generic ffi-window-unmaximize (window))
+
 (define-ffi-generic ffi-buffer-url (buffer)
   (:documentation "Return the `quri:uri' associated with the BUFFER.
 This is used to set the `buffer' `url' slot."))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -513,6 +513,12 @@ response.  The BODY is wrapped with `with-protect'."
            (setf (fullscreen-p window)
                  (find :fullscreen
                        (gdk:gdk-event-window-state-new-window-state event)))
+           nil)
+	 (connect-signal window "window-state-event" nil (widget event)
+           (declare (ignore widget))
+           (setf (maximized-p window)
+                 (find :maximized
+                       (gdk:gdk-event-window-state-new-window-state event)))
            nil))
 
        (unless *headless-p*
@@ -535,6 +541,12 @@ response.  The BODY is wrapped with `with-protect'."
 
 (define-ffi-method ffi-window-unfullscreen ((window gtk-window))
   (gtk:gtk-window-unfullscreen (gtk-object window)))
+
+(define-ffi-method ffi-window-maximize ((window gtk-window))
+  (gtk:gtk-window-maximize (gtk-object window)))
+
+(define-ffi-method ffi-window-unmaximize ((window gtk-window))
+  (gtk:gtk-window-unmaximize (gtk-object window)))
 
 (defun derive-key-string (keyval character)
   "Return string representation of a keyval.

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -513,10 +513,7 @@ response.  The BODY is wrapped with `with-protect'."
            (setf (fullscreen-p window)
                  (find :fullscreen
                        (gdk:gdk-event-window-state-new-window-state event)))
-           nil)
-	 (connect-signal window "window-state-event" nil (widget event)
-           (declare (ignore widget))
-           (setf (maximized-p window)
+	   (setf (maximized-p window)
                  (find :maximized
                        (gdk:gdk-event-window-state-new-window-state event)))
            nil))

--- a/source/renderer/qt.lisp
+++ b/source/renderer/qt.lisp
@@ -92,6 +92,12 @@
 (defmethod ffi-window-unfullscreen ((window qt-window))
   (qt:widget-show-normal (qt-object window)))
 
+(defmethod ffi-window-maximize ((window qt-window))
+  (qt:widget-show-maximized (qt-object window)))
+
+(defmethod ffi-window-unmaximize ((window qt-window))
+  (qt:widget-show-normal (qt-object window)))
+
 (defmethod initialize-instance :after ((buffer qt-buffer) &key)
   (hooks:run-hook (buffer-before-make-hook *browser*) buffer)
   (setf (id buffer) (get-unique-identifier *browser*))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -223,9 +223,7 @@ When `skip-renderer-resize' is non-nil, don't ask the renderer to "
   (let ((maximized (maximized-p window)))
     (if maximized
 	(ffi-window-unmaximize window)
-	(ffi-window-maximize window))
-  (toggle-status-buffer :show-p (not maximized))
-  (toggle-message-buffer :show-p (not maximized))))
+	(ffi-window-maximize window))))
 
 (defun enable-status-buffer (&optional (window (current-window)))
   (setf (ffi-window-status-buffer-height window) (height (status-buffer window))))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -50,6 +50,11 @@ The channel is popped when a prompt buffer is hidden.")
     :type boolean
     :documentation "Whether the window is displayed in fullscreen.")
    ;; TODO: each frame should have a status buffer, not each window
+   (maximized-p
+    nil
+    :export nil
+    :type boolean
+    :documentation "Whether the window is maximized.")
    (status-buffer
     (make-instance 'status-buffer)
     :type status-buffer
@@ -212,6 +217,15 @@ When `skip-renderer-resize' is non-nil, don't ask the renderer to "
           (ffi-window-fullscreen window)))
     (toggle-status-buffer :show-p (not fullscreen))
     (toggle-message-buffer :show-p (not fullscreen))))
+
+(define-command toggle-maximize (&key (window (current-window)))
+  "Maximize WINDOW, or the current window, when omitted."
+  (let ((maximized (maximized-p window)))
+    (if maximized
+	(ffi-window-unmaximize window)
+	(ffi-window-maximize window))
+  (toggle-status-buffer :show-p (not maximized))
+  (toggle-message-buffer :show-p (not maximized))))
 
 (defun enable-status-buffer (&optional (window (current-window)))
   (setf (ffi-window-status-buffer-height window) (height (status-buffer window))))


### PR DESCRIPTION
# Description

This pull request adds the command toggle-maximize, which maximizes the current Nyxt window analogous to how toggle-fullscreen makes the current Nyxt window occupy the entire screen. This allows a user to maximize a Nyxt window from the REPL, in config.lisp/init.lisp or from the "Execute Command" prompt.

On the QTWebEngine side, this requires exposing widgetShowMaximized for which I have filed a pull request here: https://github.com/atlas-engineer/cl-webengine/pull/14

This feature is tested as working in nyxt/gi-gtk (cloned from master just before I made the first commit in this pull request). Unfortunately, I have not been able to test it in nyxt/qt, since I could not get cffi to load libwebengine.so (or its alternatives) on Guix System (I could not find anything that provides `libQt5WebEngineWidgets.so.5.15.2` in my `guix environment`).

Fixes #2474

# Discussion

I have copied `ffi-window-unfullscreen` as `ffi-window-unmaximize` in qt.lisp. This is to keep things symmetrical with GTK which has a seperate `window-unmaximize` function as opposed to QT which has only `widget-show-normal`.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
