### PR TITLE
Use assert-string= in the test suites.

### DIFF
--- a/libraries/class-star/tests/tests.lisp
+++ b/libraries/class-star/tests/tests.lisp
@@ -8,12 +8,12 @@
 (in-package :class-star/tests)
 
 (define-test simple-class ()
-  (assert-equality 'string= "fooname"
-                   (progn
-                     (class-star:define-class foo ()
-                       ((name "fooname")))
-                     (let ((foo (make-instance 'foo)))
-                       (name-of foo)))))
+  (assert-string= "fooname"
+                  (progn
+                    (class-star:define-class foo ()
+                      ((name "fooname")))
+                    (let ((foo (make-instance 'foo)))
+                      (name-of foo)))))
 
 (define-test simple-class-with-custom-accessors ()
   (class-star:define-class bar ()
@@ -27,13 +27,13 @@
   (assert-false (fboundp 'address)))
 
 (define-test simple-class-default-value ()
-  (assert-equality 'string= ""
-                   (progn
-                     (class-star:define-class foo-default ()
-                       ((name :type string)
-                        (age :type number)))
-                     (let ((foo (make-instance 'foo-default)))
-                       (name-of foo)))))
+  (assert-string= ""
+                  (progn
+                    (class-star:define-class foo-default ()
+                      ((name :type string)
+                       (age :type number)))
+                    (let ((foo (make-instance 'foo-default)))
+                      (name-of foo)))))
 
 (define-test no-accessor ()
   (assert-false (progn
@@ -46,8 +46,8 @@
 (define-test initform-inference ()
   (class-star:define-class foo-initform-infer ()
     ((name :type string)))
-  (assert-equality 'string= ""
-                   (name-of (make-instance 'foo-initform-infer)))
+  (assert-string= ""
+                  (name-of (make-instance 'foo-initform-infer)))
   (class-star:define-class foo-initform-infer-no-unbound ()
     ((name :type function))
     (:initform-inference 'class-star:no-unbound-initform-inference))

--- a/libraries/history-tree/tests/tests.lisp
+++ b/libraries/history-tree/tests/tests.lisp
@@ -39,8 +39,8 @@
   (let ((history (make))
         (url "http://example.org"))
     (htree:add-child url history *owner*)
-    (assert-equality 'string= url
-                     (htree:data (htree:owner-node history *owner*)))))
+    (assert-string= url
+                    (htree:data (htree:owner-node history *owner*)))))
 
 (define-test multiple-entry ()
   (let ((history (make))
@@ -51,18 +51,18 @@
     (htree:add-child url2 history *owner*)
     (htree:backward history *owner*)
     (htree:add-child url3 history *owner*)
-    (assert-equality 'string= url3
-                     (htree:data (htree:owner-node history *owner*)))
-    (assert-equality 'string= url1
-                     (htree:data (htree:parent (htree:owner-node history *owner*))))
+    (assert-string= url3
+                    (htree:data (htree:owner-node history *owner*)))
+    (assert-string= url1
+                    (htree:data (htree:parent (htree:owner-node history *owner*))))
     (htree:backward history *owner*)
     (htree:go-to-child url2 history *owner*)
-    (assert-equality 'string= url2
-                     (htree:data (htree:owner-node history *owner*)))))
+    (assert-string= url2
+                    (htree:data (htree:owner-node history *owner*)))))
 
 (define-test simple-branching-tree-tests ()
-  (assert-equality 'string= "http://example.root/B2"
-                   (htree:data (htree:owner-node (make-history1) *owner*))))
+  (assert-string= "http://example.root/B2"
+                  (htree:data (htree:owner-node (make-history1) *owner*))))
 
 (define-test history-depth ()
   (assert-eq 2
@@ -134,14 +134,14 @@
 
 (define-test move-node-to-forward-child-on-add ()
   (let ((history (make-history2)))
-    (assert-equality 'string= "http://example.root/B"
-                     (htree:data (htree:owner-node history *owner*)))
+    (assert-string= "http://example.root/B"
+                    (htree:data (htree:owner-node history *owner*)))
     (htree:backward history *owner*)
-    (assert-equality 'string= "http://example.root"
-                     (htree:data (htree:owner-node history *owner*)))
+    (assert-string= "http://example.root"
+                    (htree:data (htree:owner-node history *owner*)))
     (htree:add-child "http://example.root/A" history *owner*)
-    (assert-equality 'string= "http://example.root/A"
-                     (htree:data (htree:owner-node history *owner*)))))
+    (assert-string= "http://example.root/A"
+                    (htree:data (htree:owner-node history *owner*)))))
 
 (define-class web-page ()
   ((url "")
@@ -158,16 +158,16 @@
       (htree:add-child web-page2 history *owner*)
       (assert-eq 1
                  (hash-table-count (htree:entries history)))
-      (assert-equality 'string= "Example page"
-                       (title (htree:data (htree::first-hash-table-key (htree:entries history))))))
+      (assert-string= "Example page"
+                      (title (htree:data (htree::first-hash-table-key (htree:entries history))))))
     (let ((history (make :key 'url)))
       (htree:add-child web-page1 history *owner*)
       (htree:add-owner history "b")
       (htree:add-child web-page2 history "b")
       (assert-eq 1
                  (hash-table-count (htree:entries history)))
-      (assert-equality 'string= "Example page"
-                       (title (htree:data (htree::first-hash-table-key (htree:entries history))))))
+      (assert-string= "Example page"
+                      (title (htree:data (htree::first-hash-table-key (htree:entries history))))))
     (let ((history (make)))
       (htree:add-child web-page1 history *owner*)
       (htree:add-child web-page2 history *owner*)
@@ -182,8 +182,8 @@
   (let ((history (make))
         (url1 "http://example.org"))
     (htree:add-child url1 history *owner*)
-    (assert-equality 'string= *owner*
-                     (first (alexandria:hash-table-keys (htree:owners history))))
+    (assert-string= *owner*
+                    (first (alexandria:hash-table-keys (htree:owners history))))
     (assert-eq 1
                (hash-table-count (htree:owners history)))))
 
@@ -198,16 +198,16 @@
     (htree:add-child url3 history "b")
     (assert-eq 3
                (hash-table-count (htree:entries history)))
-    (assert-equality 'string= url3
-                     (htree:data (htree:owner-node history "b")))
-    (assert-equality 'string= url2
-                     (htree:data (htree:parent (htree:owner-node history "b"))))
+    (assert-string= url3
+                    (htree:data (htree:owner-node history "b")))
+    (assert-string= url2
+                    (htree:data (htree:parent (htree:owner-node history "b"))))
     (assert-false (htree:parent (htree:parent (htree:owner-node history "b"))))
     ;; Following tests are useless now that we don't have with-current-owner anymore.
     (assert-eq 2
                (length (htree:nodes (htree:owner history "b"))))
-    (assert-equality 'string= url1
-                     (htree:data (htree:owner-node history "a")))))
+    (assert-string= url1
+                    (htree:data (htree:owner-node history "a")))))
 
 (define-test backward-and-forward ()
   (let ((history (make :owner "a"))
@@ -218,18 +218,18 @@
     (htree:add-child url2 history "a")
     (htree:add-owner history "b" :creator-id "a")
     (htree:add-child url3 history "b")
-    (assert-equality 'string= url2
-                     (htree:data (htree:owner-node history "a")))
+    (assert-string= url2
+                    (htree:data (htree:owner-node history "a")))
     (htree:backward history "a")
     (htree:backward history "a")
-    (assert-equality 'string= url1
-                     (htree:data (htree:owner-node history "a")))
+    (assert-string= url1
+                    (htree:data (htree:owner-node history "a")))
     (htree:forward history "a")
-    (assert-equality 'string= url2
-                     (htree:data (htree:owner-node history "a")))
+    (assert-string= url2
+                    (htree:data (htree:owner-node history "a")))
     (htree:forward history "a")
-    (assert-equality 'string= url2
-                     (htree:data (htree:owner-node history "a")))))
+    (assert-string= url2
+                    (htree:data (htree:owner-node history "a")))))
 
 (define-test inter-owner-relationships ()
   (let ((history (make :owner "a"))
@@ -318,8 +318,8 @@
 
     (htree:visit-all history "b" distant-node)
 
-    (assert-equality 'string= distant-node-value
-                     (htree:data (htree:owner-node history "b")))
+    (assert-string= distant-node-value
+                    (htree:data (htree:owner-node history "b")))
     (assert-equal (sort (copy-seq '("http://example.root/A1" "http://example.root/A" "http://example.root"
                                     "http://example.root/B" "http://example.root/B2" "b-data"))
                         #'string<)
@@ -336,8 +336,8 @@
     (let ((distant-node (first (htree:find-nodes history distant-node-value))))
       (htree:visit-all history *owner* distant-node))
 
-    (assert-equality 'string= distant-node-value
-                     (htree:data (htree:owner-node history *owner*)))
+    (assert-string= distant-node-value
+                    (htree:data (htree:owner-node history *owner*)))
     (assert-equal (sort (copy-seq '("http://example.root/A"
                                     "http://example.root/A1"
                                     "http://example.root/A2"
@@ -426,23 +426,23 @@
     (htree:add-child url3 history "a")
     (htree:backward history "a")
 
-    (assert-equality 'string= url1
-                     (htree:data (htree:owner-node history *owner*)))
+    (assert-string= url1
+                    (htree:data (htree:owner-node history *owner*)))
     (htree:go-to-owned-child url3 history *owner*)
-    (assert-equality 'string= url1
-                     (htree:data (htree:owner-node history *owner*)))
+    (assert-string= url1
+                    (htree:data (htree:owner-node history *owner*)))
     (htree:go-to-owned-child url2 history *owner*)
-    (assert-equality 'string= url2
-                     (htree:data (htree:owner-node history *owner*)))
+    (assert-string= url2
+                    (htree:data (htree:owner-node history *owner*)))
 
-    (assert-equality 'string= url1
-                     (htree:data (htree:owner-node history "a")))
+    (assert-string= url1
+                    (htree:data (htree:owner-node history "a")))
     (htree:go-to-owned-child url2 history "a")
-    (assert-equality 'string= url1
-                     (htree:data (htree:owner-node history "a")))
+    (assert-string= url1
+                    (htree:data (htree:owner-node history "a")))
     (htree:go-to-owned-child url3 history "a")
-    (assert-equality 'string= url3
-                     (htree:data (htree:owner-node history "a")))))
+    (assert-string= url3
+                    (htree:data (htree:owner-node history "a")))))
 
 (define-test add-children ()
   (let ((history (make))
@@ -450,12 +450,12 @@
         (url2 "https://nyxt.atlas.engineer")
         (url3 "http://en.wikipedia.org"))
     (htree:add-children (list url1 url2 url3) history *owner*)
-    (assert-equality 'string= url3
-                     (htree:data (htree:owner-node history *owner*)))
+    (assert-string= url3
+                    (htree:data (htree:owner-node history *owner*)))
     (assert-false (htree::map-data (htree:children (htree:owner-node history *owner*))))
     (htree:backward history *owner*)
-    (assert-equality 'string= url1
-                     (htree:data (htree:owner-node history *owner*)))
+    (assert-string= url1
+                    (htree:data (htree:owner-node history *owner*)))
 
     (assert-eq 2
                (length (htree:children (htree:owner-node history *owner*))))))

--- a/libraries/prompter/tests/fuzzy.lisp
+++ b/libraries/prompter/tests/fuzzy.lisp
@@ -42,38 +42,38 @@
                                      (prompter:fuzzy-match suggestion source input))
                                    (prompter::ensure-suggestions-list source list))
                            #'prompter:score>)))))
-      (assert-equality 'string= "help"
-                       (match "hel" '("help-mode" "help" "foo-help" "help-foo-bar")))
+      (assert-string= "help"
+                      (match "hel" '("help-mode" "help" "foo-help" "help-foo-bar")))
       ;; match 'help' with real suggestions list
-      (assert-equality 'string= "HELP"
-                       (match "hel" *suggestions*))
+      (assert-string= "HELP"
+                      (match "hel" *suggestions*))
       ;; match 'swit buf' (small list)
-      (assert-equality 'string= "switch-buffer"
-                       (match "swit buf" '("about" "switch-buffer-next" "switch-buffer" "delete-buffer")))
+      (assert-string= "switch-buffer"
+                      (match "swit buf" '("about" "switch-buffer-next" "switch-buffer" "delete-buffer")))
       ;; match 'swit buf' with real suggestions list
-      (assert-equality 'string= "SWITCH-BUFFER"
-                       (match "swit buf" *suggestions*))
+      (assert-string= "SWITCH-BUFFER"
+                      (match "swit buf" *suggestions*))
       ;; reverse match 'buf swit' (small list)
-      (assert-equality 'string= "switch-buffer"
-                       (match "buf swit" '("about" "switch-buffer-next" "switch-buffer" "delete-buffer")))
+      (assert-string= "switch-buffer"
+                      (match "buf swit" '("about" "switch-buffer-next" "switch-buffer" "delete-buffer")))
       ;; reverse match 'buf swit' with real suggestions list
-      (assert-equality 'string= "SWITCH-BUFFER"
-                       (match "buf swit" *suggestions*))
+      (assert-string= "SWITCH-BUFFER"
+                      (match "buf swit" *suggestions*))
       ;; suggestions beginning with the first word appear first
-      (assert-equality 'string= "delete-foo"
-                       (match "de" '("some-mode" "delete-foo")))
+      (assert-string= "delete-foo"
+                      (match "de" '("some-mode" "delete-foo")))
       ;; search without a space. All characters count (small list).
-      (assert-equality 'string= "foo-bar"
-                       (match "foobar" '("foo-dash-bar" "foo-bar")))
+      (assert-string= "foo-bar"
+                      (match "foobar" '("foo-dash-bar" "foo-bar")))
       ;; search without a space. All characters count, real list.
-      (assert-equality 'string= "SWITCH-BUFFER"
-                       (match "sbf" *suggestions*))
+      (assert-string= "SWITCH-BUFFER"
+                      (match "sbf" *suggestions*))
       ;; input is uppercase (small list).
-      (assert-equality 'string= "FOO-BAR"
-                       (match "FOO" '("foo-dash-bar" "FOO-BAR")))
+      (assert-string= "FOO-BAR"
+                      (match "FOO" '("foo-dash-bar" "FOO-BAR")))
       ;; lowercase matches uppercase
-      (assert-equality 'string= "FOO-BAR"
-                       (match "foo" '("zzz" "FOO-BAR")))
+      (assert-string= "FOO-BAR"
+                      (match "foo" '("zzz" "FOO-BAR")))
       ;; match regex meta-characters
-      (assert-equality 'string= "http://[1:0:0:2::3:0.]/"
-                       (match "[" '("test1" "http://[1:0:0:2::3:0.]/" "test2"))))))
+      (assert-string= "http://[1:0:0:2::3:0.]/"
+                      (match "[" '("test1" "http://[1:0:0:2::3:0.]/" "test2"))))))

--- a/libraries/prompter/tests/tests.lisp
+++ b/libraries/prompter/tests/tests.lisp
@@ -296,8 +296,8 @@
         (sync)
         (assert-equal '("jackfruit" "banana")
                       (history))
-        (assert-equality 'string= "jackfruit"
-                         (containers:first-item (prompter:history prompter)))
+        (assert-string= "jackfruit"
+                        (containers:first-item (prompter:history prompter)))
         (setf (prompter:input prompter) "banana")
         (sync)
         (assert-equal '("banana" "jackfruit")
@@ -318,53 +318,53 @@
                (prompter:value (prompter:selected-suggestion prompter))))
         (prompter:all-ready-p prompter)
         (prompter:select-next prompter)
-        (assert-equality 'string= "bar"
+        (assert-string= "bar"
                          (selection-value))
         (prompter:select-next prompter)
-        (assert-equality 'string= "100 foo"
+        (assert-string= "100 foo"
                          (selection-value))
         (prompter:select-next prompter)
-        (assert-equality 'string= "200"
+        (assert-string= "200"
                          (selection-value))
         (prompter:select-next prompter)
-        (assert-equality 'string= "200"
+        (assert-string= "200"
                          (selection-value))
         (prompter:select-previous prompter)
-        (assert-equality 'string= "100 foo"
+        (assert-string= "100 foo"
                          (selection-value))
         (prompter:select-first prompter)
-        (assert-equality 'string= "foo"
+        (assert-string= "foo"
                          (selection-value))
         (prompter:select-previous prompter)
-        (assert-equality 'string= "foo"
+        (assert-string= "foo"
                          (selection-value))
         (prompter:select-last prompter)
-        (assert-equality 'string= "200"
+        (assert-string= "200"
                          (selection-value))
         (prompter:select-previous-source prompter)
-        (assert-equality 'string= "bar"
+        (assert-string= "bar"
                          (selection-value))
         (prompter:select-previous-source prompter)
-        (assert-equality 'string= "bar"
+        (assert-string= "bar"
                          (selection-value))
         (prompter:select-next-source prompter)
-        (assert-equality 'string= "100 foo"
+        (assert-string= "100 foo"
                          (selection-value))
         (prompter:select-next-source prompter)
-        (assert-equality 'string= "100 foo"
+        (assert-string= "100 foo"
                          (selection-value))
 
         (setf (prompter:input prompter) "bar")
         (prompter:all-ready-p prompter)
-        (assert-equality 'string= "bar"
+        (assert-string= "bar"
                          (selection-value))
         (assert-equal '("bar")
                       (all-source-suggestions prompter))
         (prompter:select-next prompter)
-        (assert-equality 'string= "bar"
+        (assert-string= "bar"
                          (selection-value))
         (prompter:select-next-source prompter)
-        (assert-equality 'string= "bar"
+        (assert-string= "bar"
                          (selection-value)))
       (prompter:all-ready-p prompter))))
 
@@ -382,14 +382,14 @@
                (prompter:value (prompter:selected-suggestion prompter))))
         (prompter:all-ready-p prompter)
         (prompter:select-next prompter 2)
-        (assert-equality 'string= "100 foo"
-                         (selection-value))
+        (assert-string= "100 foo"
+                        (selection-value))
         (prompter:select-next prompter -2)
-        (assert-equality 'string= "foo"
-                         (selection-value))
+        (assert-string= "foo"
+                        (selection-value))
         (prompter:select-next prompter 99)
-        (assert-equality 'string= "200"
-                         (selection-value)))
+        (assert-string= "200"
+                        (selection-value)))
       (prompter:all-ready-p prompter))))
 
 (define-test select-with-wrap-over ()
@@ -406,23 +406,23 @@
                (prompter:value (prompter:selected-suggestion prompter))))
         (prompter:all-ready-p prompter)
         (prompter:select-last prompter)
-        (assert-equality 'string= "200"
-                         (selection-value))
+        (assert-string= "200"
+                        (selection-value))
         (prompter:select-next prompter)
-        (assert-equality 'string= "200"
-                         (selection-value))
+        (assert-string= "200"
+                        (selection-value))
         (prompter::select prompter 1 :wrap-over-p t)
-        (assert-equality 'string= "foo"
-                         (selection-value))
+        (assert-string= "foo"
+                        (selection-value))
         (prompter::select prompter -1 :wrap-over-p t)
-        (assert-equality 'string= "200"
-                         (selection-value))
+        (assert-string= "200"
+                        (selection-value))
         (prompter::select prompter 2 :wrap-over-p t)
-        (assert-equality 'string= "bar"
-                         (selection-value))
+        (assert-string= "bar"
+                        (selection-value))
         (prompter::select prompter -3 :wrap-over-p t)
-        (assert-equality 'string= "100 foo"
-                         (selection-value)))
+        (assert-string= "100 foo"
+                        (selection-value)))
       (prompter:all-ready-p prompter))))
 
 (class-star:define-class buffer ()
@@ -451,11 +451,11 @@
       (setf (prompter:active-attributes-keys (prompter:selected-source prompter))
             '("Title" "Keywords"))
 
-      (assert-equality 'string= ""
-                       (first (alex:assoc-value (prompter:active-attributes
-                                                 (prompter:selected-suggestion prompter)
-                                                 :source (prompter:selected-source prompter))
-                                                "Keywords" :test 'equal)))
+      (assert-string= ""
+                      (first (alex:assoc-value (prompter:active-attributes
+                                                (prompter:selected-suggestion prompter)
+                                                :source (prompter:selected-source prompter))
+                                               "Keywords" :test 'equal)))
       (sleep 2)
 
       (assert-equal `(("Title" ,(title buffer1))
@@ -477,10 +477,10 @@
       (flet ((selection-value ()
                (prompter:value (prompter:selected-suggestion prompter))))
         (prompter:all-ready-p prompter)
-        (assert-equality 'string= "foo"
-                         (selection-value))
+        (assert-string= "foo"
+                        (selection-value))
         (setf (prompter:input prompter) "bar")
         (prompter:all-ready-p prompter)
-        (assert-equality 'string= "bar"
-                         (selection-value))
+        (assert-string= "bar"
+                        (selection-value))
         (prompter:all-ready-p prompter)))))

--- a/libraries/theme/tests/test.lisp
+++ b/libraries/theme/tests/test.lisp
@@ -20,30 +20,30 @@
   "Dummy theme for testing.")
 
 (define-test basic-css-substitution ()
-  (assert-equality 'string= "a { background-color: black; color: yellow; }
+  (assert-string= "a { background-color: black; color: yellow; }
 "
-                   (theme:themed-css *theme*
-                     (a
-                      :background-color theme:background
-                      :color theme:primary))))
+                  (theme:themed-css *theme*
+                    (a
+                     :background-color theme:background
+                     :color theme:primary))))
 
 (define-test multi-rule/multi-color-substitution ()
-  (assert-equality 'string= "a { background-color: black; color: yellow; }
+  (assert-string= "a { background-color: black; color: yellow; }
 body { background-color: yellow; color: white; }
 h1 { color: magenta; }
 "
-                   (theme:themed-css *theme*
-                     (a
-                      :background-color theme:background
-                      :color theme:primary)
-                     (body
-                      :background-color theme:primary
-                      :color theme:on-background)
-                     (h1
-                      :color theme:accent))))
+                  (theme:themed-css *theme*
+                    (a
+                     :background-color theme:background
+                     :color theme:primary)
+                    (body
+                     :background-color theme:primary
+                     :color theme:on-background)
+                    (h1
+                     :color theme:accent))))
 
 (define-test inline-function-execution ()
-  (assert-equality 'string=  "body { background-color: yellow; color: magenta !important; }
+  (assert-string=  "body { background-color: yellow; color: magenta !important; }
 "
                    (theme:themed-css *theme*
                      (body
@@ -51,11 +51,11 @@ h1 { color: magenta; }
                       :color (concatenate 'string theme:accent " !important")))))
 
 (define-test inline-macro/special-form-invocation ()
-  (assert-equality 'string= "body { color: black; background-color: yellow; }
+  (assert-string= "body { color: black; background-color: yellow; }
 "
-                   (theme:themed-css *theme*
-                     (body
-                      :color (if (theme:dark-p theme:theme)
-                                 theme:background
-                                 theme:on-background)
-                      :background-color theme:primary))))
+                  (theme:themed-css *theme*
+                    (body
+                     :color (if (theme:dark-p theme:theme)
+                                theme:background
+                                theme:on-background)
+                     :background-color theme:primary))))

--- a/tests/offline/global-history.lisp
+++ b/tests/offline/global-history.lisp
@@ -30,8 +30,8 @@
                            (quri:uri "http://example.org")
                            (url entry))
           ;; "value has no title"
-          (assert-equality 'string= ""
-                           (title entry)))
+          (assert-string= ""
+                          (title entry)))
         (nyxt::history-add (quri:uri "http://example.org") :title "foo")
         ;; "history has still 1 entry after adding same URL"
         (assert-eq 1
@@ -40,8 +40,8 @@
                    (nyxt::implicit-visits (first (htree:all-data (files:content file)))))
         (let ((entry (first (htree:all-data (files:content file)))))
           ;; "value now has title"
-          (assert-equality 'string= "foo"
-                           (title entry)))
+          (assert-string= "foo"
+                          (title entry)))
         (nyxt::history-add (quri:uri "http://example.org/sub"))
         ;; "history now has 2 entries"
         (assert-eq 2

--- a/tests/offline/user-script-parsing.lisp
+++ b/tests/offline/user-script-parsing.lisp
@@ -23,8 +23,8 @@
                               :code code :base-path #p"testing-script.user.js"))
          (virtual-script (make-instance 'nyxt/user-script-mode:user-script :code code)))
     ;; Virtual user script code equality
-    (assert-equality 'string= code
-                     (nyxt/user-script-mode:code virtual-script))
+    (assert-string= code
+                    (nyxt/user-script-mode:code virtual-script))
     ;; Virtual user script noframes
     (assert-false (nyxt/user-script-mode:all-frames-p virtual-script))
     ;; Virtual user script document start

--- a/tests/online/urls.lisp
+++ b/tests/online/urls.lisp
@@ -76,9 +76,9 @@
   (assert-false (nyxt::url-equal (quri:uri "https://example.org")
                                  (quri:uri "https://example.org/foo")))
   ;; "schemeless URL"
-  (assert-equality 'string= (nyxt::schemeless-url
-                             (quri:uri "http://example.org/foo/bar?query=baz#qux"))
-                   "example.org/foo/bar?query=baz#qux")
+  (assert-string= (nyxt::schemeless-url
+                   (quri:uri "http://example.org/foo/bar?query=baz#qux"))
+                  "example.org/foo/bar?query=baz#qux")
   ;; "comparing same URL"
   (assert-false (nyxt::url< (quri:uri "http://example.org")
                             (quri:uri "http://example.org")))

--- a/tests/renderer-offline/set-url.lisp
+++ b/tests/renderer-offline/set-url.lisp
@@ -36,7 +36,7 @@
            (nyxt:start :no-config t :no-auto-config t
                        :socket "/tmp/nyxt-test.socket"
                        :profile "test")
-           (assert-equality 'string= url (calispel:? url-channel 5))
+           (assert-string= url (calispel:? url-channel 5))
            (nyxt:quit))
       (setf nyxt::*headless-p* old-headless-p))))
 


### PR DESCRIPTION
# Description
 
Now that a new `lisp-unit2` release came out, we can leverage it.
[
The patch with the update was already merged in Guix](https://lists.gnu.org/archive/html/guix-patches/2022-09/msg00306.html).

I guess the CI won't like the fact that I didn't update the git submodule.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
