### PR TITLE
conditions: Always raise nyxt-prompt-buffer-non-interactively condition in REPL

### DIFF
--- a/source/command.lisp
+++ b/source/command.lisp
@@ -357,7 +357,7 @@ With MODE-SYMBOLS and GLOBAL-P, include global commands."
   (with-current-buffer (current-buffer)
     (let ((*interactive-p* t))
       (handler-case (apply #'funcall command args)
-        (nyxt-prompt-buffer-canceled ()
+        (prompt-buffer-canceled ()
           (log:debug "Prompt buffer interrupted")
           nil)))))
 

--- a/source/concurrency.lisp
+++ b/source/concurrency.lisp
@@ -26,7 +26,7 @@ raised condition."
   (alex:with-gensyms (c sub-c)
     `(if (or *run-from-repl-p* *debug-on-error*)
          (handler-case (progn ,@body)
-           (nyxt-prompt-buffer-canceled ()
+           (prompt-buffer-canceled ()
              (log:debug "Prompt buffer interrupted")))
          (ignore-errors
           (handler-bind

--- a/source/conditions.lisp
+++ b/source/conditions.lisp
@@ -3,17 +3,18 @@
 
 (in-package :nyxt)
 
-(export-always 'nyxt-condition)
-(define-condition nyxt-condition (error)
-  ((message :initarg :message :accessor nyxt-condition-message))
+(export-always 'nyxt-error)
+(define-condition nyxt-error (error)
+  ((message :initarg :message :accessor message))
   (:report (lambda (c stream)
              (format stream "~a" (slot-value c 'message))))
-  (:documentation "An error internal to Nyxt. It should abort the ongoing command, but not the whole process."))
+  (:documentation "An error internal to Nyxt.
+It should abort the ongoing command, but not the whole process."))
 
-(define-condition nyxt-web-context-condition (nyxt-condition)
+(define-condition web-context-error (nyxt-error)
   ((context :initarg :context :reader context)))
 
-(define-condition nyxt-prompt-buffer-canceled (error)
+(define-condition prompt-buffer-canceled (error)
   ())
 (define-condition prompt-buffer-non-interactive (error)
   ((name :initarg :name :accessor name))

--- a/source/conditions.lisp
+++ b/source/conditions.lisp
@@ -15,7 +15,7 @@
 
 (define-condition nyxt-prompt-buffer-canceled (error)
   ())
-(define-condition nyxt-prompt-buffer-non-interactively (nyxt-prompt-buffer-canceled)
+(define-condition nyxt-prompt-buffer-non-interactively (error)
   ((name :initarg :name :accessor name))
   (:report (lambda (c stream)
              (format stream "Tried to invoke the prompt buffer (~a) when non-interactive."

--- a/source/conditions.lisp
+++ b/source/conditions.lisp
@@ -15,7 +15,7 @@
 
 (define-condition nyxt-prompt-buffer-canceled (error)
   ())
-(define-condition nyxt-prompt-buffer-non-interactively (error)
+(define-condition prompt-buffer-non-interactive (error)
   ((name :initarg :name :accessor name))
   (:report (lambda (c stream)
              (format stream "Tried to invoke the prompt buffer (~a) when non-interactive."

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -355,7 +355,7 @@ PROMPT is a list fed to `format nil'."
                       :prompt (format nil ,@prompt)
                       :sources '(prompter:yes-no-source)
                       :hide-suggestion-count-p t)
-                   (nyxt-prompt-buffer-canceled () "no"))))
+                   (prompt-buffer-canceled () "no"))))
      (if (string= "yes" answer)
          ,yes-form
          ,no-form)))

--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -239,7 +239,7 @@ turned into links to their respective description page."
                                     (prompt1
                                       :prompt (format nil "Set ~a to" variable)
                                       :sources 'prompter:raw-source))))
-                          (nyxt-prompt-buffer-canceled nil))))
+                          (prompt-buffer-canceled nil))))
        "Change value")
       (:p (:raw (value->html (symbol-value variable)))))))
 

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -64,9 +64,9 @@ A handler can be added with:
 The handlers take no argument.")
 
 (defvar *interactive-p* nil
-  "When non-nil, allow prompt buffers in during BODY execution.
-This is useful to ensure that non-interactive code (for instance scripts) won't
-be blocked by prompt buffer prompts.")
+  "When non-nil, allow prompt buffers during BODY execution.
+This is useful to spot potential blocks when non-interactive code (for instance
+scripts) tries to invoke the prompt buffer.")
 
 (export-always '*swank-port*)
 (defvar *swank-port* 4006

--- a/source/inspector.lisp
+++ b/source/inspector.lisp
@@ -258,7 +258,7 @@ values in help buffers, REPL and elsewhere."))
                                                 (prompt1
                                                   :prompt (format nil "Set ~a to" slot-name)
                                                   :sources 'prompter:raw-source))))
-                                      (nyxt-prompt-buffer-canceled nil))))
+                                      (prompt-buffer-canceled nil))))
                    "change "))
              (:dd (:raw (value->html (slot-value value slot-name) t)))))
           (:raw (escaped-literal-print value))))))

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -303,7 +303,7 @@ Features:
                                       :name "Completions"
                                       :constructor (first (swank:simple-completions
                                                            symbol-to-complete *package*))))
-                         (nyxt::nyxt-prompt-buffer-canceled () nil))))
+                         (nyxt::prompt-buffer-canceled () nil))))
       (when completion
         (setf (input repl) (str:concat (subseq input 0 previous-delimiter)
                                        completion (subseq input cursor))

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -334,7 +334,7 @@ Implies that `small-web-mode' is enabled."
                                 (prompt1 :prompt meta
                                          :sources 'prompter:raw-source
                                          :invisible-input-p (eq status :sensitive-input))
-                              (nyxt::nyxt-prompt-buffer-canceled () "")))))
+                              (nyxt::prompt-buffer-canceled () "")))))
                  (buffer-load (str:concat url "?" text) :buffer buffer)))
               (:success
                (if (str:starts-with-p "text/gemini" meta)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -428,7 +428,7 @@ See `update-prompt-input' to update the changes visually."
        results)
       ((calispel:? (prompter:interrupt-channel prompt-buffer))
        (hide-prompt-buffer prompt-buffer)
-       (error 'nyxt-prompt-buffer-canceled)))))
+       (error 'prompt-buffer-canceled)))))
 
 (sera:eval-always
   (defvar %prompt-args (delete-duplicates
@@ -456,7 +456,7 @@ See the documentation of `prompt-buffer' to know more about the options."
       (restart-case
           (error 'prompt-buffer-non-interactive :name prompter:prompt)
         (prompt-anyway () nil)
-        (cancel () (error 'nyxt-prompt-buffer-canceled))))
+        (cancel () (error 'prompt-buffer-canceled))))
     (alex:when-let ((prompt-text (getf args :prompt)))
       (when (str:ends-with-p ":" prompt-text)
         (log:warn "Prompt text ~s should not end with a ':'." prompt-text)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -454,7 +454,7 @@ See the documentation of `prompt-buffer' to know more about the options."
     (declare #.(cons 'ignorable %prompt-args))
     (unless *interactive-p*
       (restart-case
-          (error 'nyxt-prompt-buffer-non-interactively :name prompter:prompt)
+          (error 'prompt-buffer-non-interactive :name prompter:prompt)
         (prompt-anyway () nil)
         (cancel () (error 'nyxt-prompt-buffer-canceled))))
     (alex:when-let ((prompt-text (getf args :prompt)))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -140,7 +140,7 @@ failures."))
 
 (defmethod initialize-instance :after ((web-context webkit-web-context-ephemeral) &key)
   (unless (webkit:webkit-web-context-is-ephemeral web-context)
-    (error 'nyxt-web-context-condition :context web-context
+    (error 'web-context-error :context web-context
                                        :message "Web Contexts of class webkit-web-context-ephemeral must be ephemeral")))
 
 (defclass webkit-website-data-manager (webkit:webkit-website-data-manager) ()
@@ -151,7 +151,7 @@ failures."))
 
 (defmethod initialize-instance :after ((data-manager webkit-website-data-manager-ephemeral) &key)
   (unless (webkit:webkit-website-data-manager-is-ephemeral data-manager)
-    (error 'nyxt-web-context-condition :context data-manager
+    (error 'web-context-error :context data-manager
                                        :message "Data Managers of class webkit-website-data-manager-ephemeral must be ephemeral")))
 
 (defvar gtk-running-p nil
@@ -345,7 +345,7 @@ By default it is found in the source directory."))
 
 (defmethod initialize-instance :after ((web-view webkit-web-view-ephemeral) &key web-context)
   (unless (webkit:webkit-web-view-is-ephemeral web-view)
-    (error 'nyxt-web-context-condition :context web-context
+    (error 'web-context-error :context web-context
                                        :message "Tried to make an ephemeral web-view in a non-ephemeral context")))
 
 (defmethod make-web-view ((profile nyxt-profile) (buffer t))
@@ -1204,7 +1204,7 @@ See `finalize-buffer'."
                                            (uiop:native-namestring (uiop:getcwd)))
                                    :extra-modes 'nyxt/file-manager-mode:file-manager-mode
                                    :sources 'nyxt/file-manager-mode:file-source)
-                         (nyxt-prompt-buffer-canceled ()
+                         (prompt-buffer-canceled ()
                            nil)))))
           (if files
               (webkit:webkit-file-chooser-request-select-files
@@ -1332,7 +1332,7 @@ See `finalize-buffer'."
                                      :prompt (webkit:webkit-script-dialog-get-message dialog)
                                      :input (webkit:webkit-script-dialog-prompt-get-default-text dialog)
                                      :sources 'prompter:raw-source)
-                                  (nyxt-prompt-buffer-canceled (c) (declare (ignore c)) nil)))))
+                                  (prompt-buffer-canceled (c) (declare (ignore c)) nil)))))
                (if text
                    (webkit:webkit-script-dialog-prompt-set-text dialog text)
                    (progn


### PR DESCRIPTION
I don't know why I decided to inherit from nyxt-prompt-buffer-non-interactively,
I probably got confused when drafting this.


Possibly fixes #2470.

# Discussion

- [x] Is there a semantic relationship between `nyxt-prompt-buffer-canceled` and `nyxt-prompt-buffer-non-interactively`?

- [x] Is this enough of a fix for #2470 ?

- [x] Does this deserve a test?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
