### PR TITLE
mode/search-buffer: Add independent search-buffer style.

### DIFF
--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -9,6 +9,19 @@
   "Mode for searching text withing."
   ((visible-in-status-p nil)
    (rememberable-p nil)
+   (style
+    (theme:themed-css (theme *browser*)
+      (".nyxt-hint"
+       :background-color theme:secondary
+       :color theme:on-secondary
+       :font-family "monospace,monospace"
+       :padding "0px 0.3em"
+       :border-radius "0.3em"
+       :z-index #.(1- (expt 2 31)))
+      (".nyxt-hint.nyxt-select-hint"
+       :background-color theme:accent
+       :color theme:on-accent))
+    :documentation "The style of the search overlays.")
    (keyscheme-map
     (define-keyscheme-map "search-buffer-mode" ()
       keyscheme:cua
@@ -38,7 +51,7 @@
          (setf (ps:@ style-element id) "nyxt-stylesheet")
          (ps:chain document head (append-child style-element))
          (setf (ps:chain style-element inner-text)
-               (ps:lisp (style (find-submode 'nyxt/hint-mode:hint-mode)))))
+               (ps:lisp (style (find-submode 'nyxt/search-buffer-mode:search-buffer-mode)))))
        (:catch (error)))))
 
   (defun create-match-object (body identifier)


### PR DESCRIPTION
It was dependent on the style of mode/hint.

# Description

Fixes the fact that the style adopted for hints propagated to `search-buffer` after #2520.


# Discussion

I changed the default background color for search results so that `on-accent` and `on-"whatever-color"` match, which means that `"whatever-color"` must be `secondary`.

**Before:**

![2022-08-29_15:28:24](https://user-images.githubusercontent.com/45483512/187206668-def9ad17-a55d-4419-be63-176f594e104d.png)


**After:**
![2022-08-29_15:52:56](https://user-images.githubusercontent.com/45483512/187206649-7d4ef7c5-d364-4cc0-8616-a86b74ee7107.png)


# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
