### PR TITLE
Mark "nyxt:" URLs as secure.

### DIFF
--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -393,7 +393,7 @@ guarantee of the same result."
                 ;; buffer and `form' to have this buffer as the buffer-var.
                 (setf (url buffer) (quri:uri url))
                 (apply (form internal-page) args)))))))
-  :local-p t)
+  :secure-p t)
 
 (ps:defpsmacro nyxt/ps::lisp-eval ((&key (buffer '(nyxt:current-buffer)) title callback) &body form)
   "Request the lisp: URL and invoke CALLBACK when there's a successful result.


### PR DESCRIPTION
# Description

This marks the `nyxt:` URLs as `:secure-p`, thus allowing outside resources, like HTTP(S) pages, to link to Nyxt-specific `nyxt:` URLs. This way, one can post example URLs and make them clickable and executable in Nyxt.

# Discussion

This is one shot at #2364, and I see two options there
- Either restricting `nyxt:` URLs locally, and unlocking their query parameters to be any `read`-able value, and maybe ever non-readable ones;
- Or opening `nyxt:` URLs up to the world, while leaving their syntax restricted.

I've picked the second way, because:
- It opens more possibilities to both `nyxt:` URLs (like embedding stylesheets and other interface elements into internal pages), and to the outside world (we can now provide links to `nyxt:` pages, like `describe-class`, on our forums, for example).
- The syntax of `nyxt:` pages doesn't have much further to move, because passing non-printable objects (like buffers) will not be easily possible however much we change the syntax. Playing with the accessibility of the links is more productive, than playing with the restricted syntax in the restricted accessibility.

But does that sound sane? @Ambrevar, @aadcg, @jmercouris? Maybe we should not even change anything in the current state of affairs? Maybe we should have a proper security audit before changing the security settings of `nyxt:` pages, given their elevated privileges? Any other opinion?

A huge security problem is that marking those URLs as secure will:
- Allow embedding JS script from the outside world into `nyxt:` pages.
- These scripts, being controlled by neither Nyxt developers, not exrension/config writers, can contain arbitrary code and change in arbitrary ways.
- Executing those in the environment of `nyxt:` pages would allow executing arbitrary Lisp code from JS.
- Executing supply chain attacks on the scripts used on `nyxt:` pages could thus lead to the full control over the browser via these compromized scripts. 
Do we even need to gaze into this Pandora box, let alone open it?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.