### PR TITLE
Add on-signal-button-press method.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -958,6 +958,11 @@ BUFFER's modes."
   (dolist (mode (modes buffer))
     (on-signal-load-failed mode url)))
 
+(export-always 'on-signal-button-press)
+(defmethod on-signal-button-press ((buffer buffer) button-key)
+  (dolist (mode (modes buffer))
+    (on-signal-button-press mode button-key)))
+
 (hooks:define-hook-type buffer (function (buffer)))
 
 (define-command make-buffer (&rest args &key (title "") modes (url (default-new-buffer-url *browser*)) parent-buffer

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -480,6 +480,10 @@ If there is no corresponding keymap, return nil."
 (defmethod on-signal-load-failed ((mode mode) url)
   url)
 
+(defmethod on-signal-button-press ((mode mode) button-key)
+  (declare (ignorable button-key))
+  nil)
+
 (defmethod url-sources ((mode mode) return-actions)
   (declare (ignore return-actions))
   nil)

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -100,6 +100,13 @@ See also `vi-normal-mode' and `vi-insert-mode'."
   (declare (ignore url))
   (enable-modes '(vi-normal-mode) (buffer mode)))
 
+(defmethod on-signal-button-press ((mode vi-normal-mode) button-key)
+  (let ((buffer (buffer mode)))
+    (when (and (string= "button1" (keymaps:key-value button-key))
+               (nyxt/document-mode:input-tag-p
+                (ps-eval (ps:@ document active-element tag-name))))
+      (enable-modes '(nyxt/vi-mode:vi-insert-mode) buffer))))
+
 (defmethod nyxt/document-mode:element-focused ((mode vi-normal-mode))
   (enable-modes '(vi-insert-mode) (buffer mode)))
 


### PR DESCRIPTION


# Description

This remove the VI dependency of the renderer and generalizes the whole process.

Fixes https://github.com/atlas-engineer/nyxt/commit/fd3df52a1c26608701c7f0098e2f9c86e2b96486

# Discussion

Does it work as expected?  @aartaka 

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [ ] I have pulled from master before submitting this PR
- [ ] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [ ] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
