### PR TITLE
Refactor search buffer (Follow up to #2424)

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -453,6 +453,7 @@ The renderer is configured from NYXT_RENDERER or `*nyxt-renderer*'."))
                (:file "tests/renderer-offline/execute-command-eval")
                (:file "tests/renderer-offline/remembrance")
                (:file "tests/renderer-offline/nyxt-url-security")
+               (:file "tests/renderer-offline/search-buffer")
                (:file "tests/renderer-online/set-url")))
 
 (defsystem "nyxt/qt"

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -76,7 +76,7 @@ The most useful functions are:
   img-element input-element ins-element kbd-element label-element legend-element
   (li-element list-element) link-element (main-element semantic-element) map-element
   (mark-element semantic-element) meta-element meter-element (nav-element semantic-element)
-  noscript-element object-element (ol-element list-element) optgroup-element
+  (noscript-element plump:fulltext-element) object-element (ol-element list-element) optgroup-element
   (option-element text-element) output-element (p-element text-element) param-element
   (pre-element text-element) progress-element q-element rp-element rt-element rtc-element
   ruby-element samp-element (script-element plump:fulltext-element)

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -206,15 +206,6 @@ For instance, to include images:
       (when (ps:lisp scroll)
         (ps:chain %element (scroll-into-view (ps:create block "center")))))))
 
-(export-always 'unhighlight-selected-hint)
-(define-parenscript unhighlight-selected-hint ()
-  ;; There should be, at most, a unique element with the
-  ;; "nyxt-select-hint" class.
-  ;; querySelectAll, unlike querySelect, handles the case when none are
-  ;; found.
-  (ps:dolist (selected-hint (nyxt/ps:qsa document ".nyxt-select-hint"))
-    (ps:chain selected-hint class-list (remove "nyxt-select-hint"))))
-
 (define-parenscript-async set-hint-visibility (hint state)
   "Set visibility STATE of HINT element.
 

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -97,16 +97,6 @@ For instance, to include images:
        "g f" 'follow-hint-nosave-buffer
        "g F" 'follow-hint-nosave-buffer-focus)))))
 
-(define-parenscript-async add-stylesheet ()
-  (unless (nyxt/ps:qs document "#nyxt-stylesheet")
-    (ps:try
-     (ps:let ((style-element (ps:chain document (create-element "style"))))
-       (setf (ps:@ style-element id) "nyxt-stylesheet")
-       (ps:chain document head (append-child style-element))
-       (setf (ps:chain style-element inner-text)
-             (ps:lisp (style (find-submode 'hint-mode)))))
-     (:catch (error)))))
-
 (define-parenscript-async hint-elements (hints)
   (defun create-hint-overlay (original-element hint)
     "Create a DOM element to be used as a hint."
@@ -172,7 +162,8 @@ For instance, to include images:
     (ps:chain element (remove-attribute "nyxt-hintable"))))
 
 (defun add-hints (&key selector (buffer (current-buffer)))
-  (add-stylesheet)
+  (add-stylesheet (style (find-submode 'hint-mode))
+                  buffer)
   (set-hintable-attribute selector)
   (update-document-model :buffer buffer)
   (let* ((hintable-elements (clss:select "[nyxt-hintable]" (document-model buffer)))

--- a/source/mode/remembrance.lisp
+++ b/source/mode/remembrance.lisp
@@ -273,15 +273,16 @@ This induces a performance cost."))
 
 (defvar *remembrance-node-class-name* "nyxt-remembrance-highlight-node")
 
-(defun add-search-hint (buffer term)
-  ;; TODO: Add this to the  `nyxt/search-buffer-mode' API?
-  (unless (uiop:emptyp term)
-    (with-current-buffer buffer
-      (nyxt/search-buffer-mode::query-buffer
-       :query term
-       :keep-previous-hints t
-       :node-class-name *remembrance-node-class-name*
-       :case-sensitive-p nil))))
+;; FIXME query-buffer doesn't exist anymore
+;; (defun add-search-hint (buffer term)
+;;   ;; TODO: Add this to the  `nyxt/search-buffer-mode' API?
+;;   (unless (uiop:emptyp term)
+;;     (with-current-buffer buffer
+;;       (nyxt/search-buffer-mode::query-buffer
+;;        :query term
+;;        :keep-previous-hints t
+;;        :node-class-name *remembrance-node-class-name*
+;;        :case-sensitive-p nil))))
 
 (define-internal-scheme "view-remembered-page"
     (lambda (url buffer)
@@ -298,7 +299,9 @@ This induces a performance cost."))
                    (doc (find-url url-string mode)))
               (hooks:once-on (buffer-loaded-hook buffer) (_)
                 (dolist (term (cons query (uiop:split-string query)))
-                  (add-search-hint buffer term)))
+                  ;; FIXME
+                  ;; (add-search-hint buffer term)
+                  t))
               (spinneret:with-html-string
                 (:nstyle (style mode))
                 (:h1 "[Cache] " (:a :href url-string (if (uiop:emptyp (page-title doc))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -11,15 +11,23 @@
    (rememberable-p nil)
    (style
     (theme:themed-css (theme *browser*)
-      `(".nyxt-search-node .nyxt-hint"
-        :background-color ,theme:secondary
-        :color ,theme:on-secondary
-        :padding "0px"
-        :border-radius "0px"
+      `("span[nyxt-search-hint]"
+        :background-color ,(str:concat theme:secondary " !important")
+        :color ,(str:concat theme:on-secondary " !important")
         :z-index #.(1- (expt 2 31)))
-      `(".nyxt-search-node > .nyxt-hint.nyxt-select-hint"
-        :background-color ,theme:accent
-        :color ,theme:on-accent))
+      `("span[nyxt-search-hint].nyxt-current-search-hint"
+        :animation-name "highlight"
+        :animation-duration "1s"
+        :animation-delay "0.2s"
+        :animation-timing-function "ease-in-out"
+        :animation-iteration-count "infinite"
+        :animation-direction "alternate"
+        :background ,(format nil "linear-gradient(90deg, ~a, ~a, ~a)"
+                             theme:accent theme:background theme:accent)
+        :background-size 300% 100%)
+      `(:keyframes "highlight"
+                   (0% :background-position 100%)
+                   (100% :background-position 0%)))
     :documentation "The style of the search overlays.")
    (keyscheme-map
     (define-keyscheme-map "search-buffer-mode" ()

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -5,7 +5,7 @@
     (:documentation "Mode for element hints."))
 (in-package :nyxt/search-buffer-mode)
 
-(define-mode search-buffer-mode (nyxt/hint-mode:hint-mode)
+(define-mode search-buffer-mode ()
   "Mode for searching text withing."
   ((visible-in-status-p nil)
    (rememberable-p nil)
@@ -43,211 +43,401 @@
       keyscheme:vi-normal
       (list
        "/" 'search-buffer
-       "?" 'remove-search-hints)))))
-
-(defvar *node-class-name* "nyxt-search-node")
-
-(define-parenscript query-buffer (&key query (case-sensitive-p nil)
-                                       keep-previous-hints
-                                       (node-class-name *node-class-name*))
-  (defvar *identifier* 0)
-  (defvar *matches* (array))
-  (defvar *nodes* (ps:new (-Object)))
-  (defvar *node-replacements* (array))
-
-  (defun add-stylesheet ()
-    (unless (nyxt/ps:qs document "#nyxt-stylesheet")
-      (ps:try
-       (ps:let ((style-element (ps:chain document (create-element "style"))))
-         (setf (ps:@ style-element id) "nyxt-stylesheet")
-         (ps:chain document head (append-child style-element))
-         (setf (ps:chain style-element inner-text)
-               (ps:lisp (style (find-submode 'nyxt/search-buffer-mode:search-buffer-mode)))))
-       (:catch (error)))))
-
-  (defun create-match-object (body identifier)
-    (ps:create "type" "match" "identifier" identifier "body" body))
-
-  (defun create-match-span (body identifier)
-    (ps:let* ((el (ps:chain document (create-element "span"))))
-      (setf (ps:@ el class-name) "nyxt-hint")
-      (setf (ps:@ el text-content) body)
-      (setf (ps:@ el id) (+ "nyxt-hint-" identifier))
-      el))
-
-  (defun get-substring (string query index)
-    "Return the substring and preceding/trailing text for a given
-     index."
-    (let* ((character-preview-count 40))
-      (ps:chain string
-                (substring (- index character-preview-count)
-                           (+ index (length query) character-preview-count)))))
-
-  (defun get-substring-indices (query string)
-    "Get the indices of all matching substrings."
-    (let ((query (if (ps:lisp case-sensitive-p)
-                     query
-                     (ps:chain query (to-lower-case))))
-          (string (if (ps:lisp case-sensitive-p)
-                      string
-                      (ps:chain string (to-lower-case))))
-          (index (- (length query))))
-      (loop with subindex = 0
-            until (= subindex -1)
-            do (setf subindex (ps:chain string (index-of query)))
-               (setf string (ps:chain string (substring (+ subindex (length query)))))
-               (setf index (+ index subindex (length query)))
-            when (not (= subindex -1))
-              collect index)))
-
-  (defun matches-from-node (node query)
-    "Return all of substrings that match the search-string."
-    (when (= (ps:chain (typeof (ps:@ node node-value))) "string")
-      (let* ((node-text (ps:@ node text-content))
-             (substring-indices (get-substring-indices query node-text))
-             (node-identifier (incf (ps:chain *nodes* identifier)))
-             (new-node (ps:chain document (create-element "span"))))
-        (setf (ps:@ new-node class-name) (ps:lisp node-class-name))
-        (setf (ps:@ new-node id) node-identifier)
-        (setf (aref *nodes* node-identifier) node)
-        (when (> (length substring-indices) 0)
-          (loop for index in substring-indices
-                with last-index = 0
-                do (incf *identifier*)
-                   (ps:chain new-node (append-child (ps:chain document (create-text-node (ps:chain node-text (substring last-index index))))))
-                   (ps:chain new-node (append-child (create-match-span (ps:chain node-text (substring index (+ index (length query)))) *identifier*)))
-                   (setf last-index (+ (length query) index))
-                   (ps:chain *matches* (push (create-match-object (get-substring node-text query index) *identifier*)))
-                finally (progn
-                          (ps:chain new-node (append-child (ps:chain document (create-text-node (ps:chain node-text (substring (+ (length query) index)))))))
-                          (ps:chain *node-replacements*
-                                    (push (list node new-node)))))))))
-
-  (defun replace-original-nodes ()
-    "Replace original nodes with recreated search nodes"
-    (loop for node-pair in *node-replacements*
-          do (ps:chain (elt node-pair 0) (replace-with (elt node-pair 1)))))
-
-  (defun walk-document (node process-node)
-    (when (and node (not (ps:chain node first-child)))
-      (funcall process-node node (ps:lisp query)))
-    (setf node (ps:chain node first-child))
-    (loop while node
-          do (walk-document node process-node)
-          do (setf node (ps:chain node next-sibling))))
-
-  (defun remove-search-nodes ()
-    "Removes all the search elements"
-    (ps:dolist (node (nyxt/ps:qsa document (+ "." (ps:lisp node-class-name))))
-      (ps:chain node (replace-with (aref *nodes* (ps:@ node id))))))
-
-  (let ((*matches* (array))
-        (*node-replacements* (array))
-        (*identifier* 0))
-    (add-stylesheet)
-    (unless (ps:lisp keep-previous-hints)
-      (remove-search-nodes))
-    (setf (ps:chain *nodes* identifier) 0)
-    (walk-document (ps:chain document body) matches-from-node)
-    (replace-original-nodes)
-    *matches*))
+       "?" 'remove-search-hints))))
+  (:toggler-command-p nil))
 
 (define-class search-match ()
-  ((identifier)
+  ((pattern)
+   ;; is element needed?  Most likely yes.  But it doesn't quite identify the
+   ;; match in plump does it?
+   (element)
    (body)
-   (buffer)))
+   (match-index)
+   (identifier-beg)
+   (node-index-beg)
+   (text-index-beg)
+   (identifier-end)
+   (node-index-end)
+   (text-index-end)
+   (buffer)
+   (highlighted-p)))
 
-(defmethod nyxt/hint-mode:identifier ((match search-match))
-  (identifier match))
+(defmethod (setf highlighted-p) (value (match search-match))
+  (setf (slot-value match 'highlighted-p) value)
+  (when value (highlight-match match)))
+
+;; Rename to hint-match?
+(defmethod highlight-match ((match search-match))
+  (ps-eval :async t :buffer (or (buffer match) (current-buffer))
+    ;; StaticRange may improve performance at the cost of correctness.
+    (defun create-range () (ps:chain document (create-range)))
+
+    (defun create-match-element (index)
+      (let ((elem (ps:chain document (create-element "span"))))
+        (ps:chain elem (set-attribute "nyxt-search-hint" index))
+        elem))
+
+    (defun wrap (range new-parent) (ps:chain range (surround-contents new-parent)))
+
+    (defun test-node (node) (ps:chain (eq node this)))
+
+    (defun text-nodes-within-bounds (root-element node-beg node-end)
+      "TODO"
+      (let ((nodes '())
+            ;; 4 means NodeFilter.SHOW_TEXT
+            (walk (ps:chain document (create-tree-walker root-element 4 null false))))
+        (loop for text-node = (ps:chain walk (next-node))
+              while text-node
+              do (ps:chain nodes (push text-node)))
+        (setf nodes
+              (ps:chain nodes
+                        (slice (ps:chain nodes (find-index test-node node-beg))
+                               ;; Safe to replace with find-last-index?
+                               (1+ (ps:chain nodes (find-index test-node node-end))))))))
+
+    (let* ((match-index (ps:lisp (match-index match)))
+           (elem-beg (nyxt/ps:qs-nyxt-id (ps:@ document body)
+                                         (ps:lisp (identifier-beg match))))
+           (elem-end (nyxt/ps:qs-nyxt-id (ps:@ document body)
+                                         (ps:lisp (identifier-end match))))
+           (node-beg (ps:@ elem-beg child-nodes (ps:lisp (node-index-beg match))))
+           (node-end (ps:@ elem-end child-nodes (ps:lisp (node-index-end match))))
+           (text-beg (ps:lisp (text-index-beg match)))
+           (text-end (ps:lisp (text-index-end match)))
+           (range (create-range)))
+      (ps:chain range (set-start node-beg text-beg))
+      (ps:chain range (set-end node-end text-end))
+      (ps:try
+       ;; Possible unless a node is partially selected by the Range.
+       ;; https://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#td-partially-selected.
+       (wrap range (create-match-element match-index))
+       (:catch (error)
+         ;; When there are partially selected nodes, wrap each of the text nodes
+         ;; that account for the match.
+         (let* ((root-elem (if (ps:chain elem-beg (contains node-end))
+                               elem-beg
+                               (ps:@ elem-end parent-element)))
+                (nodes (text-nodes-within-bounds root-elem node-beg node-end)))
+           (loop with last-index = (1- (ps:chain nodes length))
+                 for i from 0 to last-index
+                 do (cond ((= i 0)
+                           (let ((range (create-range)))
+                             (ps:chain range (select-node-contents node-beg))
+                             (ps:chain range (set-start node-beg text-beg))
+                             (wrap range (create-match-element match-index))))
+                          ((= i last-index)
+                           (let ((range (create-range)))
+                             (ps:chain range (select-node-contents node-end))
+                             (ps:chain range (set-end node-end text-end))
+                             (wrap range (create-match-element match-index))))
+                          (t
+                           (let ((range (create-range)))
+                             (ps:chain range (select-node-contents (ps:getprop nodes i)))
+                             (wrap range (create-match-element match-index))))))))))))
+
+(defmethod css-selector ((match search-match))
+  "TODO"
+  (format nil "span[nyxt-search-hint=\"~a\"]" (match-index match)))
+
+;; Rename to hint-current-match?
+(defmethod highlight-current-match ((match search-match) &key (scroll t))
+  "TODO"
+  (ps-eval :buffer (buffer match)
+    (let ((selector (ps:lisp (css-selector match))))
+      (ps:dolist (elem (nyxt/ps:qsa (ps:@ document body) "span.nyxt-current-search-hint"))
+        (ps:chain elem class-list (remove "nyxt-current-search-hint")))
+      (ps:dolist (elem (nyxt/ps:qsa (ps:@ document body) selector))
+        (ps:chain elem class-list (add "nyxt-current-search-hint")))
+      ;; take the first element that has the match span and scroll that one.
+      (when (ps:lisp scroll)
+        ;; why can this element be null?
+        (let ((match (nyxt/ps:qs (ps:@ document body) selector)))
+          (when match
+            (ps:chain match (scroll-into-view (ps:create block "center")))))))))
+
+(defmethod invisible-p ((match search-match))
+  "TODO"
+  (ps-eval :buffer (buffer match)
+    (let ((elem (nyxt/ps:qs (ps:@ document body) (ps:lisp (css-selector match)))))
+          (and elem (nyxt/ps:element-invisible-p elem)))))
+
+;; move to utilities.lisp?
+;; the min length is (+ len-match (* len-ellipsis 2))
+;; if len-max is lower than that, scream with an error
+;; This is much more powerful than sera:ellipsize.  Consider contributing.
+;; There is also str:shorten.
+(defun centered-ellipsize (str beg end &key (len-max 40) (ellipsis "[...]"))
+  "TODO"
+  (let ((len-str (length str))
+        (len-ellipsis (length ellipsis))
+        (len-match (1+ (- end beg))))
+    (cond ((or (< beg 0) (> end len-str)) (error "Match out of bounds."))
+          ((>= len-max len-str) str)
+          ((> len-match len-max)
+           (str:concat (subseq str 0 (- len-max len-ellipsis))
+                       ellipsis))
+          ((> len-str len-max)
+           (let* ((delta (floor (/ (- len-max len-match) 2)))
+                  (new-beg (max 0 (- beg delta)))
+                  (new-end (min len-str (+ end delta)))
+                  (beg-omitted-p (not (zerop new-beg)))
+                  (end-omitted-p (not (= new-end len-str))))
+             (str:concat (when beg-omitted-p ellipsis)
+                         (subseq str
+                                 (if beg-omitted-p (+ new-beg len-ellipsis) new-beg)
+                                 (if end-omitted-p (- new-end len-ellipsis) new-end))
+                         (when end-omitted-p ellipsis)))))))
 
 (defmethod prompter:object-attributes ((match search-match) (source prompter:source))
-  `(("Text" ,(body match) nil 3)
-    ("ID" ,(identifier match))
+  ;; BUG search for "a" in Quebec and see that the Text attribute is wrong.
+  `(("Text" ,(let* ((pattern (pattern match))
+                    (body (body match))
+                    (beg (search pattern body :test (or (test-function source)
+                                                        (smart-case-test pattern)))))
+               (centered-ellipsize body beg (+ beg (length pattern))))
+            nil 3)
+    ;; Is this ID needed?
     ("Buffer ID" ,(id (buffer match)))
+    ;; Maybe add an attribute that shows the search number
     ("Buffer title" ,(title (buffer match)) nil 2)))
 
-(defun matches-from-js (matches-js-array &optional (buffer (current-buffer)))
-  (loop for element in matches-js-array
-        collect (make-instance 'search-match
-                               :identifier (gethash "identifier" element)
-                               :body (gethash "body" element)
-                               :buffer buffer)))
+;; Taken from libraries/prompter/filter-preprocessor.lisp
+;; Add to utilities?
+(defun smart-case-test (string)
+  (if (str:downcasep string)
+      #'string-equal
+      #'string=))
 
-(define-command remove-search-hints (&key (node-class-name *node-class-name*))
+;; Rename fn name and found-pattern/full-match-p names?
+(defun search-contiguous (pattern str &key (found-pattern nil)
+                                        (full-match-p nil)
+                                        (test #'string=))
+  "TODO"
+  (cond
+    ((or (str:empty? pattern) (str:empty? str)) nil)
+    ((string= "" (str:prefix (list found-pattern pattern)))
+     (error (format nil "~a isn't a prefix of ~a" found-pattern pattern)))
+    ((str:empty? found-pattern)
+     (loop with delta = (if full-match-p
+                            pattern
+                            (subseq pattern 0 (1- (length pattern))))
+           with len-str = (length str)
+           for i downfrom (min (length delta) (length str)) to 1
+           for beg = (search delta str :end1 i :start2 (- len-str i) :test test)
+           when beg
+             do (return (values (str:concat found-pattern (subseq delta 0 i))
+                                (list beg (+ beg i))))
+             and do (loop-finish)))
+    (t
+     (alex:when-let* ((delta (sera:string-replace found-pattern pattern ""))
+                      (len-delta (min (length delta) (length str)))
+                      (beg (search delta str :end1 len-delta :end2 len-delta :test test)))
+       (values (str:concat found-pattern (subseq delta 0 len-delta))
+               (list beg (+ beg len-delta)))))))
+
+(defun search-all (pattern str &key (test #'string=))
+  "TODO"
+  (loop with match-indices with len = (length pattern) with beg = 0
+        while beg
+        when (setf beg (search pattern str :start2 beg :test test))
+          do (push (list beg (incf beg len)) match-indices)
+        finally (return (nreverse match-indices))))
+
+;; This used to be called query-buffer.
+;; TODO add renderer test that tests highlight-matches-p.
+(export-always 'search-document)
+(defun search-document (pattern &key buffer node (highlight-matches-p nil)
+                                  (test #'string-equal))
+  (let ((matches) (partial-match) (seen) (match-index 0))
+    (labels
+        ((traverse-dfs (node)
+           "TODO"
+           (loop for child across (plump:children node) and index from 0
+                 do (typecase child
+                      (plump:fulltext-element)
+                      (nyxt/dom:noscript-element)
+                      (plump:nesting-node (traverse-dfs child))
+                      (plump:text-node
+                       (let ((text (plump:text child)))
+                         ;; Matches circumscribed to a single node
+                         (loop with id = (nyxt/dom:get-nyxt-id node)
+                               for match in (search-all pattern text :test test)
+                               do (push (make-instance 'search-match
+                                                       :pattern pattern
+                                                       :element node
+                                                       :match-index (incf match-index)
+                                                       :identifier-beg id
+                                                       :identifier-end id
+                                                       :node-index-beg index
+                                                       :node-index-end index
+                                                       :text-index-beg (first match)
+                                                       :text-index-end (second match)
+                                                       :body text
+                                                       :buffer buffer)
+                                        matches))
+                         ;; Matches spanning multiple nodes
+                         (multiple-value-bind (patt bounds)
+                             ;; Either match with what has been found thus
+                             ;; far, or from scratch.
+                             ;; FIXME This is ugly...
+                             (if (search-contiguous pattern text :found-pattern seen :test test)
+                                 (search-contiguous pattern text :found-pattern seen :test test)
+                                 (search-contiguous pattern text :test test))
+                           ;; This wouldn't be needed if patt could be
+                           ;; replaced with seen in multiple-value-bind.
+                           ;; I think pushing the let inside labels will
+                           ;; probably fix it.
+                           (setf seen patt)
+                           (cond ((str:empty? seen)
+                                  (setf partial-match nil))
+                                 ((and (null partial-match)
+                                       ;; seems useless, test!
+                                       (not (funcall test seen pattern)))
+                                  (setf partial-match
+                                        (make-instance 'search-match
+                                         :pattern pattern
+                                         ;; TODO Is :element set correctly?
+                                         :element (plump:parent node)
+                                         :identifier-beg (nyxt/dom:get-nyxt-id node)
+                                         :node-index-beg index
+                                         :text-index-beg (first bounds)
+                                         :body text
+                                         :buffer buffer)))
+                                 ((not (funcall test seen pattern))
+                                  (setf (body partial-match)
+                                        (str:concat (body partial-match) text)))
+                                 (t
+                                  (setf (identifier-end partial-match)
+                                        (nyxt/dom:get-nyxt-id node)
+                                        (node-index-end partial-match)
+                                        index
+                                        (text-index-end partial-match)
+                                        (second bounds)
+                                        (body partial-match)
+                                        (str:concat (body partial-match) text)
+                                        (match-index partial-match)
+                                        (incf match-index))
+                                  (push partial-match matches)
+                                  (setf partial-match nil
+                                        seen nil))))))))))
+      (traverse-dfs node))
+    ;; Highlighting logic.
+    (cond ((null highlight-matches-p)
+           (setf matches (nreverse matches)))
+          ((integerp highlight-matches-p)
+           (setf matches (nreverse matches))
+           (loop for match in (nreverse (sera:firstn highlight-matches-p matches))
+                 do (setf (highlighted-p match) t))
+           matches)
+          (t
+           (loop for match in matches
+                 do (setf (highlighted-p match) t))
+           (setf matches (nreverse matches))))))
+
+(define-command remove-search-hints (&optional (buffer (current-buffer)))
   "Remove all search hints."
-  (ps-eval (ps:dolist (node (nyxt/ps:qsa document (+ "." (ps:lisp node-class-name))))
-             (ps:chain node (replace-with (aref *nodes* (ps:@ node id)))))))
+  (ps-eval :buffer buffer
+    (dolist (match (nyxt/ps:qsa (ps:@ document body) "span[nyxt-search-hint]"))
+      (let ((parent (ps:chain match parent-element)))
+        (ps:chain match (insert-adjacent-h-t-m-l "beforebegin"
+                                                 (ps:@ match inner-h-t-m-l)))
+        (ps:chain match (remove))
+        ;; Ensure text nodes aren't empty and adjacent ones are concatenated.
+        (ps:chain parent (normalize))))))
 
-(defun prompt-buffer-suggestion-highlight-hint (&key suggestions scroll follow
-                                                 (prompt-buffer (current-prompt-buffer))
-                                                 (buffer (current-buffer)))
-  (let ((hint (flet ((hintp (hint-suggestion)
-                       (if (typep hint-suggestion '(or plump:element search-match))
-                           hint-suggestion
-                           nil)))
-                (if suggestions
-                    (hintp (prompter:value (first suggestions)))
-                    (when prompt-buffer
-                      (hintp (current-suggestion-value)))))))
-    (when hint
-      (when (and follow
-                 (slot-exists-p hint 'buffer)
-                 (not (equal (buffer hint) buffer)))
-        (set-current-buffer (buffer hint))
-        (setf buffer (buffer hint)))
-      (if (or
-           (not (slot-exists-p hint 'buffer))
-           (and (slot-exists-p hint 'buffer)
-                (equal (buffer hint) buffer)))
-          (with-current-buffer buffer
-            (nyxt/hint-mode:highlight-selected-hint :element hint
-                                                    :scroll scroll))
-          (nyxt/hint-mode:unhighlight-selected-hint)))))
-
+;; Maybe rename to search-buffer-match-source
 (define-class search-buffer-source (prompter:source)
-  ((case-sensitive-p nil)
+  ((prompter:name "Search")
    (buffer (current-buffer))
-   (minimum-search-length 1)
-   (prompter:name "Search buffer")
+   ;; This isn't possible because it references the buffer...
+   ;; (root-node
+   ;;  (elt (clss:select "body" (document-model buffer))
+   ;;       0))
+   (test-function
+    ;; when nil use the logic behind smart-case-test.
+    nil
+    :type (or null function)
+    ;; TODO
+    :documentation "The function that determines whether a search match is found.
+
+You can redefine it to enable regex-based search, for example:
+\(define-configuration nyxt/search-buffer-mode:search-buffer-mode
+  ((nyxt/search-buffer-mode:test-function #'cl-ppcre:scan)))")
+   (maximum-hinted-matches
+    1001
+    :type integer
+    :documentation "TODO")
+   (initial-delay
+    0.25
+    :documentation "Seconds to wait before searching.
+Takes effect when the search pattern's length is less than `no-delay-length'.")
+   (no-delay-length
+    3
+    :documentation "Search starts immediately for patterns at least this long.
+For shorter search patterns, `initial-delay' applies.")
+   ;; This is obsolete if I implement lazy highlighting.
    (prompter:actions-on-current-suggestion-enabled-p t)
    (prompter:filter nil)
+   ;; filter-preprocessor is being used as the constructor, i.e. the mechanism
+   ;; to set the suggestions
    (prompter:filter-preprocessor
     (lambda (preprocessed-suggestions source input)
       (declare (ignore preprocessed-suggestions))
-      (if (>= (length input) (minimum-search-length source))
-          (let ((input (str:replace-all " " " " input))
-                (buffer (buffer source)))
-            (with-current-buffer buffer
-              (matches-from-js
-               (query-buffer
-                :query input
-                :case-sensitive-p (case-sensitive-p source))
-               buffer)))
-          (progn
-            (remove-search-hints)
-            '()))))
+      ;; call smart-case-test here.
+      (let ((buffer (buffer source)))
+        (remove-search-hints buffer)
+        (unless (str:empty? input)
+          (when (< (length input) (no-delay-length source))
+            ;; Allow time for next keystroke to avoid long computations (see
+            ;; `prompter::update-thread').
+            (sleep (initial-delay source)))
+          (search-document input
+                           ;; add node as class slot
+                           :buffer buffer
+                           :node (alex:first-elt (clss:select "body"
+                                                   (document-model buffer)))
+                           :test (or (test-function source) (smart-case-test input))
+                           :highlight-matches-p (maximum-hinted-matches source))))))
    (prompter:actions-on-current-suggestion
     (lambda-command highlight-match (suggestion)
+      ;; TODO
       "Scroll to search match."
-      ;; TODO: rewrite prompt-buffer-suggestion-highlight-hint
       (set-current-buffer (buffer suggestion) :focus nil)
-      (prompt-buffer-suggestion-highlight-hint :scroll t)))
+      (maybe-update-highlighting suggestion (current-source))
+      (when (invisible-p suggestion)
+        (setf (slot-value (current-source) 'prompter:suggestions)
+              (delete suggestion
+                      (slot-value (current-source) 'prompter:suggestions)
+                      :key #'prompter:value))
+        ;; FIXME Hack that enables the above deletion to cascade.
+        (prompter:run-action-on-current-suggestion (current-prompt-buffer)))
+      (highlight-current-match suggestion)))
+   (prompter:constructor (lambda (source)
+                           (add-stylesheet (style (find-submode 'search-buffer-mode))
+                                           (buffer source))))
    (prompter:destructor (lambda (prompter source)
-                          (declare (ignore prompter source))
-                          (unless (keep-search-hints-p (current-buffer))
-                            (remove-search-hints))
-                          (nyxt/hint-mode:unhighlight-selected-hint))))
+                          (declare (ignore prompter))
+                          (unless (keep-search-hints-p (buffer source))
+                            (remove-search-hints)))))
   (:export-accessor-names-p t)
   (:export-class-name-p t)
   (:metaclass user-class))
 
-(defmethod initialize-instance :after ((source search-buffer-source) &key)
-  (setf (prompter:name source)
-        (format nil "~a (~a+ characters)"
-                (prompter:name source)
-                (minimum-search-length source))))
+;; TODO Add tests?
+(defmethod maybe-update-highlighting (current-match (source search-buffer-source))
+  (unless (highlighted-p current-match)
+    (let* ((matches (mapcar #'prompter:value (prompter:suggestions source)))
+           (match-batch (find current-match
+                              (sera:batches matches (maximum-hinted-matches source))
+                              :test #'member)))
+      ;; Add method that would set highlighted-p to nil?  Not sure, since it's
+      ;; probably faster to remove all hints in one go.
+      (remove-search-hints (buffer source))
+      (mapcar (lambda (match) (setf (highlighted-p match) nil)) matches)
+      (mapcar (lambda (match) (setf (highlighted-p match) t)) (nreverse match-batch)))))
 
-(define-command search-buffer (&key case-sensitive-p)
+;; TODO Add option to pass input?
+(define-command search-buffer ()
   "Search on the current buffer.
 If you want to remove the search hints when you close the search
 prompt, Set BUFFER's `keep-search-hints-p' slot to nil.
@@ -256,28 +446,29 @@ Example:
 
   (define-configuration buffer
     ((keep-search-hints-p nil)))"
-  (prompt :prompt "Search text"
-          :sources (make-instance 'search-buffer-source
-                                  :case-sensitive-p case-sensitive-p
-                                  :actions-on-return
-                                  (lambda (search-match)
-                                    (unless (keep-search-hints-p (current-buffer))
-                                      (remove-search-hints))
-                                    search-match))))
+  (let ((source (make-instance 'search-buffer-source
+                               :actions-on-return
+                               (lambda (search-match)
+                                 (unless (keep-search-hints-p (current-buffer))
+                                   (remove-search-hints))
+                                 search-match))))
+    (prompt :prompt (prompter:name source)
+            :sources source)))
 
-(define-command search-buffers (&key case-sensitive-p)
+(define-class search-buffers-source (buffer-source)
+  ((prompter:actions-on-return #'identity)))
+
+(define-command search-buffers ()
   "Search multiple buffers."
-  (let ((buffers (prompt :prompt "Search buffer(s)"
-                         :sources (make-instance 'buffer-source ; TODO: Define class?
-                                                 :actions-on-return #'identity
-                                                 :enable-marks-p t))))
-    (prompt
-     :prompt "Search text"
-     :sources (mapcar (lambda (buffer)
-                        (make-instance 'search-buffer-source
-                                       :name (format nil "Search ~a" (if (url-empty-p (url buffer))
-                                                                         (title buffer)
-                                                                         (url buffer)))
-                                       :case-sensitive-p case-sensitive-p
-                                       :buffer buffer))
-                      buffers))))
+  (let* ((buffers (prompt :prompt "Buffers"
+                          :sources (make-instance 'search-buffers-source)))
+         (sources (mapcar (lambda (buffer)
+                            (make-instance 'search-buffer-source
+                                           :name (format nil "Search ~a"
+                                                         (if (url-empty-p (url buffer))
+                                                             (title buffer)
+                                                             (url buffer)))
+                                           :buffer buffer))
+                          buffers)))
+    (prompt :prompt "Search"
+            :sources sources)))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -2,11 +2,11 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/search-buffer-mode
-    (:documentation "Mode for element hints."))
+    (:documentation "Incremental buffer search."))
 (in-package :nyxt/search-buffer-mode)
 
 (define-mode search-buffer-mode ()
-  "Mode for searching text withing."
+  "Incremental search on a single or multiple buffers."
   ((visible-in-status-p nil)
    (rememberable-p nil)
    (style

--- a/source/parenscript-macro.lisp
+++ b/source/parenscript-macro.lisp
@@ -159,3 +159,11 @@
          (progn (loop while (and el (not (eq el element)))
                       do (setf el (chain el parent-node)))
                 (null el)))))
+
+(export-always 'element-invisible-p)
+(defpsmacro element-invisible-p (element)
+  "Whether ELEMENT is invisible."
+  `(or (= (@ ,element offset-height)
+          0)
+       (= (chain window (get-computed-style ,element) "visibility")
+          "hidden")))

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -118,6 +118,17 @@ If `setf'-d to a list of two values -- set Y to `first' and X to `second' elemen
                              (ps:chain element text-content))))
     (ps:chain result (slice 0 (ps:lisp limit)))))
 
+(export-always 'add-stylesheet)
+(defun add-stylesheet (style &optional (buffer (current-buffer)))
+  (ps-eval :async t :buffer buffer
+    (unless (nyxt/ps:qs document "#nyxt-stylesheet")
+      (ps:try
+       (ps:let ((style-element (ps:chain document (create-element "style"))))
+         (setf (ps:@ style-element id) "nyxt-stylesheet")
+         (ps:chain document head (append-child style-element))
+         (setf (ps:chain style-element inner-text) (ps:lisp style)))
+       (:catch (error))))))
+
 (defun html-write (content &optional (buffer (current-buffer)))
   (ps-eval :async t :buffer buffer
     (ps:chain document (write (ps:lisp content)))))

--- a/source/search-manual.org
+++ b/source/search-manual.org
@@ -1,0 +1,25 @@
+# Read (info "(emacs) Incremental Search")
+* Incremental Search
+Lorem.
+
+** Basic usage
+Lorem.
+
+** Actions
+
+** Multi buffer search
+
+** User options
+
+** History
+
+** Programming Interface
+Mention Lisp side vs JS.
+Mention search-document.
+
+*** Invocation
+
+*** Filters (suggestion processing)
+Mention search-buffer-source.
+
+*** Highlighting

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -163,10 +163,12 @@ been.")
         (:p "You can also view a full tree of the history for a given buffer by
 invoking the command 'buffer-history-tree'."))
 
-      (:nsection :title "Searching"
-        (:p "Nyxt can search a single buffer or multiple buffers at the same time.")
-        (:p "You can view suggestions for search results in the prompt buffer in one
-place rather than having to jump around in a buffer (or multiple buffers).")
+      (:nsection :title "Incremental Search"
+        (:p "Nyxt's search is incremental, i.e. it begins as soon as you type
+the first character of the search string.  A single or multiple buffers can be
+queried, and all results are displayed in the prompt buffer.")
+        (:p "This makes it easy to interact with results found in different URLs
+from a unified interface.")
         (:ul
          (list-command-information '(nyxt/search-buffer-mode:search-buffer
                                      nyxt/search-buffer-mode:search-buffers

--- a/tests/offline/mode/search-buffer.lisp
+++ b/tests/offline/mode/search-buffer.lisp
@@ -8,3 +8,114 @@
     (with-current-buffer buffer
       (assert-true (enable-modes* 'nyxt/search-buffer-mode:search-buffer-mode buffer))
       (assert-true (disable-modes* 'nyxt/search-buffer-mode:search-buffer-mode buffer)))))
+
+(defmacro with-dom (&body body)
+  (let ((spinneret:*html-style* :tree))
+    `(nyxt/dom:named-html-parse (spinneret:with-html-string (:body ,@body)))))
+
+(defun search-dom (pattern node)
+  (nyxt/search-buffer-mode:search-document pattern
+                                           :buffer (make-instance 'document-buffer)
+                                           :node node
+                                           :hint-p nil))
+
+(defvar *query* "match"
+  "Default query pattern for search tests.")
+
+(define-test match-in-excluded-nodes ()
+  (assert= 1
+           (length (search-dom *query* (with-dom (:a *query*) (:comment *query*)
+                                         (:style *query*)
+                                         (:script *query*) (:noscript *query*))))))
+
+(define-test match-in-simple-node ()
+  ;; A simple node is a node that has a single text node child.
+  (let* ((text-node "foo match bar match baz")
+         (matches (search-dom *query* (with-dom (:a text-node)))))
+    (assert= 2 (length matches))
+    (loop for match in matches
+          do (assert-string= text-node
+                             (nyxt/search-buffer-mode::body match))
+          do (assert-string= text-node
+                             (plump:text (first (nyxt/search-buffer-mode::nodes match)))))))
+
+(define-test match-in-node ()
+  (let ((matches (search-dom *query*
+                             (with-dom (:a (:a "foo") "match" (:a "bar") (:a "match"))))))
+    (assert= 2 (length matches))
+    (loop for match in matches
+          do (assert-string= *query*
+                             (nyxt/search-buffer-mode::body match))
+          do (assert-string= *query*
+                             (plump:text (first (nyxt/search-buffer-mode::nodes match)))))))
+
+(define-test match-spanning-sibling-nodes ()
+  ;; Match
+  (let ((matches (search-dom *query*
+                          (with-dom (:a "m") (:a "a") (:a "t") (:a "c") (:a "h")
+                            (:a "foo") (:a "mat") (:b "ch")))))
+    (assert= 2 (length matches))
+    (mapcar (lambda (match) (assert-string= *query* (nyxt/search-buffer-mode::body match)))
+            matches)
+    (assert= 5 (length (nyxt/search-buffer-mode::nodes (first matches))))
+    (assert= 2 (length (nyxt/search-buffer-mode::nodes (second matches)))))
+  ;; Non-match
+  (let ((matches (search-dom *query* (with-dom (:a "m") (:a "foo") (:a "atch")))))
+    (assert= 0 (length matches))))
+
+(define-test match-spanning-nested-nodes ()
+  ;; Match
+  (let ((matches (search-dom *query*
+                          (with-dom (:p "ma" (:i "tc" (:b "h")))
+                            (:p "m" (:b "atch"))
+                            (:p "m" (:i "") (:b "atch"))))))
+    (assert= 3 (length matches))
+    (mapcar (lambda (match) (assert-string= *query* (nyxt/search-buffer-mode::body match)))
+            matches)
+    (assert= 3 (length (nyxt/search-buffer-mode::nodes (first matches))))
+    (assert= 2 (length (nyxt/search-buffer-mode::nodes (second matches))))
+    (assert= 2 (length (nyxt/search-buffer-mode::nodes (third matches)))))
+  ;; Non-match
+  (let ((matches (search-dom *query* (with-dom (:a "m" (:b "foo") (:b "atch"))))))
+    (assert= 0 (length matches))))
+
+(define-test search-all ()
+  (let ((search-all (curry 'nyxt/search-buffer-mode::search-all
+                           *query*)))
+    (assert-false (nyxt/search-buffer-mode::search-all "" *query*))
+    (assert-false (funcall search-all "foo"))
+    (assert-equal '((0 5) (10 15))
+                  (funcall search-all (str:concat *query* " foo " *query*)))))
+
+(defun assert-str-empty (str)
+  "Assert whether STR is nil or the empty string."
+  (assert-true (str:empty? str)))
+
+(define-test search-contiguous ()
+  (let ((search-contiguous (curry 'nyxt/search-buffer-mode::search-contiguous
+                                  *query*)))
+    (assert-str-empty (nyxt/search-buffer-mode::search-contiguous "" "foo"))
+    (assert-str-empty (nyxt/search-buffer-mode::search-contiguous "foo" ""))
+    (assert-error 'error (funcall search-contiguous "mat" :found-pattern "h"))
+    (assert-equal (values "m" '(4 5))
+                  (funcall search-contiguous "foo m"))
+    (assert-equal (values "matc" '(4 8))
+                  (funcall search-contiguous "foo matc"))
+    (assert-str-empty (funcall search-contiguous "foo match"))
+    (assert-equal (values "match" '(4 9))
+                  (funcall search-contiguous "foo match" :full-match-p t))
+    (assert-equal (values "ma" '(0 1))
+                  (funcall search-contiguous "a" :found-pattern "m"))
+    (assert-str-empty (funcall search-contiguous "foo a" :found-pattern "m"))
+    (assert-str-empty (funcall search-contiguous "a foo" :found-pattern "m"))
+    (assert-equal (values "mat" '(0 1))
+                  (funcall search-contiguous "t" :found-pattern "ma"))
+    (assert-str-empty (funcall search-contiguous "foo t" :found-pattern "ma"))
+    (assert-str-empty (funcall search-contiguous "t foo" :found-pattern "ma"))
+    (assert-equal (values "matc" '(0 1))
+                  (funcall search-contiguous "c" :found-pattern "mat"))
+    (assert-str-empty (funcall search-contiguous "foo c" :found-pattern "mat"))
+    (assert-str-empty (funcall search-contiguous "c foo" :found-pattern "mat"))
+    (assert-equal (values *query* '(0 1))
+                  (funcall search-contiguous "h foo" :found-pattern "matc"))
+    (assert-str-empty (funcall search-contiguous "foo h" :found-pattern "matc"))))

--- a/tests/renderer-offline/search-buffer.lisp
+++ b/tests/renderer-offline/search-buffer.lisp
@@ -1,0 +1,51 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nyxt/tests/renderer)
+
+;; TODO Add test checking the DOM state after adding spans.
+;; Test for the case when elem-beg lies deeper than elem-end.
+
+;; invariant: matches are collected from the back
+
+(define-internal-page test-search-buffer (&key)
+    (:title "*Search buffer test*")
+  "TODO"
+  (spinneret:with-html-string (:body (:p "re" (:i "su" (:b "lt"))))))
+
+;; TODO rethink tests.
+(define-test immutable-dom-after-search ()
+  (labels ((get-page-body ()
+             "TODO"
+             (let ((dom (plump:parse (ffi-buffer-get-document (current-buffer)))))
+               (plump:serialize (alex:first-elt (clss:select "body" dom)) nil)))
+           (body-after-search (pattern)
+             "TODO"
+             (reload-buffer (current-buffer))
+             (sleep 0.1)
+             (nyxt/search-buffer-mode:search-document
+              pattern
+              :buffer (current-buffer)
+              :node (alex:first-elt (clss:select "body"
+                                      (document-model (current-buffer))))
+              :hint-p t)
+             (sleep 0.1)
+             (nyxt/search-buffer-mode:remove-search-hints)
+             (sleep 0.1)
+             (get-page-body)))
+    (nyxt:start :no-config t :no-auto-config t :headless t
+                :socket "/tmp/nyxt-test.socket" :profile "test")
+    (buffer-load-internal-page-focus 'test-search-buffer)
+    (sleep 0.5)
+    (let ((expected-body (get-page-body)))
+      (assert-string= expected-body
+                      (body-after-search "l"))
+      (assert-string= expected-body
+                      (body-after-search "ul"))
+      (assert-string= expected-body
+                      (body-after-search "sul"))
+      (assert-string= expected-body
+                      (body-after-search "esul"))
+      (assert-string= expected-body
+                      (body-after-search "result")))
+    (nyxt:quit)))


### PR DESCRIPTION
# Description

This PR follows the strategy started in #2424, but the implementation is completely new.

It fixes long standing issues, and goes beyond the features of the old `search-buffer` capabilities.

Closes #1204.
Closes #2504.
Closes #1555. 
Closes #1237.
Closes #1169.


# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [ ] I have pulled from master before submitting this PR
- [ ] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [ ] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
