### PR TITLE
spinneret-tags: Remove deprecated :universal keyword.

### DIFF
--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -109,15 +109,15 @@ non-overridable."
     `(:a :href ,(cond
                   (package `(nyxt:nyxt-url (read-from-string "nyxt:describe-package") :package ,package))
                   (variable `(nyxt:nyxt-url (read-from-string "nyxt:describe-variable")
-                                            :universal t :variable ,variable))
+                                            :variable ,variable))
                   (function `(nyxt:nyxt-url (read-from-string "nyxt:describe-function")
-                                            :universal t :fn ,function))
+                                            :fn ,function))
                   (command `(nyxt:nyxt-url (read-from-string "nyxt:describe-command")
                                            :command ,command))
                   (slot `(nyxt:nyxt-url (read-from-string "nyxt:describe-slot")
-                                        :universal t :name ,slot :class ,class-name))
+                                        :name ,slot :class ,class-name))
                   (class-name `(nyxt:nyxt-url (read-from-string "nyxt:describe-class")
-                                              :universal t :class ,class-name))
+                                              :class ,class-name))
                   (t `(nyxt:javascript-url
                        (ps:ps (nyxt/ps:lisp-eval
                                (:title "describe-any")


### PR DESCRIPTION
It should have been part of PR #2579.



# Discussion

@aartaka does it make sense?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
