### PR TITLE
Selection actions list

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -330,6 +330,9 @@ call."))
   (alex:when-let ((action (first (marks-actions source))))
     (run-thread "Prompter mark action thread" (funcall action (marks source)))))
 
+(defmethod default-selection-action ((source prompter:source))
+  (first (slot-value source 'selection-actions)))
+
 (export-always 'object-attributes)
 (defgeneric object-attributes (object source)
   (:method ((object t) (source prompter:source))

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -167,13 +167,20 @@ compution is not finished.")))
 
 (defmethod (setf selection) (value (prompter prompter))
   (setf (slot-value prompter 'selection) value)
-  (let ((source (selected-source prompter)))
-    (when (selection-actions-enabled-p source)
-      (if (< 0 (selection-actions-delay source))
+  (call-selection-action prompter))
+
+(export-always 'call-selection-action)
+(defmethod call-selection-action ((prompter prompter))
+  (sera:and-let* ((source (selected-source prompter))
+                  (_ (selection-actions-enabled-p source))
+                  (action (default-selection-action source))
+                  (suggestion (selected-suggestion prompter)))
+    (let ((delay (selection-actions-delay source)))
+      (if (plusp delay)
           (run-thread "Prompter selection action thread"
-            (sleep (selection-actions-delay source))
-            (call-selection-action prompter))
-          (call-selection-action prompter)))))
+            (sleep delay)
+            (funcall action (value suggestion)))
+          (funcall action (value suggestion))))))
 
 (export-always 'input)
 (defmethod (setf input) (text (prompter prompter))
@@ -198,12 +205,6 @@ Signal destruction by sending a value to PROMPTER's `interrupt-channel'."
   ;; TODO: Interrupt before or after destructor?
   (calispel:! (sync-interrupt-channel (sync-queue prompter)) t)
   (calispel:! (interrupt-channel prompter) t))
-
-(export-always 'call-selection-action)
-(defun call-selection-action (prompter)
-  (sera:and-let* ((action (first (selection-actions (selected-source prompter))))
-                  (suggestion (selected-suggestion prompter)))
-    (funcall action (value suggestion))))
 
 (defun select (prompter steps &key wrap-over-p)
   "Select `suggestion' by jumping STEPS forward.

--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -182,6 +182,11 @@ compution is not finished.")))
             (funcall action (value suggestion)))
           (funcall action (value suggestion))))))
 
+(export-always 'set-selection-action)
+(defmethod set-selection-action (value (prompter prompter))
+  (setf (selection-actions (selected-source prompter))
+        (cons value (delete value (selection-actions (selected-source prompter))))))
+
 (export-always 'input)
 (defmethod (setf input) (text (prompter prompter))
   "Update PROMPTER sources and return TEXT."

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -485,7 +485,12 @@ to open a file, save it, switch buffer or delete current buffer.")
    (:li (:nxref :command 'nyxt/document-mode:paste-from-clipboard-ring) " is now conveniently bound to "
         (:code "M-y") " in Emacs scheme of "
         (:nxref :class-name 'nyxt/document-mode:document-mode) ".")
-   (:li "Prompt-buffer now has familiar bindings for text cutting."))
+   (:li "Prompt-buffer now has familiar bindings for text cutting.")
+   (:li "Add " (:nxref :command 'nyxt/prompt-buffer-mode:set-selection-action)
+        ", bound to " (:code "C-c C-j") "by default.")
+   (:li (:code "return-selection-over-action") " renamed to "
+        (:nxref :command 'nyxt/prompt-buffer-mode:return-marks-action)
+        ".  The default keybinding is the same."))
 
   (:h3 "Programming interface")
   (:ul

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -63,9 +63,9 @@ matching your input as you type.")
                                :modes (list (make-instance 'nyxt/prompt-buffer-mode:prompt-buffer-mode)))
                ": Validate the selected suggestion(s) or the current input if there is
 no suggestion.")
-         (:li  (command-markup 'nyxt/prompt-buffer-mode:return-selection-over-action
+         (:li  (command-markup 'nyxt/prompt-buffer-mode:return-marks-action
                                :modes (list (make-instance 'nyxt/prompt-buffer-mode:prompt-buffer-mode)))
-               ": Query the user for an action to run over the selected suggestion(s)."))
+               ": Query the user for an action to run over the marked suggestion(s)."))
         (:p " Some commands support multiple selections, for
 instance " (:code "delete-buffer") " can delete all selected buffers at once.
 When the input is changed and the suggestions are re-filtered, the selection is


### PR DESCRIPTION
# Description

Add the ability to choose from a list of `selection-actions`. 
Simplify `return-actions` by ensuring it's a list.

Fixes #2198 

# Discussion

Also, I want to test this API with the hinting system. I can imagine it being very helpful in that context.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
