### PR TITLE
Fix spelling & formatting errors

### DIFF
--- a/source/mode/blocker.lisp
+++ b/source/mode/blocker.lisp
@@ -80,7 +80,7 @@ Example:
 (defmethod files:write-file ((profile nyxt-profile) (hostlist hostlist) &key destination)
   "Write the downloaded hostlist to disk.
 This is the raw downloaded content and not the serialized parsed content.
-This gives more integrity guaranteees to the user and allows external manipulation."
+This gives more integrity guarantees to the user and allows external manipulation."
   (unless (uiop:emptyp (files:url-content hostlist))
     (alex:write-string-into-file (files:url-content hostlist) destination :if-exists :supersede)))
 

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -9,7 +9,7 @@
 ;;; - It's too verbose, e.g. a list is
 ;;; (:SEQUENCE 3 :CLASS CL:LIST :SIZE 2 :ELEMENTS ( "bar" "baz" ) )
 ;;;
-;;; - We lack control on the linebreaks.
+;;; - We lack control on the line breaks.
 ;;;
 ;;; - It needs IDs for every object, which makes it hard for the user to
 ;;;   hand-edit the file without breaking it.

--- a/source/mode/bookmarklets.lisp
+++ b/source/mode/bookmarklets.lisp
@@ -1,6 +1,6 @@
 ;;;; This package and file serves as a source for bookmarklets that
 ;;;; originate outside of the Nyxt codebase. Eventually, the goal is
-;;;; to translate these bookmarklets into their equivalent parenscript
+;;;; to translate these bookmarklets into their equivalent Parenscript
 ;;;; forms for easier interaction and editing.
 
 ;;;; The Bookmarklets in this file are copyright Jesse Ruderman and

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -581,7 +581,7 @@ of buffers."
                                       :top "0"
                                       :left "0"
                                       :border-style "dotted"
-                                      :bordeer-width "1px"
+                                      :border-width "1px"
                                       :border-color theme:on-background
                                       :background-color theme:on-background
                                       :opacity 0.05
@@ -725,7 +725,7 @@ of buffers."
                                                       (make-buffer :url (quri:uri i)))
                                                     urls))))
           :after-destructor (lambda () (with-current-buffer buffer
-                                    (frame-element-clear)))))
+                                         (frame-element-clear)))))
 
 (defun frame-source-selection ()
   (remove-duplicates (mapcar #'url (frame-element-get-selection))

--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -50,7 +50,7 @@ disk.")
                     :export t
                     :type (or null function)
                     :documentation "The function to call when
-cancelling a download. This can be set by the download engine.")
+canceling a download. This can be set by the download engine.")
    (cancel-button (make-instance 'user-interface:button
                                  :text "✕"
                                  :action (ps:ps (nyxt/ps:lisp-eval () (echo "Can't cancel download."))))
@@ -63,7 +63,7 @@ cancel-download with an argument of the URL to cancel.")
                                :action (ps:ps (nyxt/ps:lisp-eval () (echo "Can't open file, file path unknown."))))
                 :export nil
                 :documentation "The file name to open is encoded
-within the button's URL when the destinaton path is set.")
+within the button's URL when the destination path is set.")
    (progress-text (make-instance 'user-interface:paragraph)
                   :export nil)
    (progress (make-instance 'user-interface:progress-bar)
@@ -81,7 +81,7 @@ the URL. It will search the URLs of all the existing downloads, if it
 finds it, it will invoke its cancel-function."
   (alex:when-let ((download (find url (downloads *browser*) :key #'url :test #'equal)))
     (funcall (cancel-function download))
-    (echo "Download cancelled: ~a." url)))
+    (echo "Download canceled: ~a." url)))
 
 (defmethod (setf cancel-function) (cancel-function (download download))
   (setf (slot-value download 'cancel-function) cancel-function)

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -119,9 +119,9 @@ For instance, to include images:
   (let* ((exponents (nreverse (loop for pow below char-length
                                     collect (expt (length alphabet) pow)))))
     (coerce (loop for exp in exponents
-                  for quotinent = (floor (/ code exp))
-                  collect (aref alphabet quotinent)
-                  do (decf code (* quotinent exp)))
+                  for quotient = (floor (/ code exp))
+                  collect (aref alphabet quotient)
+                  do (decf code (* quotient exp)))
             'string)))
 
 (-> generate-hints (integer) list-of-strings)
@@ -236,7 +236,7 @@ FUNCTION is the action to perform on the selected elements."
                                             (declare (ignore source))
                                             (add-hints :selector selector)))
                             :after-destructor (lambda () (with-current-buffer buffer
-                                                      (remove-hints))))))
+                                                           (remove-hints))))))
     (funcall function result)))
 
 (defmethod prompter:object-attributes :around ((element plump:element) (source hint-source))

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -16,7 +16,7 @@
                       :type list-of-strings
                       :documentation "URL prefixes to not save in history.
 Example: DuckDuckGo redirections should be ignored or else going backward in
-history after consulting a result reloads the result, not the duckduckgo
+history after consulting a result reloads the result, not the DuckDuckGo
 search.")
    (conservative-history-movement-p
     nil
@@ -137,9 +137,9 @@ This saves the history to disk when BODY exits."
 (define-command history-backwards-query (&optional (buffer (current-buffer)))
   "Query parent URL to navigate back to."
   (let ((input (prompt1
-                 :prompt "Navigate backwards to"
-                 :sources (make-instance 'history-backwards-source
-                                         :buffer buffer))))
+                :prompt "Navigate backwards to"
+                :sources (make-instance 'history-backwards-source
+                                        :buffer buffer))))
     (when input
       (with-history-access (history buffer)
         (loop until (eq input (htree:owner-node history (id buffer)))
@@ -162,9 +162,9 @@ This saves the history to disk when BODY exits."
 (define-command history-forwards-direct-children (&optional (buffer (current-buffer)))
   "Query child URL to navigate to."
   (let ((input (prompt1
-                 :prompt "Navigate forwards to"
-                 :sources (make-instance 'direct-history-forwards-source
-                                         :buffer buffer))))
+                :prompt "Navigate forwards to"
+                :sources (make-instance 'direct-history-forwards-source
+                                        :buffer buffer))))
     (when input
       (with-history-access (history buffer)
         (htree:go-to-child (htree:data input) history (id buffer)))

--- a/source/mode/no-procrastinate.lisp
+++ b/source/mode/no-procrastinate.lisp
@@ -14,7 +14,7 @@
   "Default hostlist for `no-procrastinate-mode'.")
 
 (define-mode no-procrastinate-mode (nyxt/blocker-mode:blocker-mode)
-  "Mode to block access to hosts associated to procrastination."
+  "Mode to block access to hosts associated with procrastination."
   ((rememberable-p nil)
    (no-procrastinate-hosts-file
     (make-instance 'no-procrastinate-hosts-file)

--- a/source/mode/os-package-manager.lisp
+++ b/source/mode/os-package-manager.lisp
@@ -31,7 +31,7 @@
      (current-buffer)
      (ps:ps (ps:chain document
                       (write (ps:lisp (spinneret:with-html-string
-                                        (:p "Operation cancelled.")))))))))
+                                        (:p "Operation canceled.")))))))))
 
 (defmethod prompter:object-attributes ((pkg ospm:os-package) (source prompter:source))
   (declare (ignore source))
@@ -280,7 +280,7 @@ OBJECTS can be a list of packages, a generation, etc."
               (format-command-stream
                process-info
                (lambda (s)
-                 ;; TODO: Make shell formating function and add support for
+                 ;; TODO: Make shell formatting function and add support for
                  ;; special characters, e.g. progress bars.
                  (nyxt::html-write
                   (spinneret:with-html-string

--- a/source/mode/record-input-field.lisp
+++ b/source/mode/record-input-field.lisp
@@ -125,8 +125,8 @@ See `save-input-data' and `set-input-data-from-saved'."
 
 (define-command set-input-data-from-saved
     (&key (return-actions (list (lambda-command set-input-data* (suggestion-values)
-                           "Load selected input-entry in current buffer's input fields."
-                           (ps-write-input-data (input-data (first suggestion-values)))))))
+                                  "Load selected input-entry in current buffer's input fields."
+                                  (ps-write-input-data (input-data (first suggestion-values)))))))
   "Set the input data from a list of saved data into the current buffer.
 See also `set-input-data-from-saved-domain'."
   (prompt :prompt "Write input data from"
@@ -135,12 +135,12 @@ See also `set-input-data-from-saved-domain'."
 
 (define-command set-input-data-from-saved-domain
     (&key (return-actions (list (lambda-command buffer-load* (suggestion-values)
-                           "Load selected input-entry in current buffer's input fields."
-                           (ps-write-input-data (input-data (first suggestion-values)))))))
+                                  "Load selected input-entry in current buffer's input fields."
+                                  (ps-write-input-data (input-data (first suggestion-values)))))))
   "Set the input data from a list of saved data filtered by current domain into
 the current buffer.
 
-See alsy `set-input-data-from-saved'."
+See also `set-input-data-from-saved'."
   (prompt :prompt "Write input data from"
           :sources (make-instance 'filtered-domain-input-data-source
                                   :return-actions return-actions)))

--- a/source/mode/reduce-tracking.lisp
+++ b/source/mode/reduce-tracking.lisp
@@ -7,7 +7,7 @@
 
 (define-mode reduce-tracking-mode ()
   "Set specific settings in the web view in order to mitigate fingerprinting,
-(how third-party trackers attempt to indentify you).
+(how third-party trackers attempt to identify you).
 
 Fingerprinting can be tested with https://panopticlick.eff.org/."
   ((preferred-languages

--- a/source/mode/repeat.lisp
+++ b/source/mode/repeat.lisp
@@ -90,7 +90,7 @@ It takes a `repeat-mode' instance as argument.")))
 
 (defun skip-repeat-dispatch (keyspec)
   (declare (ignore keyspec))
-  (echo "Cancelled repeat-key.")
+  (echo "Canceled repeat-key.")
   (setf (command-dispatcher (current-window)) #'dispatch-command
         (input-skip-dispatcher (current-window)) #'dispatch-input-skip))
 

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -268,7 +268,7 @@ Features:
             (cursor repl) (1+ cursor)))))
 
 (define-command closing-paren (&optional (repl (find-submode 'repl-mode)))
-  "Automatically closes all the open parens before the cursor."
+  "Automatically closes all the open parentheses before the cursor."
   (when (input-focus-p repl)
     (let* ((input (input repl))
            (cursor (cursor repl))
@@ -281,7 +281,7 @@ Features:
 
 (defparameter +delimiters+
   (uiop:strcat "()"
-          sera:whitespace)
+               sera:whitespace)
   "Non-symbol Lisp delimiters.")
 
 (define-command tab-complete-symbol (&optional (repl (find-submode 'repl-mode)))
@@ -381,7 +381,7 @@ Features:
                                                                          'current-evaluation)
                                                              order)))
                                                (input evaluation)))
-                              (:div :class "evalution-result"
+                              (:div :class "evaluation-result"
                                     :id (format nil "evaluation-result-~a" (id evaluation))
                                     (:raw (html-result evaluation)))))
                    (:div :class "input"

--- a/source/user-files.lisp
+++ b/source/user-files.lisp
@@ -23,7 +23,7 @@ standard locations."))
    (editable-p
     t
     :type boolean
-    :documentation "Whether the file can be editted using a text editor.
+    :documentation "Whether the file can be edited using a text editor.
 It's not always the case, take the socket for instance."))
   (:export-class-name-p t)
   (:export-accessor-names-p t)


### PR DESCRIPTION
Just a # of minor spelling errors as well as some reformatting (while connected to a running Nyxt instance, of course).