### PR TITLE
mode/hint: Refactor filter processing.

### DIFF
--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -231,6 +231,13 @@ For instance, to include images:
                              (prompter:attributes-default suggestion)
                              :ignore-case t))
         #'prompter:fuzzy-match))
+   (prompter:filter-preprocessor
+    (lambda (suggestions source input)
+      (declare (ignore source input))
+      (delete-duplicates suggestions :test (lambda (url1 url2)
+                                             ;; Not all DOM elements have a URL.
+                                             (and url1 url2 (quri:uri= url1 url2)))
+                                     :key (compose #'url #'prompter:value))))
    (prompter:filter-postprocessor
     (lambda (suggestions source input)
       (declare (ignore source))
@@ -238,11 +245,7 @@ For instance, to include images:
           (sera:partition
            (lambda (element)
              (str:starts-with-p input (plump:attribute element "nyxt-hint") :ignore-case t))
-           (delete-duplicates suggestions :test (lambda (url1 url2)
-                                                  ;; Not all DOM elements have a URL.
-                                                  (when (and url1 url2)
-                                                    (quri:uri= url1 url2)))
-                                          :key (compose #'url #'prompter:value))
+           suggestions
            :key #'prompter:value)
         (append matching-hints other-hints))))
    (prompter:selection-actions


### PR DESCRIPTION
filter-preprocessor solely handles de-duplicating hints, while filter-postprocessor sorts them.

# Description

As discussed [under this commit](https://github.com/atlas-engineer/nyxt/commit/2dbf2ab9f828fe66a2f2bac31cff147ddfcd4d52).


# Discussion
@aartaka take a final look, but it should be good.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
