### PR TITLE
libraries/user-interface: rename query-select to query-selector

### DIFF
--- a/source/user-interface.lisp
+++ b/source/user-interface.lisp
@@ -10,7 +10,7 @@
    (user-interface:buffer paragraph)
    (ps:ps
      (setf (ps:chain document
-                     (query-select (ps:lisp (user-interface:id paragraph)))
+                     (query-selector (ps:lisp (user-interface:id paragraph)))
                      text-content)
            (ps:lisp (user-interface:text paragraph))))))
 
@@ -19,7 +19,7 @@
    (user-interface:buffer progress-bar)
    (ps:ps
      (setf (ps:chain document
-                     (query-select (ps:lisp (user-interface:id progress-bar)))
+                     (query-selector (ps:lisp (user-interface:id progress-bar)))
                      style
                      width)
            (ps:lisp (format nil "~,1f%" (user-interface:percentage progress-bar)))))))
@@ -29,10 +29,10 @@
    (user-interface:buffer button)
    (ps:ps
      (setf (ps:chain document
-                     (query-select (ps:lisp (user-interface:id button)))
+                     (query-selector (ps:lisp (user-interface:id button)))
                      text-content)
            (ps:lisp (user-interface:text button)))
      (setf (ps:chain document
-                     (query-select (ps:lisp (user-interface:id button)))
+                     (query-selector (ps:lisp (user-interface:id button)))
                      onclick)
            (ps:lisp (user-interface:action button))))))


### PR DESCRIPTION
I found this while trying to download something, which resulted in an infinite loop of ParenScript errors.