### PR TITLE
* describe: sort slot/method/package lists where sensible

### DIFF
--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -227,11 +227,11 @@ turned into links to their respective description page."
          (:li "Total: " (length total-symbols)))
         (:h2 "Use list:")
         (:ul
-         (dolist (use (package-use-list package))
+         (dolist (use (safe-sort (package-use-list package) :key #'package-name))
            (:li (package-markup use))))
         (:h2 "Used by list:")
         (:ul
-         (dolist (use (package-used-by-list package))
+         (dolist (use (safe-sort (package-used-by-list package) :key #'package-name))
            (:li (package-markup use))))))))
 
 (define-internal-page-command-global describe-variable
@@ -482,7 +482,7 @@ A command is a special kind of function that can be called with
               :sources (make-instance 'class-source :universal universal))))
     (buffer (str:concat "*Help-" (symbol-name class) "*") (resolve-symbol :help-mode :mode))
   "Inspect a class and show it in a help buffer."
-  (let* ((slots (class-public-slots class))
+  (let* ((slots (safe-sort (class-public-slots class)))
          (slot-descs (sera:string-join (mapcar (rcurry #'describe-slot* class) slots) ""))
          (*print-case* :downcase))
     (spinneret:with-html-string
@@ -495,14 +495,15 @@ A command is a special kind of function that can be called with
                    collect (:li (:a :href (nyxt-url 'describe-class :class class-name) class-name)))))
       (when (mopu:direct-subclasses class)
         (:h2 "Direct subclasses:")
-        (:ul (loop for class-name in (mapcar #'class-name (mopu:direct-subclasses class))
+        (:ul (loop for class-name in (safe-sort (mapcar #'class-name (mopu:direct-subclasses class)))
                    collect (:li (:a :href (nyxt-url 'describe-class :class class-name) class-name)))))
       (:h2 "Slots:")
       (:raw slot-descs)
       (:h2 "Methods:")
-      (:ul (loop for method in (remove-if
-                                #'listp (mapcar #'mopu:generic-function-name
-                                                (mopu:generic-functions class)))
+      (:ul (loop for method in (safe-sort
+				(remove-if
+				 #'listp (mapcar #'mopu:generic-function-name
+						 (mopu:generic-functions class))))
                  collect (:li (:a :href (nyxt-url 'describe-function :fn method) method)))))))
 
 (define-command-global universal-describe-class ()

--- a/source/utilities.lisp
+++ b/source/utilities.lisp
@@ -142,6 +142,11 @@ This is useful if you do not trust the input."
     (uiop:with-safe-io-syntax (:package package)
       (read input-stream eof-error-p eof-value recursive-p))))
 
+(export-always 'safe-sort)
+(defun safe-sort (s &key (predicate #'string-lessp) (key #'string))
+  "Sort sequence S of objects by KEY using PREDICATE."
+  (sort (copy-seq s) predicate :key key))
+
 (export-always 'safe-slurp-stream-forms)
 (defun safe-slurp-stream-forms (stream)
   "Like `uiop:slurp-stream-forms' but wrapped in `uiop:with-safe-io-syntax' and


### PR DESCRIPTION
# Description

Sort lists of slots/packages/methods/subclasses in `describe-*` pages where it seems sensible.

Fixes #2552

# Discussion

This is a minimal solution to the problem.  One could do more.  Example: `values->html` would probably benefit from something similar.  

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
