### PR TITLE
Fail safe profile

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -33,9 +33,7 @@ inherited from the superclasses.")
     :documentation "Unique identifier for a buffer.")
    ;; TODO: Or maybe a dead-buffer should just be a buffer history?
    (profile
-    (alex:if-let ((profile-class (find-profile-class (getf *options* :profile))))
-      (make-instance profile-class)
-      *global-profile*)
+    *global-profile*
     :type nyxt-profile
     :documentation "Buffer profiles are used to specialize the behaviour of
 various parts, such as the path of all data files.")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -777,9 +777,13 @@ core to finalize the instance.")))
             (:nxref :command 'nyxt:toggle-debug-on-error)
             " command to enable Nyxt-native debugger and see the reasons of these. Based on
 this information, you can report a bug using " (:nxref :command 'nyxt:report-bug) ".")
+        (:p "You can also try to start the browser with the " (:code "--failsafe")
+            " command line option and see if you can reproduce your issue then.  If not,
+then the issue is most likely due to your configuration, an extension, or some
+corrupt data file like the history.")
         (:p "Note that often errors, hangs, and crashes happen on the side of renderer and
 thus are not visible to the Nyxt-native debugger and fixable on the side of
-Nyxt. See below for some of those"))
+Nyxt. See below."))
 
       (:nsection :title "Playing videos"
         (:p "Nyxt delegates video support to third-party plugins.")

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -147,7 +147,11 @@ Known profiles are found among subclasses of `nyxt-profile'.")
        :description "Set path reference to the given path.
 Can be specified multiple times.  An empty path means it won't be used.
 Example: --with-file bookmarks=/path/to/bookmarks
-         --with-file session="))))
+         --with-file session=")
+      (:name :failsafe
+       :long "failsafe"
+       :description "Ensure Nyxt starts in a vanilla environment.
+It skips configuration files and other data files like the history."))))
 ;; Also define command line options at read-time because we parse
 ;; `opts::*options*' in `start'.
 (sera:eval-always (define-opts))
@@ -435,11 +439,20 @@ Examples:
                          help version system-information
                          list-profiles script
                          config no-config init no-init ; TODO: Deprecated, remove in 4.0.
+                         failsafe
                          load eval quit remote
                        &allow-other-keys)
       options
     (when headless
       (setf *headless-p* t))
+
+    (when failsafe
+      (setf
+       (getf *options* :verbose) t
+       (getf *options* :no-config) t
+       (getf *options* :no-auto-config) t
+       (getf *options* :no-socket) t
+       (getf *options* :profile) (profile-name (find-class 'nofile-profile))))
 
     (if verbose
         (progn

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -327,7 +327,7 @@ It takes URL-STRINGS so that the URL argument can be `cl-read' in case
                    ;; If we get pinged too early, we do not have a current-window yet.
                    (when (current-window)
                      (ffi-window-to-foreground (current-window)))))))
-    (log:info "Listening on socket ~s" socket-path)))
+    (log:info "Listening to socket: ~s" socket-path)))
 
 (defun listening-socket-p ()
   (ignore-errors
@@ -357,7 +357,6 @@ Otherwise bind socket and return the listening thread."
        (log:error "Could not bind socket ~a, non-socket file exists." socket-path)
        nil)
       (t
-       (log:info "Listening to socket ~s." socket-path)
        (uiop:delete-file-if-exists socket-path) ; Safe since socket-path is a :socket at this point.
        (run-thread "socket listener"
          (listen-socket))))))

--- a/source/user-files.lisp
+++ b/source/user-files.lisp
@@ -72,6 +72,13 @@ If the file is modified externally, Nyxt automatically reloads it."))
   (:documentation "With the nosave profile no data should be persisted to disk.
 No data should be shared with other nosave buffers either."))
 
+(define-class nofile-profile (files:virtual-profile nyxt-profile)
+  ((files:name "nofile"))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (class*:make-name-transformer name))
+  (:documentation "Data is neither read nor persisted persisted to disk."))
+
 (defun find-file-name-path (ref)
   "Return the value of the REF found in `*options*'s `:with-file'.
 An empty path can be used to disable file persistence for the referenced `nyxt-file'.


### PR DESCRIPTION
# Description

This adds a long overdue `failsafe` command line parameter which should easily allow users to start Nyxt regardless of the their config, history, etc.

Fixes #2386.
Also addresses https://github.com/atlas-engineer/nyxt/issues/2535#issuecomment-1236731207

# Discussion

- Should `--failsafe` really modify the `*options*` values?  It makes for short code, but technically we lose "integrity" in the `*options*` variable.

- Do you like the `nofile-profile` name?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
