### PR TITLE
mode/download: Fix colors in progress bar.

### DIFF
--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -146,7 +146,7 @@ appearance in the buffer when they are setf'd."
              :height "20px"
              :width "100%")
             (".progress-bar-base"
-             :background-color theme:secondary
+             :background-color theme:primary
              :height "100%")
             (".progress-bar-fill"
              :background-color theme:secondary


### PR DESCRIPTION
`progress-bar-base` and `progress-bar-fill` in `download-mode` have same colors, so the progress bar shows no progress. This PR fixes it.

Closes #2489