### PR TITLE
mode/hint: Remove deduplication logic.

### DIFF
--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -296,8 +296,14 @@ FUNCTION is the action to perform on the selected elements."
                 :hide-suggestion-count-p (fit-to-prompt-p (find-submode 'hint-mode))
                 :sources (make-instance 'hint-source
                                         :multi-selection-p multi-selection-p
-                                        :constructor (lambda (source) (declare (ignore source))
-                                                       (add-hints :selector selector)))
+                                        :constructor
+                                        (lambda (source) (declare (ignore source))
+                                          (delete-duplicates
+                                           (add-hints :selector selector)
+                                           :test (lambda (h1 h2)
+                                                   (let ((h1 (plump:attribute h1 "href"))
+                                                         (h2 (plump:attribute h2 "href")))
+                                                     (and h1 h2 (string= h1 h2)))))))
                 :after-destructor (lambda () (with-current-buffer buffer (remove-hints))))))
     (funcall function result)))
 

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -297,13 +297,19 @@ FUNCTION is the action to perform on the selected elements."
                 :sources (make-instance 'hint-source
                                         :multi-selection-p multi-selection-p
                                         :constructor
-                                        (lambda (source) (declare (ignore source))
-                                          (delete-duplicates
-                                           (add-hints :selector selector)
-                                           :test (lambda (h1 h2)
-                                                   (let ((h1 (plump:attribute h1 "href"))
-                                                         (h2 (plump:attribute h2 "href")))
-                                                     (and h1 h2 (string= h1 h2)))))))
+                                        (lambda (source)
+                                          (declare (ignore source))
+                                          (multiple-value-bind (no-url-hints url-hints)
+                                              (sera:partition #'null
+                                                              (add-hints :selector selector)
+                                                              :key (alex:rcurry #'plump:attribute "href"))
+                                            (append no-url-hints
+                                                    (delete-duplicates
+                                                     url-hints
+                                                     :test (lambda (h1 h2)
+                                                             (quri:uri-equal h1 h2))
+                                                     :key (compose (alex:rcurry #'quri:merge-uris (url buffer))
+                                                                   (alex:rcurry #'plump:attribute "href")))))))
                 :after-destructor (lambda () (with-current-buffer buffer (remove-hints))))))
     (funcall function result)))
 

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -231,13 +231,6 @@ For instance, to include images:
                              (prompter:attributes-default suggestion)
                              :ignore-case t))
         #'prompter:fuzzy-match))
-   (prompter:filter-preprocessor
-    (lambda (suggestions source input)
-      (declare (ignore source input))
-      (delete-duplicates suggestions :test (lambda (url1 url2)
-                                             ;; Not all DOM elements have a URL.
-                                             (and url1 url2 (quri:uri= url1 url2)))
-                                     :key (compose #'url #'prompter:value))))
    (prompter:filter-postprocessor
     (lambda (suggestions source input)
       (declare (ignore source))

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -299,17 +299,10 @@ FUNCTION is the action to perform on the selected elements."
                                         :constructor
                                         (lambda (source)
                                           (declare (ignore source))
-                                          (multiple-value-bind (no-url-hints url-hints)
-                                              (sera:partition #'null
-                                                              (add-hints :selector selector)
-                                                              :key (alex:rcurry #'plump:attribute "href"))
-                                            (append no-url-hints
-                                                    (delete-duplicates
-                                                     url-hints
-                                                     :test (lambda (h1 h2)
-                                                             (quri:uri-equal h1 h2))
-                                                     :key (compose (alex:rcurry #'quri:merge-uris (url buffer))
-                                                                   (alex:rcurry #'plump:attribute "href")))))))
+                                          (delete-duplicates
+                                           (add-hints :selector selector)
+                                           :test (lambda (h1 h2) (and h1 h2 (string= h1 h2)))
+                                           :key (alex:rcurry #'plump:attribute "href"))))
                 :after-destructor (lambda () (with-current-buffer buffer (remove-hints))))))
     (funcall function result)))
 


### PR DESCRIPTION
It's too expensive and sacrifices the interactive nature of the prompt buffer.

For a page with 255 hints, it takes 1.5 seconds for the deduplication to finish on a reasonable machine.

Notice that pages can have more than 2000 hints.

Fixes #2516

# Description

Fixes the issue I've reported [in this comment](https://github.com/atlas-engineer/nyxt/pull/2555#issuecomment-1246895114).

Lessons:
- @aartaka we need to be more cautions when trying to close an issue in such a hasty manner (see 6196f12a9). This fix didn't take into account the frequent case when there is no URL.
- @Ambrevar noticed that commit 6196f12a9 was short-sighted, but didn't check how much overhead it introduced in terms of responsiveness with his fix (2dbf2ab9f).
- @aadcg made two mistakes. Firstly, he didn't make an in-depth analysis of commit 2dbf2ab9f. That is, he just believed that it was properly working. Secondly, he didn't take into account that the preprocessing runs multiple times, when it should only be triggered once. 

# Discussion

Let's re-open #2516 and leave it for post-3.0. Sounds reasonable?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
