### PR TITLE
Review changelog

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -518,7 +518,7 @@ the selection, and the string to paste instead of the clipboard (respectively)."
         that it propagates to reader macros such as "
         (:code "#+nyxt-3-pre-release-2") ".")
    (:li "Fix touchscreen gestures for VI mode.")
-   (:li "Fix processing absolute paths via relative paths when opening files.")
+   (:li "Fix processing via relative paths when opening files.")
    (:li "Setting " (:nxref :slot 'restore-session-on-startup-p :class-name 'browser)
         "no longer hangs the browser.")
    (:li "Fix buffer re-attachment from the deleted window.")

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -450,36 +450,36 @@ SLY install.")
    (:li "Remove " (:nxref :class-name 'nyxt/hint-mode:hint-mode) " image support
         by default.")
    (:li "Add "
-        (:nxref :class-name nyxt/hint-mode:hint-mode :slot 'compute-hints-in-view-port-p=)
+        (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'nyxt/hint-mode:compute-hints-in-view-port-p)
         " allowing hints to be optionally computed in viewport.")
    (:li "Add " (:nxref :class-name 'prompt-buffer :slot 'height) " so that every
         prompt has a configurable height (options are "
-        (:code ":default") (:code ":fit-to-prompt")
+        (:code ":default") ", " (:code ":fit-to-prompt")
         " or an integer specifying the height in pixels).")
    (:li "Add "
-        (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'fit-to-prompt-p)
+        (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'nyxt/hint-mode:fit-to-prompt-p)
         " minimizing the space taken by the prompt-buffer while navigating hints.")
    (:li "Add "
         (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'nyxt/hint-mode:show-hint-scope-p)
         "for element highlighting of hinted elements.")
-   (:li "Add " (:nxref :class-name 'prompter:source :slot 'marks-actions)
+   (:li "Add " (:nxref :class-name 'prompter:source :slot 'prompter:marks-actions)
         " that run when marked items on prompt-buffer change.")
-   (:li "Extend " (nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'style)
+   (:li "Extend " (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'style)
         " to accommodate for marked hints.")
    (:li (:code "default-modes") " can be configured with "
         (:code "%slot-value%") " .")
    (:li "Add " (:nxref :command 'toggle-maximize) " command for maximizing a window.")
    (:li "All copying and pasting commands populate "
         (:nxref :class-name 'browser :slot 'clipboard-ring) " reliably, thus fixing the "
-        (:nxref :command 'paste-from-clipboard-ring) " command.")
+        (:nxref :command 'nyxt/document-mode:paste-from-clipboard-ring) " command.")
    (:li "Major improvement of " (:nxref :class-name 'nyxt/editor-mode:editor-mode)
         " (try it with " (:a :href "https://github.com/atlas-engineer/nx-ace" "nx-ace") ".")
    (:li (:code "execute-command")
         " evaluates arbitrary Lisp code and provides inline documentation for symbols.")
    (:li "Extend keybinding for all keyschemes in "
         (:nxref :class-name 'nyxt/editor-mode:editor-mode) " .")
-   (:li "Bind " (:nxref :command 'paste-from-clipboard-ring) " to " (:code "M-y")
-        " in Emacs keyscheme.")
+   (:li "Bind " (:nxref :command 'nyxt/document-mode:paste-from-clipboard-ring)
+        " to " (:code "M-y") " in Emacs keyscheme.")
    (:li "Bind familiar keys for text cutting in prompt-buffer."))
 
   (:h3 "Bindings")
@@ -487,7 +487,7 @@ SLY install.")
    (:li (:nxref :class-name 'nyxt/editor-mode:editor-mode)
         " now has an equally powerful set of bindings in all key schemes, allowing one
 to open a file, save it, switch buffer or delete current buffer.")
-   (:li (:nxref :command 'paste-from-clipboard-ring) " is now conveniently bound to "
+   (:li (:nxref :command 'nyxt/document-mode:paste-from-clipboard-ring) " is now conveniently bound to "
         (:code "M-y") " in Emacs scheme of "
         (:nxref :class-name 'nyxt/document-mode:document-mode) ".")
    (:li "Prompt-buffer now has familiar bindings for text cutting."))
@@ -503,10 +503,11 @@ the selection, and the string to paste instead of the clipboard (respectively)."
    (:li (:nxref :function 'encode-json) " and " (:nxref :function 'decode-json)
         " functions are now capable of encoding from/decoding to files, strings and streams.")
    (:li (:nxref :function 'nyxt/dom:copy) " generic to copy elements and whole DOMs.")
-   (:li "New " (:nxref :command 'define-bookmarklet-command-global)
+   (:li "New " (:code 'nyxt/bookmarklets-mode:define-bookmarklet-command-global)
         " that allows to define bookmarklets globally.")
-   (:li (:code "open-new-editor-with-file") " renamed to " (:nxref :command 'edit-file) ".")
-   (:li "Add " (:nxref :command 'edit-file-with-external-editor)
+   (:li (:code "open-new-editor-with-file") " renamed to "
+        (:nxref :command 'nyxt/editor-mode:edit-file) ".")
+   (:li "Add " (:nxref :command 'nyxt/file-manager-mode:edit-file-with-external-editor)
         " to edit arbitrary files in the editor of choice.")
    (:li (:code "peval") " and " (:code "pflet") " renamed to " (:nxref :function 'ps-eval) " and "
         (:nxref :function 'ps-labels) " (respectively).")
@@ -529,8 +530,9 @@ the selection, and the string to paste instead of the clipboard (respectively)."
         " enabling proper typing and adding handlers to them.")
    (:li "Clipboard ring is properly filled on every clipboard action happening
         inside Nyxt.")
-   (:li (:nxref :command 'view-source) " returns an unmodified DOM without "
-        (:code "nyxt-identifier") "s or other Nyxt-specific implementation details.")
+   (:li (:nxref :command 'nyxt/document-mode:view-source)
+        " returns an unmodified DOM without " (:code "nyxt-identifier")
+        "s or other Nyxt-specific implementation details.")
    (:li "Fix " (:nxref :command 'nyxt/history-mode:history-backwards)
         " by gracefully handling pages that are not yet done loading.")
    (:li "Fix full-screening event handling — status buffer no longer goes

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -515,7 +515,7 @@ the selection, and the string to paste instead of the clipboard (respectively)."
    (:li "Security: don't read arbitrary Lisp values from URLs when searching for
         internal pages.")
    (:li "Improve version parsing so that it is aware of pre-releases (notice
-        that it propagates to reader macro such as "
+        that it propagates to reader macros such as "
         (:code "#+nyxt-3-pre-release-2") ".")
    (:li "Fix touchscreen gestures for VI mode.")
    (:li "Fix processing absolute paths via relative paths when opening files.")

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -441,30 +441,46 @@ SLY install.")
 (define-version "3.0.0"
   (:ul
    (:li (:nxref :class-name 'nyxt/reduce-tracking-mode:reduce-tracking-mode)
-        " now cleans widely known tracking query parameters.")
-   (:li "Improve the algorithm that determines if an element is in viewport.")
-   (:li (:code "nyxt/hint-mode:box-style") "renamed
-   to " (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'style) ".")
-   (:li (:code "nyxt/hint-mode:highlighted-box-style") "is deprecated as it was
-   merged into " (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'style) ".")
-   (:li "Remove image support from " (:nxref :class-name 'nyxt/hint-mode:hint-mode) ".")
-   (:li "Hints are now computed in viewport.")
-   (:li "Add " (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'nyxt/hint-mode:fit-to-prompt-p)
-        "to configure whether the prompt takes the bare minimum of the screen space.")
-   (:li "Add " (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'nyxt/hint-mode:show-hint-scope-p)
+        " cleans widely known tracking query parameters.")
+   (:li "Improve the algorithm that determines whether an element is in viewport.")
+   (:li "Rename " (:code "nyxt/hint-mode:box-style") " to "
+        (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'style) ".")
+   (:li "Deprecate "(:code "nyxt/hint-mode:highlighted-box-style") "and merge
+        into " (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'style) ".")
+   (:li "Remove " (:nxref :class-name 'nyxt/hint-mode:hint-mode) " image support
+        by default.")
+   (:li "Add "
+        (:nxref :class-name nyxt/hint-mode:hint-mode :slot 'compute-hints-in-view-port-p=)
+        " allowing hints to be optionally computed in viewport.")
+   (:li "Add " (:nxref :class-name 'prompt-buffer :slot 'height) " so that every
+        prompt has a configurable height (options are "
+        (:code ":default") (:code ":fit-to-prompt")
+        " or an integer specifying the height in pixels).")
+   (:li "Add "
+        (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'fit-to-prompt-p)
+        " minimizing the space taken by the prompt-buffer while navigating hints.")
+   (:li "Add "
+        (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'nyxt/hint-mode:show-hint-scope-p)
         "for element highlighting of hinted elements.")
-   (:li "Add " (:nxref :class-name 'prompt-buffer :slot 'height)
-        "so that every prompt has a configurable height.")
-   (:li (:code "default-modes") " can be configured with " (:code "%slot-value%")
-        " due to finally having an underlying slot.")
-   (:li "New " (:nxref :command 'toggle-maximize) " command for maximizing a window.")
-   (:li "All the copying and pasting commands now fill the "
-        (:nxref :class-name 'browser :slot 'clipboard-ring) " reliably, thus making "
-        (:nxref :command 'paste-from-clipboard-ring) " useful again.")
-   (:li (:nxref :class-name 'nyxt/editor-mode:editor-mode) " is improved and cleaned up in general.")
+   (:li "Add " (:nxref :class-name 'prompter:source :slot 'marks-actions)
+        " that run when marked items on prompt-buffer change.")
+   (:li "Extend " (nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'style)
+        " to accommodate for marked hints.")
+   (:li (:code "default-modes") " can be configured with "
+        (:code "%slot-value%") " .")
+   (:li "Add " (:nxref :command 'toggle-maximize) " command for maximizing a window.")
+   (:li "All copying and pasting commands populate "
+        (:nxref :class-name 'browser :slot 'clipboard-ring) " reliably, thus fixing the "
+        (:nxref :command 'paste-from-clipboard-ring) " command.")
+   (:li "Major improvement of " (:nxref :class-name 'nyxt/editor-mode:editor-mode)
+        " (try it with " (:a :href "https://github.com/atlas-engineer/nx-ace" "nx-ace") ".")
    (:li (:code "execute-command")
-        " now can evaluate arbitrary Lisp code and provide you with the inline
-documentation for functions."))
+        " evaluates arbitrary Lisp code and provides inline documentation for symbols.")
+   (:li "Extend keybinding for all keyschemes in "
+        (:nxref :class-name 'nyxt/editor-mode:editor-mode) " .")
+   (:li "Bind " (:nxref :command 'paste-from-clipboard-ring) " to " (:code "M-y")
+        " in Emacs keyscheme.")
+   (:li "Bind familiar keys for text cutting in prompt-buffer."))
 
   (:h3 "Bindings")
   (:ul
@@ -499,21 +515,23 @@ the selection, and the string to paste instead of the clipboard (respectively)."
 
   (:h3 "Bug fixes")
   (:ul
-   (:li "Security: don't read arbitrary Lisp values from URLs when searching for internal pages.")
-   (:li "The version parsing (that features like " (:code "#+nyxt-3")
-        " depend on) is more robust and pre-release-aware now.")
-   (:li "Touchscreen gestures fixed for VI mode.")
-   (:li "Opening files via a relative path (for instance, " (:code "buffer.html")
-        ") is now correctly processed to an absolute path.")
+   (:li "Security: don't read arbitrary Lisp values from URLs when searching for
+        internal pages.")
+   (:li "Improve version parsing so that it is aware of pre-releases (notice
+        that it propagates to reader macro such as "
+        (:code "#+nyxt-3-pre-release-2") ".")
+   (:li "Fix touchscreen gestures for VI mode.")
+   (:li "Fix processing absolute paths via relative paths when opening files.")
    (:li "Setting " (:nxref :slot 'restore-session-on-startup-p :class-name 'browser)
-        "to nil no longer hangs the browser.")
+        "no longer hangs the browser.")
    (:li "Fix buffer re-attachment from the deleted window.")
-   (:li "Download hooks are properly typed and belong to " (:nxref :class-name 'nyxt/download-mode:download)
-        " now, allowing to add handlers to them.")
-   (:li "Clipboard ring is properly filled on every clipboard action happening inside Nyxt.")
-   (:li (:nxref :command 'view-source) " now shows a cleaned-up version of the pages without "
-        (:code "nyxt-identifier") "s and other Nyxt-specific helpers.")
-   (:li (:nxref :command 'nyxt/history-mode:history-backwards)
-        " does no longer skip pages when going back from pages that are not yet done loading.")
-   (:li "Fix full-screening event handling — status buffer no longer goes off-sync with
-the full-screened page/video.")))
+   (:li "Move download hooks to " (:nxref :class-name 'nyxt/download-mode:download)
+        " enabling proper typing and adding handlers to them.")
+   (:li "Clipboard ring is properly filled on every clipboard action happening
+        inside Nyxt.")
+   (:li (:nxref :command 'view-source) " returns an unmodified DOM without "
+        (:code "nyxt-identifier") "s or other Nyxt-specific implementation details.")
+   (:li "Fix " (:nxref :command 'nyxt/history-mode:history-backwards)
+        " by gracefully handling pages that are not yet done loading.")
+   (:li "Fix full-screening event handling — status buffer no longer goes
+        off-sync with the full-screened page/video.")))

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -469,8 +469,7 @@ SLY install.")
    (:li "All copying and pasting commands populate "
         (:nxref :class-name 'browser :slot 'clipboard-ring) " reliably, thus fixing the "
         (:nxref :command 'nyxt/document-mode:paste-from-clipboard-ring) " command.")
-   (:li "Major improvement of " (:nxref :class-name 'nyxt/editor-mode:editor-mode)
-        " (try it with " (:a :href "https://github.com/atlas-engineer/nx-ace" "nx-ace") ".")
+   (:li "Major improvement of " (:nxref :class-name 'nyxt/editor-mode:editor-mode) ".")
    (:li (:code "execute-command")
         " evaluates arbitrary Lisp code and provides inline documentation for symbols.")
    (:li "Extend keybinding for all keyschemes in "

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -452,10 +452,7 @@ SLY install.")
    (:li "Add "
         (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'nyxt/hint-mode:compute-hints-in-view-port-p)
         " allowing hints to be optionally computed in viewport.")
-   (:li "Add " (:nxref :class-name 'prompt-buffer :slot 'height) " so that every
-        prompt has a configurable height (options are "
-        (:code ":default") ", " (:code ":fit-to-prompt")
-        " or an integer specifying the height in pixels).")
+   (:li "Add " (:nxref :class-name 'prompt-buffer :slot 'height) ".")
    (:li "Add "
         (:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'nyxt/hint-mode:fit-to-prompt-p)
         " minimizing the space taken by the prompt-buffer while navigating hints.")


### PR DESCRIPTION
# Description

As requested in #2565.

The rephrasing I did is in accordance to [this PR](https://github.com/atlas-engineer/nyxt-site/pull/71).

# Discussion

~~I don't understand why clicking on some of the hyperlinks on the changelog (`M-x changelog` on a running Nyxt instance) doesn't work. For instance `(:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'style)` works, but `(:nxref :class-name 'nyxt/hint-mode:hint-mode :slot 'compute-hints-in-view-port-p)` doesn't. Simply open the changelog on Nyxt and see if you can reproduce.~~

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
