### PR TITLE
User funcallable class

### DIFF
--- a/source/user-classes.lisp
+++ b/source/user-classes.lisp
@@ -3,8 +3,9 @@
 
 (in-package :nyxt)
 
-(defclass user-class (standard-class)
+(defclass user-mixin-class ()
   ((customize-hook :initform (make-instance 'hooks:hook-any)
+                   :accessor customize-hook
                    :documentation "An internal hook to add customization handlers to.
 
 Reserved for `define-configuration'.
@@ -12,16 +13,41 @@ Reserved for `define-configuration'.
 Prefer `define-configuration' and `customize-instance' instead."))
   (:documentation "Classes using this metaclass will call `customize-instance'
 on instantiation.
-This is useful to expose a class configuration knob to the user."))
+This is useful to expose a class configuration knob to the user.
+
+This class is also for portable configuration management. Imagine some
+implementation has structs totally separate from classes, and thus configuring
+structs may be possible, but would require adding yet another class. Say,
+user-structure-class. With user-mixin-class, that would be a one-liner:
+
+(defclass user-structure-class (impl:built-in-structure-class user-mixin-class) ())
+
+while having the customize-hook and other configuration functionality in 3+
+classes (user-class, user-funcallable-class, and user-structure-class in case of
+this imaginary implementation) would already be 3x+ code duplication..."))
+
+(defclass user-class (standard-class user-mixin-class)
+  ()
+  (:documentation "User-configurable value class.
+Can be configured using `customize-instance' and `customize-hook'."))
 (export-always 'user-class)
 
-(defmethod closer-mop:validate-superclass ((class user-class)
-                                           (superclass standard-class))
-  t)
+(defmethod closer-mop:validate-superclass ((class user-class) (superclass standard-class)) t)
+(defmethod closer-mop:validate-superclass ((superclass standard-class) (class user-class)) t)
+(defmethod closer-mop:validate-superclass ((class user-class) (superclass user-mixin-class)) t)
+(defmethod closer-mop:validate-superclass ((superclass user-mixin-class) (class user-class)) t)
 
-(defmethod closer-mop:validate-superclass ((superclass standard-class)
-                                           (class user-class))
-  t)
+(defclass user-funcallable-class (closer-mop:funcallable-standard-class user-mixin-class)
+  ()
+  (:documentation "User-configurable class that behaves like function.
+One can use `funcall' on it, thus funcallable.
+Can be configured using `customize-instance' and `customize-hook'."))
+(export-always 'user-funcallable-class)
+
+(defmethod closer-mop:validate-superclass ((class user-funcallable-class) (superclass closer-mop:funcallable-standard-class)) t)
+(defmethod closer-mop:validate-superclass ((superclass closer-mop:funcallable-standard-class) (class user-funcallable-class)) t)
+(defmethod closer-mop:validate-superclass ((class user-funcallable-class) (superclass user-mixin-class)) t)
+(defmethod closer-mop:validate-superclass ((superclass user-mixin-class) (class user-funcallable-class)) t)
 
 (export-always 'customize-instance)
 (defgeneric customize-instance (object &key &allow-other-keys)
@@ -39,34 +65,7 @@ Do not specialize the standard method in public code, prefer
 `customize-instance :after' for code that relies on finalized slot values."))
 
 (defmethod #+nyxt-debug-make-instance cl:make-instance #-nyxt-debug-make-instance make-instance
-  :around ((class user-class) &rest initargs &key &allow-other-keys)
-  (sera:lret ((initialized-object (call-next-method)))
-    (mapcar (lambda (class)
-              (hooks:run-hook (slot-value class 'customize-hook) initialized-object))
-            (sera:filter #'user-class-p (cons class (mopu:superclasses class))))
-    (apply #'customize-instance initialized-object initargs)))
-
-(defclass user-funcallable-class (closer-mop:funcallable-standard-class)
-  ((customize-hook :initform (make-instance 'hooks:hook-any)
-                   :documentation "An internal hook to add customization handlers to.
-
-Reserved for `define-configuration'.
-
-Prefer `define-configuration' and `customize-instance' instead."))
-  (:documentation "Classes using this metaclass will call `customize-instance' on instantiation.
-This is useful to expose a class configuration knob to the user."))
-(export-always 'user-funcallable-class)
-
-(defmethod closer-mop:validate-superclass ((class user-funcallable-class)
-                                           (superclass closer-mop:funcallable-standard-class))
-  t)
-
-(defmethod closer-mop:validate-superclass ((superclass closer-mop:funcallable-standard-class)
-                                           (class user-funcallable-class))
-  t)
-
-(defmethod #+nyxt-debug-make-instance cl:make-instance #-nyxt-debug-make-instance make-instance
-  :around ((class user-funcallable-class) &rest initargs &key &allow-other-keys)
+  :around ((class user-mixin-class) &rest initargs &key &allow-other-keys)
   (sera:lret ((initialized-object (call-next-method)))
     (mapcar (lambda (class)
               (hooks:run-hook (slot-value class 'customize-hook) initialized-object))


### PR DESCRIPTION
# Description

This is a small addition as a first step to address the #2537. `user-funcallable-class`, as implemented here, is not immediately useful, as we usually initialize commands not with `make-instance` but rather with `defgeneric` and `setf`, which destroys the purpose of user configuration there. I've tried to refactor our commands to use `make-instance` instead, but it seems that this part of the spec is too rigid for dynamic generic function creation to be easy (/ω＼)

However, my idea for the future work is to initialize commands, internal pages, and panels in a `customize-instance`-friendly manner. Need to think on it for some time, though :)

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.