### PR TITLE
renderer/gtk: Fix exit-code slots

### DIFF
--- a/source/renderer/gi-gtk.lisp
+++ b/source/renderer/gi-gtk.lisp
@@ -46,7 +46,7 @@ interface. On Darwin, we must run the GTK thread on the main thread."
           (unless nyxt::*run-from-repl-p*
             (bt:join-thread main-thread)
             ;; See comment about FreeBSD in gtk.lisp
-            (uiop:quit (slot-value browser 'exit-code) #+freebsd nil)))
+            (uiop:quit (slot-value browser 'nyxt::exit-code) #+freebsd nil)))
         #+darwin
         (main-func)))
 

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -275,7 +275,7 @@ the renderer thread, use `defmethod' instead."
           ;; UIOP:QUIT with FINISH-OUTPUT = NIL in the first place.
           ;;
           ;; FIXME: This also can be true for other BSD systems.
-          (uiop:quit (slot-value browser 'exit-code) #+freebsd nil)))
+          (uiop:quit (slot-value browser 'nyxt::exit-code) #+freebsd nil)))
       #+darwin
       (progn
         (setf gtk-running-p t)


### PR DESCRIPTION
This fixes the following bug, in addition to the similar one in `gtk.lisp`:

```
<WARN> [17:07:37] Warning: Error: When attempting to read the slot's value (slot-value), the slot
NYXT/RENDERER/GI-GTK::EXIT-CODE is missing from the object
#&lt;BROWSER {100B5BCE13}&gt;.
It has a slot NYXT::EXIT-CODE, while NYXT/RENDERER/GI-GTK::EXIT-CODE is requested.
```

