### PR TITLE
configuration: Make one handler for slot-configuration in define-conf…

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -228,6 +228,7 @@
   :targets (:package :nyxt/tests)
   :serial t
   :components ((:file "tests/package")
+               (:file "tests/offline/define-configuration")
                (:file "tests/offline/global-history")
                (:file "tests/offline/user-script-parsing")
                (:file "tests/online/urls")))

--- a/tests/offline/define-configuration.lisp
+++ b/tests/offline/define-configuration.lisp
@@ -1,0 +1,52 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nyxt/tests)
+(use-nyxt-package-nicknames)
+
+(define-test simple-configuration ()
+  (let ((test-url (quri:uri "about:blank")))
+    (nyxt:define-configuration nyxt:browser
+      ((nyxt:default-new-buffer-url test-url)))
+    (let ((browser (make-instance 'browser)))
+      (assert-equality #'quri:uri=
+                       test-url
+                       (nyxt:default-new-buffer-url browser)))
+    (nyxt:clean-configuration)
+    (let ((browser (make-instance 'browser)))
+      (assert-equality #'quri:uri=
+                       (quri:uri (nyxt-url 'new))
+                       (nyxt:default-new-buffer-url browser)))
+    (nyxt:clean-configuration)))
+
+(define-test slot-default ()
+  (let ((test-url (quri:uri "about:blank")))
+    (nyxt:define-configuration nyxt:browser
+      ((nyxt:default-new-buffer-url test-url)))
+    (let ((browser (make-instance 'browser)))
+      (assert-equality #'quri:uri=
+                       test-url
+                       (nyxt:default-new-buffer-url browser)))
+    (nyxt:clean-configuration)
+    (nyxt:define-configuration nyxt:browser
+      ((nyxt:default-new-buffer-url nyxt:%slot-default%)))
+    (let ((browser (make-instance 'browser)))
+      (assert-equality #'quri:uri=
+                       (quri:uri (nyxt-url 'new))
+                       (nyxt:default-new-buffer-url browser)))
+    (nyxt:clean-configuration)))
+
+(define-test test-slot-value ()
+  (nyxt:define-configuration nyxt:browser
+    ((nyxt:before-exit-hook (hooks:add-hook nyxt:%slot-value%
+                                            (make-instance 'nhooks:handler
+                                                           :fn (lambda () (print 'dummy1))
+                                                           :name 'dummy1)))))
+  (nyxt:define-configuration nyxt:browser
+    ((nyxt:before-exit-hook (hooks:add-hook nyxt:%slot-value%
+                                            (make-instance 'nhooks:handler
+                                                           :fn (lambda () (print 'dummy2))
+                                                           :name 'dummy2)))))
+  (let ((browser (make-instance 'browser)))
+    (assert-eql 2
+                (length (hooks:handlers (nyxt:before-exit-hook browser))))))


### PR DESCRIPTION
# Description

This helps with debugging and live-manipulation of the hook.

Supersedes #2451 

# Discussion

Do we still need the `(c2mop:class-finalized-p (find-class class))` check?
In which case can this code run and the class not be finalized?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
