### PR TITLE
fix username not stored when password generated with pass backend

### DIFF
--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -90,13 +90,13 @@ The prefix is discarded from the result and returned."
 (defmethod save-password ((password-interface password-store-interface)
                           &key password-name username password service)
   (declare (ignore service))
+  (with-open-stream (st (make-string-input-stream (format nil "~a~%username:~a"
+                                                          password
+                                                          username)))
+    (execute password-interface (list "insert" "--multiline" password-name)
+      :input st))
   (if (str:emptyp password)
-      (execute password-interface (list "generate" password-name))
-      (with-open-stream (st (make-string-input-stream (format nil "~a~&username:~a"
-                                                              password
-                                                              username)))
-        (execute password-interface (list "insert" "--multiline" password-name)
-          :input st))))
+    (execute password-interface (list "generate" "--in-place" password-name))))
 
 (defmethod password-correct-p ((password-interface password-store-interface))
   t)

--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -95,7 +95,7 @@ The prefix is discarded from the result and returned."
                                                           username)))
     (execute password-interface (list "insert" "--multiline" password-name)
       :input st))
-  (if (str:emptyp password)
+  (when (str:emptyp password)
     (execute password-interface (list "generate" "--in-place" password-name))))
 
 (defmethod password-correct-p ((password-interface password-store-interface))


### PR DESCRIPTION
Fixes #2499

# Discussion

The pass backend provides no way to generate a new password and add additional information in the same operation/commit. Therefore we now first insert the new information, namingly the username and add a blank line for the password. Then we let pass generate a new password in place. Note that this only changes line 1 in the encrypted file.

This is not optimal, but I found no way to do this differently with pass. We could generate the password in nyxt and then write both username and password to the encrypted file, but I guess one would want to let pass generate the password.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
