### PR TITLE
Allow bindings commands to context menu actions.

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -492,7 +492,9 @@ the selection, and the string to paste instead of the clipboard (respectively)."
    (:li "Add " (:nxref :command 'edit-file-with-external-editor)
         " to edit arbitrary files in the editor of choice.")
    (:li (:code "peval") " and " (:code "pflet") " renamed to " (:nxref :function 'ps-eval) " and "
-        (:nxref :function 'ps-labels) " (respectively)."))
+        (:nxref :function 'ps-labels) " (respectively).")
+   (:li "Add " (:nxref :function 'ffi-add-context-menu-command)
+        " to add custom context menu commands."))
 
   (:h3 "Bug fixes")
   (:ul

--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -363,3 +363,20 @@ Return the text cut."))
   (:method ((buffer t))
     (echo-warning "Redoing edits is not yet implemented for this renderer."))
   (:documentation "Redo the last undone text edit performed in BUFFER's web view."))
+
+(defvar *context-menu-commands* (make-hash-table)
+  "A hash table from command symbols to context menu labels for those.
+Once a context menu appears, those commands will be added to it as actions with
+the labels they have as hash values.")
+
+(define-ffi-generic ffi-add-context-menu-command (command &optional label)
+  (:method :around ((command command) &optional label)
+    (call-next-method command (or label (format nil "~:(~a~)" (str:remove-punctuation (symbol-name (name command)))))))
+  (:method ((command command) &optional label)
+    (setf (gethash (name command) *context-menu-commands*)
+          label))
+  (:method ((command symbol) &optional label)
+    (ffi-add-context-menu-command (symbol-function command) label))
+  (:documentation "Add COMMAND as accessible in context menus with LABEL displayed for it.
+If LABEL is not provided, it's auto-generated from the command name.
+COMMAND should be either a symbol naming an already defined command, or the command object itself."))

--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -371,7 +371,7 @@ the labels they have as hash values.")
 
 (define-ffi-generic ffi-add-context-menu-command (command &optional label)
   (:method :around ((command command) &optional label)
-    (call-next-method command (or label (format nil "~:(~a~)" (str:remove-punctuation (symbol-name (name command)))))))
+    (call-next-method command (or label (str:capitalize (str:remove-punctuation (symbol-name (name command)))))))
   (:method ((command command) &optional label)
     (setf (gethash (name command) *context-menu-commands*)
           label))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -223,7 +223,15 @@ Lisp function, except the form is " (:code "define-command") " instead of "
               :sources 'prompter:raw-source)))
     (bookmark-add url)))"))
         (:p "See the " (:nxref :class-name 'prompt-buffer) " class documentation for how
-to write custom prompt-buffers."))
+to write custom prompt-buffers.")
+        (:p "You can also create your own context menu entries binding those to Lisp commands, using "
+            (:nxref :function 'ffi-add-context-menu-command) " function. You can bind the "
+            (:code "bookmark-url") " like this:")
+        (:pre (:code "(ffi-add-context-menu-command 'boorkmark-url \"Bookmark the chosen URL\")"))
+        (:p "Currently, context menu commands don't have access to the renderer objects (and
+shouldn't hope to). Commands you bind to context menu actions should deduce most
+of the information from their surroundings, using JavaScript and Lisp functions
+Nyxt provides."))
 
       (:nsection :title "Custom URL schemes"
         (:p "If there's a scheme that Nyxt doesn't support, but you want it to, you can

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1598,12 +1598,12 @@ See `finalize-buffer'."
                       (context-commands (alex:hash-table-keys *context-menu-commands*))
                       (accessible-context-commands (intersection accessible-commands context-commands)))
         (dolist (command accessible-context-commands)
-          (let* ((label (gethash command *context-menu-commands*))
-                 ;; Using stock actions here, because cl-cffi-gtk has a
-                 ;; terrible API for GActions, requiring an exact type to be
-                 ;; passed and disallowing NULL as a type :/
-                 (item (webkit:webkit-context-menu-item-new-from-stock-action-with-label
-                        :webkit-context-menu-action-action-custom label)))
+          ;; Using stock actions here, because cl-cffi-gtk has a terrible API
+          ;; for GActions, requiring an exact type to be passed and disallowing
+          ;; NULL as a type :/
+          (let ((item (webkit:webkit-context-menu-item-new-from-stock-action-with-label
+                       :webkit-context-menu-action-action-custom
+                       (gethash command *context-menu-commands*))))
             (gobject:g-signal-connect
              (webkit:webkit-context-menu-item-get-g-action item) "activate"
              (lambda (action parameter)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1588,28 +1588,28 @@ See `finalize-buffer'."
                   i))))))
       (webkit:webkit-context-menu-append
        context-menu (webkit:webkit-context-menu-item-new-separator))
-      (unless (zerop (hash-table-count *context-menu-commands*))
-        (let* ((accessible-commands
-                 (mapcar #'name
-                         (list-commands
-                          :global-p t
-                          :mode-symbols (mapcar #'sera:class-name-of
-                                                (sera:filter #'enabled-p (modes buffer))))))
-               (context-commands (alex:hash-table-keys *context-menu-commands*))
-               (accessible-context-commands (intersection accessible-commands context-commands)))
-          (dolist (command accessible-context-commands)
-            (let* ((label (gethash command *context-menu-commands*))
-                   ;; Using stock actions here, because cl-cffi-gtk has a
-                   ;; terrible API for GActions, requiring an exact type to be
-                   ;; passed and disallowing NULL as a type :/
-                   (item (webkit:webkit-context-menu-item-new-from-stock-action-with-label
-                          :webkit-context-menu-action-action-custom label)))
-              (gobject:g-signal-connect
-               (webkit:webkit-context-menu-item-get-g-action item) "activate"
-               (lambda (action parameter)
-                 (declare (ignore action parameter))
-                 (run-async command)))
-              (webkit:webkit-context-menu-append context-menu item))))))
+      (sera:and-let* ((_ (plusp (hash-table-count *context-menu-commands*)))
+                      (accessible-commands
+                       (mapcar #'name
+                               (list-commands
+                                :global-p t
+                                :mode-symbols (mapcar #'sera:class-name-of
+                                                      (sera:filter #'enabled-p (modes buffer))))))
+                      (context-commands (alex:hash-table-keys *context-menu-commands*))
+                      (accessible-context-commands (intersection accessible-commands context-commands)))
+        (dolist (command accessible-context-commands)
+          (let* ((label (gethash command *context-menu-commands*))
+                 ;; Using stock actions here, because cl-cffi-gtk has a
+                 ;; terrible API for GActions, requiring an exact type to be
+                 ;; passed and disallowing NULL as a type :/
+                 (item (webkit:webkit-context-menu-item-new-from-stock-action-with-label
+                        :webkit-context-menu-action-action-custom label)))
+            (gobject:g-signal-connect
+             (webkit:webkit-context-menu-item-get-g-action item) "activate"
+             (lambda (action parameter)
+               (declare (ignore action parameter))
+               (run-async command)))
+            (webkit:webkit-context-menu-append context-menu item)))))
     nil)
   (connect-signal buffer "enter-fullscreen" nil (web-view)
     (declare (ignore web-view))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1595,9 +1595,8 @@ See `finalize-buffer'."
                                 :global-p t
                                 :mode-symbols (mapcar #'sera:class-name-of
                                                       (sera:filter #'enabled-p (modes buffer))))))
-                      (context-commands (alex:hash-table-keys *context-menu-commands*))
-                      (accessible-context-commands (intersection accessible-commands context-commands)))
-        (dolist (command accessible-context-commands)
+                      (context-commands (alex:hash-table-keys *context-menu-commands*)))
+        (dolist (command (intersection accessible-commands context-commands))
           ;; Using stock actions here, because cl-cffi-gtk has a terrible API
           ;; for GActions, requiring an exact type to be passed and disallowing
           ;; NULL as a type :/

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1585,7 +1585,31 @@ See `finalize-buffer'."
                   (webkit:webkit-context-menu-item-new-from-stock-action-with-label
                    :webkit-context-menu-action-open-link-in-new-window
                    "Open Link in New Buffer")
-                  i)))))))
+                  i))))))
+      (webkit:webkit-context-menu-append
+       context-menu (webkit:webkit-context-menu-item-new-separator))
+      (unless (zerop (hash-table-count *context-menu-commands*))
+        (let* ((accessible-commands
+                 (mapcar #'name
+                         (list-commands
+                          :global-p t
+                          :mode-symbols (mapcar #'sera:class-name-of
+                                                (sera:filter #'enabled-p (modes buffer))))))
+               (context-commands (alex:hash-table-keys *context-menu-commands*))
+               (accessible-context-commands (intersection accessible-commands context-commands)))
+          (dolist (command accessible-context-commands)
+            (let* ((label (gethash command *context-menu-commands*))
+                   ;; Using stock actions here, because cl-cffi-gtk has a
+                   ;; terrible API for GActions, requiring an exact type to be
+                   ;; passed and disallowing NULL as a type :/
+                   (item (webkit:webkit-context-menu-item-new-from-stock-action-with-label
+                          :webkit-context-menu-action-action-custom label)))
+              (gobject:g-signal-connect
+               (webkit:webkit-context-menu-item-get-g-action item) "activate"
+               (lambda (action parameter)
+                 (declare (ignore action parameter))
+                 (run-async command)))
+              (webkit:webkit-context-menu-append context-menu item))))))
     nil)
   (connect-signal buffer "enter-fullscreen" nil (web-view)
     (declare (ignore web-view))


### PR DESCRIPTION
# Description

This allows binding Lisp commands to context menu actions with the help of the new `ffi-add-context-menu-command`. Those actions are only available when the respecitve command is (which means always for global commands, and only when the mode is enabled—for mode-specific ones). It's quite basic, which might be a good reason it works in the first place xD

# Discussion

- [ ] Any idea for a better design? Maybe include this functionality in `define-command` somehow?
- [ ] Now that I think of it, internal schemes and `define-internal-scheme` should also have an `ffi-` prefix, shouldn't they? Or maybe we should provide the most intuitive interface possible, while doing the renderer-specific things based on internal information? In this case propagating context menu actions inside `define-*command-*` makes lots of sense...
- [X] I've updated `cl-webkit` to 3.5.4, incorporating all the recent useful changes. @Ambrevar, care to send a patch to Guix?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.