### PR TITLE
libraries/nyxt-asdf: Report error when non-interactive.

### DIFF
--- a/libraries/class-star/tests/tests.lisp
+++ b/libraries/class-star/tests/tests.lisp
@@ -8,7 +8,7 @@
 (in-package :class-star/tests)
 
 (define-test simple-class ()
-  (assert-string= "fooname"
+  (lisp-unit2::assert-string= "fooname"
                   (progn
                     (class-star:define-class foo ()
                       ((name "fooname")))
@@ -27,7 +27,7 @@
   (assert-false (fboundp 'address)))
 
 (define-test simple-class-default-value ()
-  (assert-string= ""
+  (lisp-unit2::assert-string= ""
                   (progn
                     (class-star:define-class foo-default ()
                       ((name :type string)
@@ -46,7 +46,7 @@
 (define-test initform-inference ()
   (class-star:define-class foo-initform-infer ()
     ((name :type string)))
-  (assert-string= ""
+  (lisp-unit2::assert-string= ""
                   (name-of (make-instance 'foo-initform-infer)))
   (class-star:define-class foo-initform-infer-no-unbound ()
     ((name :type function))

--- a/libraries/history-tree/tests/tests.lisp
+++ b/libraries/history-tree/tests/tests.lisp
@@ -39,7 +39,7 @@
   (let ((history (make))
         (url "http://example.org"))
     (htree:add-child url history *owner*)
-    (assert-string= url
+    (lisp-unit2::assert-string= url
                     (htree:data (htree:owner-node history *owner*)))))
 
 (define-test multiple-entry ()
@@ -51,17 +51,17 @@
     (htree:add-child url2 history *owner*)
     (htree:backward history *owner*)
     (htree:add-child url3 history *owner*)
-    (assert-string= url3
+    (lisp-unit2::assert-string= url3
                     (htree:data (htree:owner-node history *owner*)))
-    (assert-string= url1
+    (lisp-unit2::assert-string= url1
                     (htree:data (htree:parent (htree:owner-node history *owner*))))
     (htree:backward history *owner*)
     (htree:go-to-child url2 history *owner*)
-    (assert-string= url2
+    (lisp-unit2::assert-string= url2
                     (htree:data (htree:owner-node history *owner*)))))
 
 (define-test simple-branching-tree-tests ()
-  (assert-string= "http://example.root/B2"
+  (lisp-unit2::assert-string= "http://example.root/B2"
                   (htree:data (htree:owner-node (make-history1) *owner*))))
 
 (define-test history-depth ()
@@ -134,13 +134,13 @@
 
 (define-test move-node-to-forward-child-on-add ()
   (let ((history (make-history2)))
-    (assert-string= "http://example.root/B"
+    (lisp-unit2::assert-string= "http://example.root/B"
                     (htree:data (htree:owner-node history *owner*)))
     (htree:backward history *owner*)
-    (assert-string= "http://example.root"
+    (lisp-unit2::assert-string= "http://example.root"
                     (htree:data (htree:owner-node history *owner*)))
     (htree:add-child "http://example.root/A" history *owner*)
-    (assert-string= "http://example.root/A"
+    (lisp-unit2::assert-string= "http://example.root/A"
                     (htree:data (htree:owner-node history *owner*)))))
 
 (define-class web-page ()
@@ -158,7 +158,7 @@
       (htree:add-child web-page2 history *owner*)
       (assert-eq 1
                  (hash-table-count (htree:entries history)))
-      (assert-string= "Example page"
+      (lisp-unit2::assert-string= "Example page"
                       (title (htree:data (htree::first-hash-table-key (htree:entries history))))))
     (let ((history (make :key 'url)))
       (htree:add-child web-page1 history *owner*)
@@ -166,7 +166,7 @@
       (htree:add-child web-page2 history "b")
       (assert-eq 1
                  (hash-table-count (htree:entries history)))
-      (assert-string= "Example page"
+      (lisp-unit2::assert-string= "Example page"
                       (title (htree:data (htree::first-hash-table-key (htree:entries history))))))
     (let ((history (make)))
       (htree:add-child web-page1 history *owner*)
@@ -182,7 +182,7 @@
   (let ((history (make))
         (url1 "http://example.org"))
     (htree:add-child url1 history *owner*)
-    (assert-string= *owner*
+    (lisp-unit2::assert-string= *owner*
                     (first (alexandria:hash-table-keys (htree:owners history))))
     (assert-eq 1
                (hash-table-count (htree:owners history)))))
@@ -198,15 +198,15 @@
     (htree:add-child url3 history "b")
     (assert-eq 3
                (hash-table-count (htree:entries history)))
-    (assert-string= url3
+    (lisp-unit2::assert-string= url3
                     (htree:data (htree:owner-node history "b")))
-    (assert-string= url2
+    (lisp-unit2::assert-string= url2
                     (htree:data (htree:parent (htree:owner-node history "b"))))
     (assert-false (htree:parent (htree:parent (htree:owner-node history "b"))))
     ;; Following tests are useless now that we don't have with-current-owner anymore.
     (assert-eq 2
                (length (htree:nodes (htree:owner history "b"))))
-    (assert-string= url1
+    (lisp-unit2::assert-string= url1
                     (htree:data (htree:owner-node history "a")))))
 
 (define-test backward-and-forward ()
@@ -218,17 +218,17 @@
     (htree:add-child url2 history "a")
     (htree:add-owner history "b" :creator-id "a")
     (htree:add-child url3 history "b")
-    (assert-string= url2
+    (lisp-unit2::assert-string= url2
                     (htree:data (htree:owner-node history "a")))
     (htree:backward history "a")
     (htree:backward history "a")
-    (assert-string= url1
+    (lisp-unit2::assert-string= url1
                     (htree:data (htree:owner-node history "a")))
     (htree:forward history "a")
-    (assert-string= url2
+    (lisp-unit2::assert-string= url2
                     (htree:data (htree:owner-node history "a")))
     (htree:forward history "a")
-    (assert-string= url2
+    (lisp-unit2::assert-string= url2
                     (htree:data (htree:owner-node history "a")))))
 
 (define-test inter-owner-relationships ()
@@ -318,7 +318,7 @@
 
     (htree:visit-all history "b" distant-node)
 
-    (assert-string= distant-node-value
+    (lisp-unit2::assert-string= distant-node-value
                     (htree:data (htree:owner-node history "b")))
     (assert-equal (sort (copy-seq '("http://example.root/A1" "http://example.root/A" "http://example.root"
                                     "http://example.root/B" "http://example.root/B2" "b-data"))
@@ -336,7 +336,7 @@
     (let ((distant-node (first (htree:find-nodes history distant-node-value))))
       (htree:visit-all history *owner* distant-node))
 
-    (assert-string= distant-node-value
+    (lisp-unit2::assert-string= distant-node-value
                     (htree:data (htree:owner-node history *owner*)))
     (assert-equal (sort (copy-seq '("http://example.root/A"
                                     "http://example.root/A1"
@@ -426,22 +426,22 @@
     (htree:add-child url3 history "a")
     (htree:backward history "a")
 
-    (assert-string= url1
+    (lisp-unit2::assert-string= url1
                     (htree:data (htree:owner-node history *owner*)))
     (htree:go-to-owned-child url3 history *owner*)
-    (assert-string= url1
+    (lisp-unit2::assert-string= url1
                     (htree:data (htree:owner-node history *owner*)))
     (htree:go-to-owned-child url2 history *owner*)
-    (assert-string= url2
+    (lisp-unit2::assert-string= url2
                     (htree:data (htree:owner-node history *owner*)))
 
-    (assert-string= url1
+    (lisp-unit2::assert-string= url1
                     (htree:data (htree:owner-node history "a")))
     (htree:go-to-owned-child url2 history "a")
-    (assert-string= url1
+    (lisp-unit2::assert-string= url1
                     (htree:data (htree:owner-node history "a")))
     (htree:go-to-owned-child url3 history "a")
-    (assert-string= url3
+    (lisp-unit2::assert-string= url3
                     (htree:data (htree:owner-node history "a")))))
 
 (define-test add-children ()
@@ -450,11 +450,11 @@
         (url2 "https://nyxt.atlas.engineer")
         (url3 "http://en.wikipedia.org"))
     (htree:add-children (list url1 url2 url3) history *owner*)
-    (assert-string= url3
+    (lisp-unit2::assert-string= url3
                     (htree:data (htree:owner-node history *owner*)))
     (assert-false (htree::map-data (htree:children (htree:owner-node history *owner*))))
     (htree:backward history *owner*)
-    (assert-string= url1
+    (lisp-unit2::assert-string= url1
                     (htree:data (htree:owner-node history *owner*)))
 
     (assert-eq 2

--- a/libraries/prompter/tests/fuzzy.lisp
+++ b/libraries/prompter/tests/fuzzy.lisp
@@ -42,38 +42,38 @@
                                      (prompter:fuzzy-match suggestion source input))
                                    (prompter::ensure-suggestions-list source list))
                            #'prompter:score>)))))
-      (assert-string= "help"
+      (lisp-unit2::assert-string= "help"
                       (match "hel" '("help-mode" "help" "foo-help" "help-foo-bar")))
       ;; match 'help' with real suggestions list
-      (assert-string= "HELP"
+      (lisp-unit2::assert-string= "HELP"
                       (match "hel" *suggestions*))
       ;; match 'swit buf' (small list)
-      (assert-string= "switch-buffer"
+      (lisp-unit2::assert-string= "switch-buffer"
                       (match "swit buf" '("about" "switch-buffer-next" "switch-buffer" "delete-buffer")))
       ;; match 'swit buf' with real suggestions list
-      (assert-string= "SWITCH-BUFFER"
+      (lisp-unit2::assert-string= "SWITCH-BUFFER"
                       (match "swit buf" *suggestions*))
       ;; reverse match 'buf swit' (small list)
-      (assert-string= "switch-buffer"
+      (lisp-unit2::assert-string= "switch-buffer"
                       (match "buf swit" '("about" "switch-buffer-next" "switch-buffer" "delete-buffer")))
       ;; reverse match 'buf swit' with real suggestions list
-      (assert-string= "SWITCH-BUFFER"
+      (lisp-unit2::assert-string= "SWITCH-BUFFER"
                       (match "buf swit" *suggestions*))
       ;; suggestions beginning with the first word appear first
-      (assert-string= "delete-foo"
+      (lisp-unit2::assert-string= "delete-foo"
                       (match "de" '("some-mode" "delete-foo")))
       ;; search without a space. All characters count (small list).
-      (assert-string= "foo-bar"
+      (lisp-unit2::assert-string= "foo-bar"
                       (match "foobar" '("foo-dash-bar" "foo-bar")))
       ;; search without a space. All characters count, real list.
-      (assert-string= "SWITCH-BUFFER"
+      (lisp-unit2::assert-string= "SWITCH-BUFFER"
                       (match "sbf" *suggestions*))
       ;; input is uppercase (small list).
-      (assert-string= "FOO-BAR"
+      (lisp-unit2::assert-string= "FOO-BAR"
                       (match "FOO" '("foo-dash-bar" "FOO-BAR")))
       ;; lowercase matches uppercase
-      (assert-string= "FOO-BAR"
+      (lisp-unit2::assert-string= "FOO-BAR"
                       (match "foo" '("zzz" "FOO-BAR")))
       ;; match regex meta-characters
-      (assert-string= "http://[1:0:0:2::3:0.]/"
+      (lisp-unit2::assert-string= "http://[1:0:0:2::3:0.]/"
                       (match "[" '("test1" "http://[1:0:0:2::3:0.]/" "test2"))))))

--- a/libraries/prompter/tests/tests.lisp
+++ b/libraries/prompter/tests/tests.lisp
@@ -296,7 +296,7 @@
         (sync)
         (assert-equal '("jackfruit" "banana")
                       (history))
-        (assert-string= "jackfruit"
+        (lisp-unit2::assert-string= "jackfruit"
                         (containers:first-item (prompter:history prompter)))
         (setf (prompter:input prompter) "banana")
         (sync)
@@ -318,53 +318,53 @@
                (prompter:value (prompter:selected-suggestion prompter))))
         (prompter:all-ready-p prompter)
         (prompter:select-next prompter)
-        (assert-string= "bar"
+        (lisp-unit2::assert-string= "bar"
                          (selection-value))
         (prompter:select-next prompter)
-        (assert-string= "100 foo"
+        (lisp-unit2::assert-string= "100 foo"
                          (selection-value))
         (prompter:select-next prompter)
-        (assert-string= "200"
+        (lisp-unit2::assert-string= "200"
                          (selection-value))
         (prompter:select-next prompter)
-        (assert-string= "200"
+        (lisp-unit2::assert-string= "200"
                          (selection-value))
         (prompter:select-previous prompter)
-        (assert-string= "100 foo"
+        (lisp-unit2::assert-string= "100 foo"
                          (selection-value))
         (prompter:select-first prompter)
-        (assert-string= "foo"
+        (lisp-unit2::assert-string= "foo"
                          (selection-value))
         (prompter:select-previous prompter)
-        (assert-string= "foo"
+        (lisp-unit2::assert-string= "foo"
                          (selection-value))
         (prompter:select-last prompter)
-        (assert-string= "200"
+        (lisp-unit2::assert-string= "200"
                          (selection-value))
         (prompter:select-previous-source prompter)
-        (assert-string= "bar"
+        (lisp-unit2::assert-string= "bar"
                          (selection-value))
         (prompter:select-previous-source prompter)
-        (assert-string= "bar"
+        (lisp-unit2::assert-string= "bar"
                          (selection-value))
         (prompter:select-next-source prompter)
-        (assert-string= "100 foo"
+        (lisp-unit2::assert-string= "100 foo"
                          (selection-value))
         (prompter:select-next-source prompter)
-        (assert-string= "100 foo"
+        (lisp-unit2::assert-string= "100 foo"
                          (selection-value))
 
         (setf (prompter:input prompter) "bar")
         (prompter:all-ready-p prompter)
-        (assert-string= "bar"
+        (lisp-unit2::assert-string= "bar"
                          (selection-value))
         (assert-equal '("bar")
                       (all-source-suggestions prompter))
         (prompter:select-next prompter)
-        (assert-string= "bar"
+        (lisp-unit2::assert-string= "bar"
                          (selection-value))
         (prompter:select-next-source prompter)
-        (assert-string= "bar"
+        (lisp-unit2::assert-string= "bar"
                          (selection-value)))
       (prompter:all-ready-p prompter))))
 
@@ -382,13 +382,13 @@
                (prompter:value (prompter:selected-suggestion prompter))))
         (prompter:all-ready-p prompter)
         (prompter:select-next prompter 2)
-        (assert-string= "100 foo"
+        (lisp-unit2::assert-string= "100 foo"
                         (selection-value))
         (prompter:select-next prompter -2)
-        (assert-string= "foo"
+        (lisp-unit2::assert-string= "foo"
                         (selection-value))
         (prompter:select-next prompter 99)
-        (assert-string= "200"
+        (lisp-unit2::assert-string= "200"
                         (selection-value)))
       (prompter:all-ready-p prompter))))
 
@@ -406,22 +406,22 @@
                (prompter:value (prompter:selected-suggestion prompter))))
         (prompter:all-ready-p prompter)
         (prompter:select-last prompter)
-        (assert-string= "200"
+        (lisp-unit2::assert-string= "200"
                         (selection-value))
         (prompter:select-next prompter)
-        (assert-string= "200"
+        (lisp-unit2::assert-string= "200"
                         (selection-value))
         (prompter::select prompter 1 :wrap-over-p t)
-        (assert-string= "foo"
+        (lisp-unit2::assert-string= "foo"
                         (selection-value))
         (prompter::select prompter -1 :wrap-over-p t)
-        (assert-string= "200"
+        (lisp-unit2::assert-string= "200"
                         (selection-value))
         (prompter::select prompter 2 :wrap-over-p t)
-        (assert-string= "bar"
+        (lisp-unit2::assert-string= "bar"
                         (selection-value))
         (prompter::select prompter -3 :wrap-over-p t)
-        (assert-string= "100 foo"
+        (lisp-unit2::assert-string= "100 foo"
                         (selection-value)))
       (prompter:all-ready-p prompter))))
 
@@ -451,7 +451,7 @@
       (setf (prompter:active-attributes-keys (prompter:selected-source prompter))
             '("Title" "Keywords"))
 
-      (assert-string= ""
+      (lisp-unit2::assert-string= ""
                       (first (alex:assoc-value (prompter:active-attributes
                                                 (prompter:selected-suggestion prompter)
                                                 :source (prompter:selected-source prompter))
@@ -477,10 +477,10 @@
       (flet ((selection-value ()
                (prompter:value (prompter:selected-suggestion prompter))))
         (prompter:all-ready-p prompter)
-        (assert-string= "foo"
+        (lisp-unit2::assert-string= "foo"
                         (selection-value))
         (setf (prompter:input prompter) "bar")
         (prompter:all-ready-p prompter)
-        (assert-string= "bar"
+        (lisp-unit2::assert-string= "bar"
                         (selection-value))
         (prompter:all-ready-p prompter)))))

--- a/libraries/theme/tests/test.lisp
+++ b/libraries/theme/tests/test.lisp
@@ -20,7 +20,7 @@
   "Dummy theme for testing.")
 
 (define-test basic-css-substitution ()
-  (assert-string= "a { background-color: black; color: yellow; }
+  (lisp-unit2::assert-string= "a { background-color: black; color: yellow; }
 "
                   (theme:themed-css *theme*
                     (a
@@ -28,7 +28,7 @@
                      :color theme:primary))))
 
 (define-test multi-rule/multi-color-substitution ()
-  (assert-string= "a { background-color: black; color: yellow; }
+  (lisp-unit2::assert-string= "a { background-color: black; color: yellow; }
 body { background-color: yellow; color: white; }
 h1 { color: magenta; }
 "
@@ -43,7 +43,7 @@ h1 { color: magenta; }
                      :color theme:accent))))
 
 (define-test inline-function-execution ()
-  (assert-string=  "body { background-color: yellow; color: magenta !important; }
+  (lisp-unit2::assert-string=  "body { background-color: yellow; color: magenta !important; }
 "
                    (theme:themed-css *theme*
                      (body
@@ -51,7 +51,7 @@ h1 { color: magenta; }
                       :color (concatenate 'string theme:accent " !important")))))
 
 (define-test inline-macro/special-form-invocation ()
-  (assert-string= "body { color: black; background-color: yellow; }
+  (lisp-unit2::assert-string= "body { color: black; background-color: yellow; }
 "
                   (theme:themed-css *theme*
                     (body

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -541,7 +541,7 @@ Example:
     :documentation "Proxy for buffer.")
    (certificate-exceptions
     '()
-    :type (list-of strings)
+    :type (list-of string)
     :documentation "A list of hostnames for which certificate errors shall be ignored."))
   (:export-class-name-p t)
   (:export-accessor-names-p t)

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -37,7 +37,7 @@ include implicit visits.")
 Number of times the URL was visited by following a link on a page.  This does
 not include explicit visits.")
    (scroll-position '()
-                    :type (list-of numbers)
+                    :type (list-of number)
                     :documentation "The scroll position user was at when last visiting the page.
 It's a list of a form (Y &OPTIONAL X)."))
   (:accessor-name-transformer (class*:make-name-transformer name))

--- a/source/types.lisp
+++ b/source/types.lisp
@@ -25,6 +25,8 @@ functions for the `satisfies' type condition."))
   "The empty list or a proper list of TYPE elements.
 Unlike `(cons TYPE *)', it checks all the elements.
 `(cons TYPE *)' does not accept the empty list."
+  (unless (trivial-types:type-specifier-p type)
+    (error "Invalid type specifier: ~a" type))
   (let ((predicate-name (intern (uiop:strcat "LIST-OF-" (symbol-name type) "-P")
                                 (find-package :nyxt/types))))
     (unless (fboundp predicate-name)

--- a/source/web-extensions.lisp
+++ b/source/web-extensions.lisp
@@ -11,25 +11,26 @@
 (sera:eval-always
   (sb-ext:add-implementation-package :nyxt/web-extensions :nyxt))
 
-(define-class content-script ()
-  ((match-patterns (error "Match pattern is required.")
-                   :type list
-                   :documentation "The match-pattern for URLs the script should run on.
+(sera:eval-always
+  (define-class content-script ()
+    ((match-patterns (error "Match pattern is required.")
+                     :type list
+                     :documentation "The match-pattern for URLs the script should run on.
 Not a WebExtensions match pattern, but a renderer-friendly one.")
-   (files nil
-          :type list
-          :documentation "The .js or .css files of the script as a list.")
-   (user-styles nil
-                :type list
-                :documentation "The renderer-friendly representation of the CSS style sheets.
+     (files nil
+            :type list
+            :documentation "The .js or .css files of the script as a list.")
+     (user-styles nil
+                  :type list
+                  :documentation "The renderer-friendly representation of the CSS style sheets.
 A list of objects. Does not necessarily have the same order as `files' of the script.")
-   (user-scripts nil
-                 :type list
-                 :documentation "The renderer-friendly representation of the JS scripts.
+     (user-scripts nil
+                   :type list
+                   :documentation "The renderer-friendly representation of the JS scripts.
 A list of objects. Does not necessarily have the same order as `files' of the script."))
-  (:export-class-name-p t)
-  (:export-accessor-names-p t)
-  (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name)))
+    (:export-class-name-p t)
+    (:export-accessor-names-p t)
+    (:accessor-name-transformer (hu.dwim.defclass-star:make-name-transformer name))))
 
 (defmethod remove-content-script ((buffer buffer) extension (script content-script))
   (declare (ignore extension))

--- a/tests/offline/global-history.lisp
+++ b/tests/offline/global-history.lisp
@@ -30,7 +30,7 @@
                            (quri:uri "http://example.org")
                            (url entry))
           ;; "value has no title"
-          (assert-string= ""
+          (lisp-unit2::assert-string= ""
                           (title entry)))
         (nyxt::history-add (quri:uri "http://example.org") :title "foo")
         ;; "history has still 1 entry after adding same URL"
@@ -40,7 +40,7 @@
                    (nyxt::implicit-visits (first (htree:all-data (files:content file)))))
         (let ((entry (first (htree:all-data (files:content file)))))
           ;; "value now has title"
-          (assert-string= "foo"
+          (lisp-unit2::assert-string= "foo"
                           (title entry)))
         (nyxt::history-add (quri:uri "http://example.org/sub"))
         ;; "history now has 2 entries"

--- a/tests/offline/user-script-parsing.lisp
+++ b/tests/offline/user-script-parsing.lisp
@@ -23,7 +23,7 @@
                               :code code :base-path #p"testing-script.user.js"))
          (virtual-script (make-instance 'nyxt/user-script-mode:user-script :code code)))
     ;; Virtual user script code equality
-    (assert-string= code
+    (lisp-unit2::assert-string= code
                     (nyxt/user-script-mode:code virtual-script))
     ;; Virtual user script noframes
     (assert-false (nyxt/user-script-mode:all-frames-p virtual-script))

--- a/tests/online/urls.lisp
+++ b/tests/online/urls.lisp
@@ -76,7 +76,7 @@
   (assert-false (nyxt::url-equal (quri:uri "https://example.org")
                                  (quri:uri "https://example.org/foo")))
   ;; "schemeless URL"
-  (assert-string= (nyxt::schemeless-url
+  (lisp-unit2::assert-string= (nyxt::schemeless-url
                    (quri:uri "http://example.org/foo/bar?query=baz#qux"))
                   "example.org/foo/bar?query=baz#qux")
   ;; "comparing same URL"

--- a/tests/renderer-offline/set-url.lisp
+++ b/tests/renderer-offline/set-url.lisp
@@ -36,7 +36,7 @@
            (nyxt:start :no-config t :no-auto-config t
                        :socket "/tmp/nyxt-test.socket"
                        :profile "test")
-           (assert-string= url (calispel:? url-channel 5))
+           (lisp-unit2::assert-string= url (calispel:? url-channel 5))
            (nyxt:quit))
       (setf nyxt::*headless-p* old-headless-p))))
 


### PR DESCRIPTION
# Description

The CI failed to run the tests since https://github.com/atlas-engineer/nyxt/pull/2553, and worse, it failed to report the failure :(  So effectively nothing got reported at all...

This should fix it.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
