### PR TITLE
libraries/user-interface: fix `eval' with runtime solution

### DIFF
--- a/libraries/user-interface/package.lisp
+++ b/libraries/user-interface/package.lisp
@@ -11,10 +11,9 @@
    #:update
    #:text
    #:action
-   #:object-expression
+   #:to-html-string
    #:paragraph
    #:progress-bar
    #:button
    #:percentage
-   #:object-string
    #:connect))

--- a/libraries/user-interface/user-interface.lisp
+++ b/libraries/user-interface/user-interface.lisp
@@ -17,9 +17,8 @@
   (setf (id element) (unique-id)))
 
 (defmethod object-string ((element ui-element))
-  ;; TODO: figure out how to remove `eval'
-  (eval `(spinneret:with-html-string
-           ,(object-expression element))))
+  (with-output-to-string (spinneret:*html*)
+    (spinneret:interpret-html-tree (object-expression element))))
 
 (defmethod connect ((element ui-element) buffer)
   (setf (buffer element) buffer))

--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -210,16 +210,16 @@ download."
            collect
            (:div :class "download"
                  (when (member (status download) '(:unloaded :loading))
-                   (:raw (user-interface:object-string cancel-button)))
+                   (:raw (user-interface:to-html-string cancel-button)))
                  (when (eq (status download) :finished)
-                   (:raw (user-interface:object-string open-button)))
+                   (:raw (user-interface:to-html-string open-button)))
                  (:p :class "download-url" (:a :href url url))
                  (:div :class "progress-bar-container"
-                       (:raw (user-interface:object-string progress)))
+                       (:raw (user-interface:to-html-string progress)))
                  (:div :class "status"
-                       (:raw (user-interface:object-string progress-text))
-                       (:raw (user-interface:object-string bytes-text))
-                       (:raw (user-interface:object-string status-text))))))))
+                       (:raw (user-interface:to-html-string progress-text))
+                       (:raw (user-interface:to-html-string bytes-text))
+                       (:raw (user-interface:to-html-string status-text))))))))
 
 
 (defun download-watch (download-render download-object)


### PR DESCRIPTION
As recommended by the README of spinneret:
<https://github.com/ruricolist/spinneret#interpreting-trees>

# Description

Removed `TODO` in code that asked to remove `eval`.

# Discussion

The spinneret project claims that the function `interpret-html-tree` does not support the full range of features. It should be fine for the marshalled expressions. It could be tested with a unit test.

Feel free to comment on this commit and offer tips, it's my first in the project.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
