### PR TITLE
Log to file

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -542,23 +542,6 @@ Return BUFFER."
                  (active-buffer window)
                  (status-buffer window))))
 
-(defmethod write-output-to-log ((browser browser))
-  "Set the *standard-output* and *error-output* to write to a log file."
-  (let ((buffer (current-buffer)))
-    (values
-     (sera:and-let* ((path (files:expand (standard-output-file buffer))))
-       (setf *standard-output*
-             (open path
-                   :direction :output
-                   :if-does-not-exist :create
-                   :if-exists :append)))
-     (sera:and-let* ((path (files:expand (error-output-file buffer))))
-       (setf *error-output*
-             (open path
-                   :direction :output
-                   :if-does-not-exist :create
-                   :if-exists :append))))))
-
 (define-internal-page-command-global reduce-to-buffer (&key (delete t))
     (reduced-buffer "*Reduced Buffers*")
   "Query the buffer(s) to \"reduce \" by copying their titles/URLs to a

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -394,15 +394,7 @@ query is not a valid URL, or the first keyword is not recognized.")
     :type history-file
     :documentation "File where to save the global history used by this buffer.
 See also `history-file' in `browser' for the global history restored on startup,
-which is not necessarily the same.")
-   (standard-output-file
-    (make-instance 'standard-output-file)
-    :type standard-output-file
-    :documentation "File `*standard-output*' can be written to.")
-   (error-output-file
-    (make-instance 'error-output-file)
-    :type error-output-file
-    :documentation "File `*error-output*' can be written to."))
+which is not necessarily the same."))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:export-predicate-name-p t)

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -71,6 +71,20 @@ Consider porting your configuration to ~a."
 (defvar *config-file* (make-instance 'config-file)
   "The configuration file entry point.")
 
+(define-class log-file (files:data-file nyxt-file)
+  ((files:base-path #p"nyxt.log")
+   (files:name "log-file"))
+  (:export-class-name-p t)
+  (:accessor-name-transformer (class*:make-name-transformer name)))
+
+(export-always '*log-file*)
+(defvar *log-file* (make-instance 'log-file)
+  "Path to the file where log is saved.
+This is global because logging starts before the `*browser*' is even initialized.")
+
+(defvar *log-pattern* "<%p> [%D{%H:%M:%S}] %m%n"
+  "Non-verbose log pattern.")
+
 (define-class nyxt-source-directory (nyxt-file)
   ((files:name "source"))
   (:export-class-name-p t)

--- a/source/migration.lisp
+++ b/source/migration.lisp
@@ -126,10 +126,8 @@ major versions."
   (:p (:nxref :slot 'history-file :class-name 'context-buffer)
       " is in " (:nxref :class-name 'context-buffer) ".")
 
-  (standard-output-file standard-error-file)
-  (:p (:nxref :slot 'nyxt:standard-output-file :class-name 'context-buffer) " and "
-      (:nxref :slot 'nyxt:error-output-file :class-name 'context-buffer)
-      " are in " (:nxref :class-name 'context-buffer) ".")
+  (standard-output-file error-output-file)
+  (:p (:nxref :variable 'nyxt:*log-file*))
 
   (annotations-file)
   (:p (:nxref :slot 'nyxt/annotate-mode:annotations-file :class-name 'nyxt/annotate-mode:annotate-mode)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -445,7 +445,7 @@ Examples:
         (progn
           (log:config :debug)
           (format t "Arguments parsed: ~a and ~a~&" options urls))
-        (log:config :pattern "<%p> [%D{%H:%M:%S}] %m%n"))
+        (log:config :pattern *log-pattern*))
 
     ;; TODO: Deprecated, remove in 4.0.
     (when (and init (not config))
@@ -516,6 +516,11 @@ Then load `*config-file*' if any.
 Instantiate `*browser*'.
 Finally, run the browser, load URL-STRINGS if any, then run
 `*after-init-hook*'."
+  (let ((log-path (files:expand *log-file*)))
+    (unless (files:nil-pathname-p log-path)
+      (uiop:delete-file-if-exists log-path) ; Otherwise `log4cl' appends.
+      ;; REVIEW: Do we want to back up the log?
+      (log:config :backup nil :pattern *log-pattern* :daily log-path)))
   (format t "Nyxt version ~a~&" +version+)
   (log:info "Source location: ~s" (files:expand *source-directory*))
   (let* ((urls (strings->urls url-strings))

--- a/source/user-files.lisp
+++ b/source/user-files.lisp
@@ -148,18 +148,6 @@ Example: when passed command line option --with-file foo=bar,
                                  (setf (gethash full-path path-map) file))))
                            (alexandria:hash-table-values path-map)))))
 
-(define-class standard-output-file (files:data-file nyxt-file)
-  ((files:base-path #p"standard-output.txt")
-   (files:name "standard-output"))
-  (:export-class-name-p t)
-  (:accessor-name-transformer (class*:make-name-transformer name)))
-
-(define-class error-output-file (files:data-file nyxt-file)
-  ((files:base-path #p"error-output.txt")
-   (files:name "error-output"))
-  (:export-class-name-p t)
-  (:accessor-name-transformer (class*:make-name-transformer name)))
-
 (export-always 'xdg-download-dir)
 (defun xdg-download-dir ()
   (let ((dir (ignore-errors (uiop:run-program '("xdg-user-dir" "DOWNLOAD")


### PR DESCRIPTION
# Description

Log to file.  We use a global variable because we must start logging at the very beginning, before `*browser*` is instantiated.

Fixes #2449.

# Discussion

Should we log `*standard-output*` and `*error-output*`?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
