### PR TITLE
Use LASS in libraries/theme.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -590,3 +590,7 @@
 	path = _build/nsymbols
 	url = https://github.com/atlas-engineer/nsymbols
   	shallow = true
+[submodule "_build/LASS"]
+	path = _build/LASS
+	url = https://github.com/Shinmera/LASS
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -50,10 +50,6 @@
 	path = _build/metatilities-base
 	url = https://github.com/gwkkwg/metatilities-base
 	shallow = true
-[submodule "_build/cl-css"]
-	path = _build/cl-css
-	url = https://github.com/inaimathi/cl-css/
-	shallow = true
 [submodule "_build/cl-custom-hash-table"]
 	path = _build/cl-custom-hash-table
 	url = https://github.com/metawilm/cl-custom-hash-table

--- a/build-scripts/nyxt.scm
+++ b/build-scripts/nyxt.scm
@@ -137,7 +137,6 @@
           cl-base64
           cl-calispel
           cl-containers
-          cl-css
           cl-closer-mop
           cl-clss
           cl-cluffer

--- a/build-scripts/nyxt.scm
+++ b/build-scripts/nyxt.scm
@@ -153,6 +153,7 @@
           cl-hu.dwim.defclass-star
           cl-iolib
           cl-json
+          cl-lass
           cl-local-time
           cl-lparallel
           cl-log4cl

--- a/documents/SOURCES.org
+++ b/documents/SOURCES.org
@@ -12,7 +12,6 @@ which external dependencies we are directly relying on.
 - bordeaux-threads
 - calispel
 - cl-containers
-- cl-css
 - cl-custom-hash-table
 - cl-html-diff
 - cl-json
@@ -28,6 +27,7 @@ which external dependencies we are directly relying on.
 - fset
 - hu.dwim.defclass-star
 - iolib
+- lass
 - local-time
 - log4cl
 - lparallel

--- a/libraries/theme/tests/test.lisp
+++ b/libraries/theme/tests/test.lisp
@@ -23,30 +23,30 @@
   (lisp-unit2::assert-string= "a{background-color:black;color:yellow;}"
                   (let ((lass:*pretty* nil))
                     (theme:themed-css *theme*
-                      (a
-                       :background-color #(theme:background)
-                       :color #(theme:primary))))))
+                      `(a
+                        :background-color ,theme:background
+                        :color ,theme:primary)))))
 
 (define-test multi-rule/multi-color-substitution ()
   (lisp-unit2::assert-string= "a{background-color:black;color:yellow;}body{background-color:yellow;color:white;}h1{color:magenta;}"
                   (let ((lass:*pretty* nil))
                     (theme:themed-css *theme*
-                      (a
-                       :background-color #(theme:background)
-                       :color #(theme:primary))
-                      (body
-                       :background-color #(theme:primary)
-                       :color #(theme:on-background))
-                      (h1
-                       :color #(theme:accent))))))
+                      `(a
+                       :background-color ,theme:background
+                       :color ,theme:primary)
+                      `(body
+                       :background-color ,theme:primary
+                       :color ,theme:on-background)
+                      `(h1
+                       :color ,theme:accent)))))
 
 (define-test irregular-args ()
   (lisp-unit2::assert-string=  "body{background-color:yellow;color:magenta !important;}"
                    (let ((lass:*pretty* nil))
                      (theme:themed-css *theme*
-                       (body
-                        :background-color #(theme:primary)
-                        :color #(theme:accent) "!important")))))
+                       `(body
+                         :background-color ,theme:primary
+                         :color ,theme:accent "!important")))))
 
 (define-test quasi-quoted-form ()
   (lisp-unit2::assert-string= "body{color:black;background-color:yellow;}"
@@ -56,7 +56,7 @@
                         :color ,(if (theme:dark-p theme:theme)
                                     theme:background
                                     theme:on-background)
-                        :background-color #(theme:primary))))))
+                        :background-color ,theme:primary)))))
 
 (defun hex-to-rgb (hex)
   "Convert HEX to an RGB triple."

--- a/libraries/theme/tests/test.lisp
+++ b/libraries/theme/tests/test.lisp
@@ -20,45 +20,43 @@
   "Dummy theme for testing.")
 
 (define-test basic-css-substitution ()
-  (lisp-unit2::assert-string= "a { background-color: black; color: yellow; }
-"
-                  (theme:themed-css *theme*
-                    (a
-                     :background-color theme:background
-                     :color theme:primary))))
+  (lisp-unit2::assert-string= "a{background-color:black;color:yellow;}"
+                  (let ((lass:*pretty* nil))
+                    (theme:themed-css *theme*
+                      (a
+                       :background-color #(theme:background)
+                       :color #(theme:primary))))))
 
 (define-test multi-rule/multi-color-substitution ()
-  (lisp-unit2::assert-string= "a { background-color: black; color: yellow; }
-body { background-color: yellow; color: white; }
-h1 { color: magenta; }
-"
-                  (theme:themed-css *theme*
-                    (a
-                     :background-color theme:background
-                     :color theme:primary)
-                    (body
-                     :background-color theme:primary
-                     :color theme:on-background)
-                    (h1
-                     :color theme:accent))))
+  (lisp-unit2::assert-string= "a{background-color:black;color:yellow;}body{background-color:yellow;color:white;}h1{color:magenta;}"
+                  (let ((lass:*pretty* nil))
+                    (theme:themed-css *theme*
+                      (a
+                       :background-color #(theme:background)
+                       :color #(theme:primary))
+                      (body
+                       :background-color #(theme:primary)
+                       :color #(theme:on-background))
+                      (h1
+                       :color #(theme:accent))))))
 
-(define-test inline-function-execution ()
-  (lisp-unit2::assert-string=  "body { background-color: yellow; color: magenta !important; }
-"
-                   (theme:themed-css *theme*
-                     (body
-                      :background-color theme:primary
-                      :color (concatenate 'string theme:accent " !important")))))
+(define-test irregular-args ()
+  (lisp-unit2::assert-string=  "body{background-color:yellow;color:magenta !important;}"
+                   (let ((lass:*pretty* nil))
+                     (theme:themed-css *theme*
+                       (body
+                        :background-color #(theme:primary)
+                        :color #(theme:accent) "!important")))))
 
-(define-test inline-macro/special-form-invocation ()
-  (lisp-unit2::assert-string= "body { color: black; background-color: yellow; }
-"
-                  (theme:themed-css *theme*
-                    (body
-                     :color (if (theme:dark-p theme:theme)
-                                theme:background
-                                theme:on-background)
-                     :background-color theme:primary))))
+(define-test quasi-quoted-form ()
+  (lisp-unit2::assert-string= "body{color:black;background-color:yellow;}"
+                  (let ((lass:*pretty* nil))
+                    (theme:themed-css *theme*
+                      `(body
+                        :color ,(if (theme:dark-p theme:theme)
+                                    theme:background
+                                    theme:on-background)
+                        :background-color #(theme:primary))))))
 
 (defun hex-to-rgb (hex)
   "Convert HEX to an RGB triple."

--- a/libraries/theme/theme.lisp
+++ b/libraries/theme/theme.lisp
@@ -151,13 +151,13 @@ headings have border of secondary color.
                             :dark-p t
                             :on-background-color \"red\"
                             :accent-color \"blue\")
-           '(|h1,h2,h3,h4,h5,h6|
+           `(|h1,h2,h3,h4,h5,h6|
              :border-style \"solid\"
              :border-width \"1px\"
-             :border-color #(theme:secondary))
+             :border-color ,theme:secondary)
            `(p
              :color ,(if (theme:dark-p theme:theme) theme:accent theme:secondary)
-             :background-color #(theme:background)))"
+             :background-color ,theme:background))"
   `(with-theme ,theme
      (funcall #'%themed-css theme:theme
               ;; NOTE: This loop allows to omit quotes for most trivial rules,

--- a/libraries/theme/theme.lisp
+++ b/libraries/theme/theme.lisp
@@ -110,19 +110,9 @@ out from all of the other theme colors.")
      ,@body))
 
 (defmacro themed-css (theme &body rules)
-  "Generate a CSS styled according to the THEME.
+  "Generate a CSS styled according to the THEME and RULES.
 
-RULES is a list of LASS rules. There are special symbols that this macro
-:let-binds with LASS:
-- `theme:background';
-- `theme:on-background';
-- `theme:primary';
-- `theme:on-primary';
-- `theme:secondary';
-- `theme:on-secondary';
-- `theme:accent';
-- `theme:on-accent';
-- `theme:font-family';
+RULES is a list of LASS rules.
 
 Any LASS-friendly syntax (including quasi-quotes) works, so you can evaluate
 arbitrary code before the rules are compiled. For the convenience of

--- a/libraries/theme/theme.lisp
+++ b/libraries/theme/theme.lisp
@@ -109,20 +109,6 @@ out from all of the other theme colors.")
           (theme:font-family (font-family theme:theme)))
      ,@body))
 
-(defun %themed-css (theme &rest rules)
-  (lass:compile-and-write
-   (append `(:let
-                ,(list (list (quote theme:background) (background-color theme))
-                       (list (quote theme:on-background) (on-background-color theme))
-                       (list (quote theme:primary) (primary-color theme))
-                       (list (quote theme:on-primary) (on-primary-color theme))
-                       (list (quote theme:secondary) (secondary-color theme))
-                       (list (quote theme:on-secondary) (on-secondary-color theme))
-                       (list (quote theme:accent) (accent-color theme))
-                       (list (quote theme:on-accent) (on-accent-color theme))
-                       (list (quote theme:font-family) (font-family theme))))
-           rules)))
-
 (defmacro themed-css (theme &body rules)
   "Generate a CSS styled according to the THEME.
 
@@ -159,20 +145,4 @@ headings have border of secondary color.
              :color ,(if (theme:dark-p theme:theme) theme:accent theme:secondary)
              :background-color ,theme:background))"
   `(with-theme ,theme
-     (funcall #'%themed-css theme:theme
-              ;; NOTE: This loop allows to omit quotes for most trivial rules,
-              ;; mostly preserving backwards-compatibility.
-              ,@(loop for rule in rules
-                      for first = (first rule)
-                      ;; FIXME: This is not perfect, but it's good enough for
-                      ;; 99% of cases. Maybe somehow parse selectors with LASS?
-                      if (or (stringp first)
-                             (keywordp first)
-                             (eq '* first)
-                             (and (symbolp first)
-                                  (eq :internal (nth-value 1 (find-symbol (symbol-name first)
-                                                                          (symbol-package first)))))
-                             (and (listp first)
-                                  (keywordp (first first))))
-                        collect (cons 'quote (list rule))
-                      else collect rule))))
+     (lass:compile-and-write ,@rules)))

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -42,6 +42,7 @@
                flexi-streams
                iolib
                iolib/os
+               lass
                local-time
                lparallel
                log4cl

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -24,7 +24,6 @@
                bordeaux-threads
                calispel
                cl-base64
-               cl-css
                cl-gopher
                cl-html-diff
                cl-json
@@ -553,7 +552,7 @@
   :defsystem-depends-on (nyxt-asdf)
   :class :nyxt-system
   :depends-on (alexandria
-               cl-css
+               lass
                nyxt/class-star
                serapeum)
   :pathname #p"NYXT:libraries;theme;"

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -56,13 +56,13 @@ various parts, such as the path of all data files.")
               :height "3px"
               :border-radius "2px"
               :border-width "0")
-            (button
-             :background "transparent"
-             :color "inherit"
-             :border "none"
-             :padding 0
-             :font "inherit"
-             :outline "inherit")
+            `(button
+              :background "transparent"
+              :color "inherit"
+              :border "none"
+              :padding 0
+              :font "inherit"
+              :outline "inherit")
             `(.button
               :all "unset"
               :background-color ,theme:primary
@@ -83,20 +83,20 @@ various parts, such as the path of all data files.")
              :text-decoration "underline"
              :display "inline"
              :color ,theme:primary)
-            (".link:hover"
-             :opacity 0.8)
+            `(".link:hover"
+              :opacity 0.8)
             `(.accent
               :color ,theme:accent)
-            (|.button:hover|
-             :opacity 0.8)
+            `(|.button:hover|
+              :opacity 0.8)
             `(|.button:visited|
              :color ,theme:background)
             `(|.button:active|
              :color ,theme:background)
             `(a
              :color ,theme:primary)
-            ("a:hover"
-             :opacity 0.8)
+            `("a:hover"
+              :opacity 0.8)
             `(pre
              :overflow "auto"
              :color ,theme:on-background
@@ -114,8 +114,8 @@ various parts, such as the path of all data files.")
              :background-color ,theme:primary
              :color ,theme:on-primary
              :text-align "left")
-            (dt
-             :font-weight "bold")
+            `(dt
+              :font-weight "bold")
             `("::selection"
              :color ,theme:on-accent
              :background-color ,theme:accent)))
@@ -642,13 +642,13 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :font-weight 500)
             `(a
               :color ,theme:primary)
-            (button
-             :background "transparent"
-             :color "inherit"
-             :border "none"
-             :padding 0
-             :font "inherit"
-             :outline "inherit")
+            `(button
+              :background "transparent"
+              :color "inherit"
+              :border "none"
+              :padding 0
+              :font "inherit"
+              :outline "inherit")
             `(.button
               :background-color ,theme:primary
               :color ,theme:on-primary
@@ -657,8 +657,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :border-radius "2px"
               :padding "6px"
               :margin "2px")
-            (|.button:hover|
-             :opacity 0.8)
+            `(|.button:hover|
+              :opacity 0.8)
             `(|.button:visited|
               :color ,theme:background)
             `(|.button:active|
@@ -682,11 +682,11 @@ store them somewhere and `ffi-buffer-delete' them once done."))
     nil
     :documentation "Display the modes as a list of glyphs.")
    (style (theme:themed-css (theme *browser*)
-            (body
-             :line-height "20px"
-             :font-size "14px"
-             :padding 0
-             :margin 0)
+            `(body
+              :line-height "20px"
+              :font-size "14px"
+              :padding 0
+              :margin 0)
             `(.loader
               :border-width "2px"
               :border-style "solid"
@@ -698,20 +698,20 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :width "7px"
               :height "7px"
               :animation "spin 1s linear infinite")
-            ("@keyframes spin"
-             ("0%" :transform "rotate(0deg)")
-             ("100%" :transform "rotate(360deg)"))
-            (".arrow-right"
-             :clip-path "polygon(0 0, calc(100% - 10px) 0, 100% 50%, calc(100% - 10px) 100%, 0 100%)"
-             :margin-right "-10px")
-            (".arrow-left"
-             :clip-path "polygon(10px 0, 100% 0, 100% 100%, 10px 100%, 0% 50%)"
-             :margin-left "-10px")
-            ("#container"
-             :display "flex"
-             ;; Columns: controls, url, tabs, modes
-             :justify-content "space-between"
-             :overflow-y "hidden")
+            `("@keyframes spin"
+              ("0%" :transform "rotate(0deg)")
+              ("100%" :transform "rotate(360deg)"))
+            `(".arrow-right"
+              :clip-path "polygon(0 0, calc(100% - 10px) 0, 100% 50%, calc(100% - 10px) 100%, 0 100%)"
+              :margin-right "-10px")
+            `(".arrow-left"
+              :clip-path "polygon(10px 0, 100% 0, 100% 100%, 10px 100%, 0% 50%)"
+              :margin-left "-10px")
+            `("#container"
+              :display "flex"
+              ;; Columns: controls, url, tabs, modes
+              :justify-content "space-between"
+              :overflow-y "hidden")
             `("#controls"
               :background-color ,theme:secondary
               :color ,theme:on-secondary
@@ -748,16 +748,16 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :flex-grow "10"
               :flex-shrink "4"
               :flex-basis "10em")
-            ("#tabs::-webkit-scrollbar"
-             :display "none")
+            `("#tabs::-webkit-scrollbar"
+              :display "none")
             `(.tab
               :color ,theme:background
               :white-space "nowrap"
               :text-decoration "none"
               :padding-left "5px"
               :padding-right "5px")
-            (".tab:hover"
-             :opacity 0.8)
+            `(".tab:hover"
+              :opacity 0.8)
             `("#modes"
               :background-color ,theme:primary
               :color ,theme:on-primary
@@ -770,18 +770,18 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :flex-grow "2"
               :flex-shrink "1"
               :flex-basis "10em")
-            ("#modes::-webkit-scrollbar"
-             :display "none")
-            (button
-             :background "transparent"
-             :color "inherit"
-             :text-decoration "transparent"
-             :border "transparent"
-             :padding 0
-             :font "inherit"
-             :outline "inherit")
-            (|.button:hover|
-             :opacity 0.8))))
+            `("#modes::-webkit-scrollbar"
+              :display "none")
+            `(button
+              :background "transparent"
+              :color "inherit"
+              :text-decoration "transparent"
+              :border "transparent"
+              :padding 0
+              :font "inherit"
+              :outline "inherit")
+            `(|.button:hover|
+              :opacity 0.8))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:export-predicate-name-p t)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -43,16 +43,16 @@ various parts, such as the path of all data files.")
 
    (style (theme:themed-css (theme *browser*)
             (body
-             :background-color theme:background
-             :color theme:on-background
+             :background-color #(theme:background)
+             :color #(theme:on-background)
              :margin-left "20px"
              :margin-top "20px")
             ("h1,h2,h3,h4,h5,h6"
-             :color theme:primary
-             :font-family theme:font-family)
+             :color #(theme:primary)
+             :font-family #(theme:font-family))
             (hr
-             :background-color theme:secondary
-             :color theme:on-secondary
+             :background-color #(theme:secondary)
+             :color #(theme:on-secondary)
              :height "3px"
              :border-radius "2px"
              :border-width "0")
@@ -65,60 +65,60 @@ various parts, such as the path of all data files.")
              :outline "inherit")
             (.button
              :all "unset"
-             :background-color theme:primary
-             :color theme:on-primary
+             :background-color #(theme:primary)
+             :color #(theme:on-primary)
              :display "inline-block"
              :text-decoration "none"
              :border-radius "2px"
-             :border-color theme:primary
+             :border-color #(theme:primary)
              :border-style "solid"
              :border-width "0px"
              :padding "6px"
              :margin "2px")
             (.button.accent
-             :background-color theme:accent
-             :color theme:on-accent)
+             :background-color #(theme:accent)
+             :color #(theme:on-accent))
             (.link
              :all "unset"
              :text-decoration "underline"
              :display "inline"
-             :color theme:primary)
+             :color #(theme:primary))
             (".link:hover"
              :opacity 0.8)
             (.accent
-             :color theme:accent)
+             :color #(theme:accent))
             (|.button:hover|
              :opacity 0.8)
             (|.button:visited|
-             :color theme:background)
+             :color #(theme:background))
             (|.button:active|
-             :color theme:background)
+             :color #(theme:background))
             (a
-             :color theme:primary)
+             :color #(theme:primary))
             ("a:hover"
              :opacity 0.8)
             (pre
              :overflow "auto"
-             :color theme:on-background
-             :background-color theme:secondary
+             :color #(theme:on-background)
+             :background-color #(theme:secondary)
              :border-radius "2px"
              :padding "5px")
             ("table, th, td"
-             :border-color theme:secondary
+             :border-color #(theme:secondary)
              :border-collapse "collapse"
              :border-width "1px"
              :border-style "solid"
-             :background-color theme:background
-             :color theme:on-background)
+             :background-color #(theme:background)
+             :color #(theme:on-background))
             (th
-             :background-color theme:primary
-             :color theme:on-primary
+             :background-color #(theme:primary)
+             :color #(theme:on-primary)
              :text-align "left")
             (dt
              :font-weight "bold")
             ("::selection"
-             :color theme:on-accent
-             :background-color theme:accent)))
+             :color #(theme:on-accent)
+             :background-color #(theme:accent))))
    (buffer-delete-hook                  ; TODO: Should we move this to `context-buffer'?
     (make-instance 'hook-buffer)
     :type hook-buffer
@@ -630,18 +630,18 @@ store them somewhere and `ffi-buffer-delete' them once done."))
   ((width 250 :documentation "The width in pixels.")
    (style (theme:themed-css (theme *browser*)
             (body
-             :background-color theme:background
-             :color theme:on-background
+             :background-color #(theme:background)
+             :color #(theme:on-background)
              :margin "0"
              :padding "10px"
              :border-style "solid"
              :border-width "0px 1px"
-             :border-color theme:secondary)
+             :border-color #(theme:secondary))
             ("h1,h2,h3,h4,h5,h6"
-             :font-family theme:font-family
+             :font-family #(theme:font-family)
              :font-weight 500)
             (a
-             :color theme:primary)
+             :color #(theme:primary))
             (button
              :background "transparent"
              :color "inherit"
@@ -650,8 +650,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
              :font "inherit"
              :outline "inherit")
             (.button
-             :background-color theme:primary
-             :color theme:on-primary
+             :background-color #(theme:primary)
+             :color #(theme:on-primary)
              :display "inline-block"
              :text-decoration "none"
              :border-radius "2px"
@@ -660,9 +660,9 @@ store them somewhere and `ffi-buffer-delete' them once done."))
             (|.button:hover|
              :opacity 0.8)
             (|.button:visited|
-             :color theme:background)
+             :color #(theme:background))
             (|.button:active|
-             :color theme:background))))
+             :color #(theme:background)))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:export-predicate-name-p t)
@@ -691,8 +691,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
              :border-width "2px"
              :border-style "solid"
              :border-color "transparent"
-             :border-top-color theme:accent
-             :border-left-color theme:accent
+             :border-top-color #(theme:accent)
+             :border-left-color #(theme:accent)
              :border-radius "50%"
              :display "inline-block"
              :width "7px"
@@ -713,8 +713,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
              :justify-content "space-between"
              :overflow-y "hidden")
             ("#controls"
-             :background-color theme:secondary
-             :color theme:on-secondary
+             :background-color #(theme:secondary)
+             :color #(theme:on-secondary)
              ;; :font-size "16px"
              :font-weight "700"
              :padding-left "5px"
@@ -723,8 +723,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
              :z-index "3"
              :flex-basis "6em")
             ("#url"
-             :background-color theme:primary
-             :color theme:on-primary
+             :background-color #(theme:primary)
+             :color #(theme:on-primary)
              :min-width "100px"
              :text-overflow "ellipsis"
              :overflow-x "hidden"
@@ -736,8 +736,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
              :flex-shrink "2"
              :flex-basis "10em")
             ("#tabs"
-             :background-color theme:secondary
-             :color theme:on-secondary
+             :background-color #(theme:secondary)
+             :color #(theme:on-secondary)
              :min-width "100px"
              :white-space "nowrap"
              :overflow-x "scroll"
@@ -751,7 +751,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
             ("#tabs::-webkit-scrollbar"
              :display "none")
             (.tab
-             :color theme:background
+             :color #(theme:background)
              :white-space "nowrap"
              :text-decoration "none"
              :padding-left "5px"
@@ -759,8 +759,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
             (".tab:hover"
              :opacity 0.8)
             ("#modes"
-             :background-color theme:primary
-             :color theme:on-primary
+             :background-color #(theme:primary)
+             :color #(theme:on-primary)
              :text-align "right"
              :padding-left "10px"
              :padding-right "5px"

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -42,20 +42,20 @@ various parts, such as the path of all data files.")
    (title "")
 
    (style (theme:themed-css (theme *browser*)
-            (body
-             :background-color #(theme:background)
-             :color #(theme:on-background)
-             :margin-left "20px"
-             :margin-top "20px")
-            ("h1,h2,h3,h4,h5,h6"
-             :color #(theme:primary)
-             :font-family #(theme:font-family))
-            (hr
-             :background-color #(theme:secondary)
-             :color #(theme:on-secondary)
-             :height "3px"
-             :border-radius "2px"
-             :border-width "0")
+            `(body
+              :background-color ,theme:background
+              :color ,theme:on-background
+              :margin-left "20px"
+              :margin-top "20px")
+            `("h1,h2,h3,h4,h5,h6"
+              :color ,theme:primary
+              :font-family ,theme:font-family)
+            `(hr
+              :background-color ,theme:secondary
+              :color ,theme:on-secondary
+              :height "3px"
+              :border-radius "2px"
+              :border-width "0")
             (button
              :background "transparent"
              :color "inherit"
@@ -63,62 +63,62 @@ various parts, such as the path of all data files.")
              :padding 0
              :font "inherit"
              :outline "inherit")
-            (.button
-             :all "unset"
-             :background-color #(theme:primary)
-             :color #(theme:on-primary)
-             :display "inline-block"
-             :text-decoration "none"
-             :border-radius "2px"
-             :border-color #(theme:primary)
-             :border-style "solid"
-             :border-width "0px"
-             :padding "6px"
-             :margin "2px")
-            (.button.accent
-             :background-color #(theme:accent)
-             :color #(theme:on-accent))
-            (.link
+            `(.button
+              :all "unset"
+              :background-color ,theme:primary
+              :color ,theme:on-primary
+              :display "inline-block"
+              :text-decoration "none"
+              :border-radius "2px"
+              :border-color ,theme:primary
+              :border-style "solid"
+              :border-width "0px"
+              :padding "6px"
+              :margin "2px")
+            `(.button.accent
+              :background-color ,theme:accent
+              :color ,theme:on-accent)
+            `(.link
              :all "unset"
              :text-decoration "underline"
              :display "inline"
-             :color #(theme:primary))
+             :color ,theme:primary)
             (".link:hover"
              :opacity 0.8)
-            (.accent
-             :color #(theme:accent))
+            `(.accent
+              :color ,theme:accent)
             (|.button:hover|
              :opacity 0.8)
-            (|.button:visited|
-             :color #(theme:background))
-            (|.button:active|
-             :color #(theme:background))
-            (a
-             :color #(theme:primary))
+            `(|.button:visited|
+             :color ,theme:background)
+            `(|.button:active|
+             :color ,theme:background)
+            `(a
+             :color ,theme:primary)
             ("a:hover"
              :opacity 0.8)
-            (pre
+            `(pre
              :overflow "auto"
-             :color #(theme:on-background)
-             :background-color #(theme:secondary)
+             :color ,theme:on-background
+             :background-color ,theme:secondary
              :border-radius "2px"
              :padding "5px")
-            ("table, th, td"
-             :border-color #(theme:secondary)
+            `("table, th, td"
+             :border-color ,theme:secondary
              :border-collapse "collapse"
              :border-width "1px"
              :border-style "solid"
-             :background-color #(theme:background)
-             :color #(theme:on-background))
-            (th
-             :background-color #(theme:primary)
-             :color #(theme:on-primary)
+             :background-color ,theme:background
+             :color ,theme:on-background)
+            `(th
+             :background-color ,theme:primary
+             :color ,theme:on-primary
              :text-align "left")
             (dt
              :font-weight "bold")
-            ("::selection"
-             :color #(theme:on-accent)
-             :background-color #(theme:accent))))
+            `("::selection"
+             :color ,theme:on-accent
+             :background-color ,theme:accent)))
    (buffer-delete-hook                  ; TODO: Should we move this to `context-buffer'?
     (make-instance 'hook-buffer)
     :type hook-buffer
@@ -629,19 +629,19 @@ store them somewhere and `ffi-buffer-delete' them once done."))
 (define-class panel-buffer (input-buffer modable-buffer document-buffer network-buffer)
   ((width 250 :documentation "The width in pixels.")
    (style (theme:themed-css (theme *browser*)
-            (body
-             :background-color #(theme:background)
-             :color #(theme:on-background)
-             :margin "0"
-             :padding "10px"
-             :border-style "solid"
-             :border-width "0px 1px"
-             :border-color #(theme:secondary))
-            ("h1,h2,h3,h4,h5,h6"
-             :font-family #(theme:font-family)
-             :font-weight 500)
-            (a
-             :color #(theme:primary))
+            `(body
+              :background-color ,theme:background
+              :color ,theme:on-background
+              :margin "0"
+              :padding "10px"
+              :border-style "solid"
+              :border-width "0px 1px"
+              :border-color ,theme:secondary)
+            `("h1,h2,h3,h4,h5,h6"
+              :font-family ,theme:font-family
+              :font-weight 500)
+            `(a
+              :color ,theme:primary)
             (button
              :background "transparent"
              :color "inherit"
@@ -649,20 +649,20 @@ store them somewhere and `ffi-buffer-delete' them once done."))
              :padding 0
              :font "inherit"
              :outline "inherit")
-            (.button
-             :background-color #(theme:primary)
-             :color #(theme:on-primary)
-             :display "inline-block"
-             :text-decoration "none"
-             :border-radius "2px"
-             :padding "6px"
-             :margin "2px")
+            `(.button
+              :background-color ,theme:primary
+              :color ,theme:on-primary
+              :display "inline-block"
+              :text-decoration "none"
+              :border-radius "2px"
+              :padding "6px"
+              :margin "2px")
             (|.button:hover|
              :opacity 0.8)
-            (|.button:visited|
-             :color #(theme:background))
-            (|.button:active|
-             :color #(theme:background)))))
+            `(|.button:visited|
+              :color ,theme:background)
+            `(|.button:active|
+              :color ,theme:background))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
   (:export-predicate-name-p t)
@@ -687,17 +687,17 @@ store them somewhere and `ffi-buffer-delete' them once done."))
              :font-size "14px"
              :padding 0
              :margin 0)
-            (.loader
-             :border-width "2px"
-             :border-style "solid"
-             :border-color "transparent"
-             :border-top-color #(theme:accent)
-             :border-left-color #(theme:accent)
-             :border-radius "50%"
-             :display "inline-block"
-             :width "7px"
-             :height "7px"
-             :animation "spin 1s linear infinite")
+            `(.loader
+              :border-width "2px"
+              :border-style "solid"
+              :border-color "transparent"
+              :border-top-color ,theme:accent
+              :border-left-color ,theme:accent
+              :border-radius "50%"
+              :display "inline-block"
+              :width "7px"
+              :height "7px"
+              :animation "spin 1s linear infinite")
             ("@keyframes spin"
              ("0%" :transform "rotate(0deg)")
              ("100%" :transform "rotate(360deg)"))
@@ -712,64 +712,64 @@ store them somewhere and `ffi-buffer-delete' them once done."))
              ;; Columns: controls, url, tabs, modes
              :justify-content "space-between"
              :overflow-y "hidden")
-            ("#controls"
-             :background-color #(theme:secondary)
-             :color #(theme:on-secondary)
-             ;; :font-size "16px"
-             :font-weight "700"
-             :padding-left "5px"
-             :overflow "hidden"
-             :white-space "nowrap"
-             :z-index "3"
-             :flex-basis "6em")
-            ("#url"
-             :background-color #(theme:primary)
-             :color #(theme:on-primary)
-             :min-width "100px"
-             :text-overflow "ellipsis"
-             :overflow-x "hidden"
-             :white-space "nowrap"
-             :padding-right "10px"
-             :padding-left "15px"
-             :z-index "2"
-             :flex-grow "3"
-             :flex-shrink "2"
-             :flex-basis "10em")
-            ("#tabs"
-             :background-color #(theme:secondary)
-             :color #(theme:on-secondary)
-             :min-width "100px"
-             :white-space "nowrap"
-             :overflow-x "scroll"
-             :text-align "left"
-             :padding-left "15px"
-             :padding-right "10px"
-             :z-index "1"
-             :flex-grow "10"
-             :flex-shrink "4"
-             :flex-basis "10em")
+            `("#controls"
+              :background-color ,theme:secondary
+              :color ,theme:on-secondary
+              ;; :font-size "16px"
+              :font-weight "700"
+              :padding-left "5px"
+              :overflow "hidden"
+              :white-space "nowrap"
+              :z-index "3"
+              :flex-basis "6em")
+            `("#url"
+              :background-color ,theme:primary
+              :color ,theme:on-primary
+              :min-width "100px"
+              :text-overflow "ellipsis"
+              :overflow-x "hidden"
+              :white-space "nowrap"
+              :padding-right "10px"
+              :padding-left "15px"
+              :z-index "2"
+              :flex-grow "3"
+              :flex-shrink "2"
+              :flex-basis "10em")
+            `("#tabs"
+              :background-color ,theme:secondary
+              :color ,theme:on-secondary
+              :min-width "100px"
+              :white-space "nowrap"
+              :overflow-x "scroll"
+              :text-align "left"
+              :padding-left "15px"
+              :padding-right "10px"
+              :z-index "1"
+              :flex-grow "10"
+              :flex-shrink "4"
+              :flex-basis "10em")
             ("#tabs::-webkit-scrollbar"
              :display "none")
-            (.tab
-             :color #(theme:background)
-             :white-space "nowrap"
-             :text-decoration "none"
-             :padding-left "5px"
-             :padding-right "5px")
+            `(.tab
+              :color ,theme:background
+              :white-space "nowrap"
+              :text-decoration "none"
+              :padding-left "5px"
+              :padding-right "5px")
             (".tab:hover"
              :opacity 0.8)
-            ("#modes"
-             :background-color #(theme:primary)
-             :color #(theme:on-primary)
-             :text-align "right"
-             :padding-left "10px"
-             :padding-right "5px"
-             :overflow-x "scroll"
-             :white-space "nowrap"
-             :z-index "2"
-             :flex-grow "2"
-             :flex-shrink "1"
-             :flex-basis "10em")
+            `("#modes"
+              :background-color ,theme:primary
+              :color ,theme:on-primary
+              :text-align "right"
+              :padding-left "10px"
+              :padding-right "5px"
+              :overflow-x "scroll"
+              :white-space "nowrap"
+              :z-index "2"
+              :flex-grow "2"
+              :flex-shrink "1"
+              :flex-basis "10em")
             ("#modes::-webkit-scrollbar"
              :display "none")
             (button

--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -749,9 +749,7 @@ A command is a special kind of function that can be called with
                          based features are currently unlisted.")
                      (:h1 "Commands")))
     (format f "~a" (spinneret:with-html-string
-                     (:style (cl-css:css
-                              '((".nyxt-source"
-                                 :overflow "auto"))))))
+                     (:style (lass:compile-and-write '(.nyxt-source :overflow auto)))))
     (format f "~{~a ~%~}"
             (loop for command in (list-commands)
                   collect (spinneret:with-html-string

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -153,7 +153,7 @@ disabling compositing, you will need to restart Nyxt."))
   (nyxt::html-set-style (theme:themed-css (theme *browser*)
                           (h3
                            :font-size "10px"
-                           :font-family #(theme:font-family)
+                           :font-family ,theme:font-family
                            :font-weight 500)
                           (tr
                            :font-size "7px")
@@ -330,23 +330,23 @@ System information is also saved to clipboard."
                             (render-url (url bookmark)))))
                  (:p (format nil "No bookmarks in ~s." (files:expand (nyxt/bookmark-mode:bookmarks-file mode)))))))))
     (let ((dashboard-style (theme:themed-css (theme *browser*)
-                             (body
-                              :background-color #(theme:background)
-                              :color #(theme:on-background)
-                              :margin-top 0
-                              :margin-bottom 0)
+                             `(body
+                               :background-color ,theme:background
+                               :color ,theme:on-background
+                               :margin-top 0
+                               :margin-bottom 0)
                              ("#title"
                               :font-size "400%")
-                             ("#subtitle"
-                              :color #(theme:secondary))
-                             (.section
-                              :border-style "solid none none none"
-                              :border-color #(theme:secondary)
-                              :margin-top "10px"
-                              :overflow "scroll"
-                              :min-height "150px")
-                             ("h3"
-                              :color #(theme:secondary))
+                             `("#subtitle"
+                               :color ,theme:secondary)
+                             `(.section
+                               :border-style "solid none none none"
+                               :border-color ,theme:secondary
+                               :margin-top "10px"
+                               :overflow "scroll"
+                               :min-height "150px")
+                             `("h3"
+                               :color ,theme:secondary)
                              ("ul"
                               :list-style-type "circle"))))
       (spinneret:with-html-string

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -151,14 +151,14 @@ disabling compositing, you will need to restart Nyxt."))
 (define-command print-bindings-cheatsheet ()
   "Print a buffer listing all known bindings for the current buffer."
   (nyxt::html-set-style (theme:themed-css (theme *browser*)
-                          (h3
-                           :font-size "10px"
-                           :font-family ,theme:font-family
-                           :font-weight 500)
-                          (tr
-                           :font-size "7px")
-                          (div
-                           :display inline-block))
+                          `(h3
+                            :font-size "10px"
+                            :font-family ,theme:font-family
+                            :font-weight 500)
+                          `(tr
+                            :font-size "7px")
+                          `(div
+                            :display inline-block))
                         (describe-bindings))
   (nyxt/document-mode:print-buffer))
 
@@ -197,33 +197,33 @@ The version number is saved to clipboard."
   "Open up a buffer with useful links suitable for `default-new-buffer-url'."
   (spinneret:with-html-string
     (:style (:raw (theme:themed-css (theme *browser*)
-                    (body
-                     :min-height "100vh")
-                    (nav
-                     :text-align "center"
-                     :top 0)
-                    (details
-                     :display "inline"
-                     :margin "1em")
-                    (h1
-                     :font-size "5em"
-                     :margin "0.1em")
-                    (main
-                     :padding "10%"
-                     :text-align "center"
-                     :display "flex"
-                     :flex-direction "column"
-                     :justify-content "center")
-                    (.centered
-                     :text-align "center")
-                    (.button
-                     :min-width "100px")
-                    (.container
-                     :min-height "100%")
-                    (.copyright
-                     :position "absolute"
-                     :bottom "1em"
-                     :right "1em"))))
+                    `(body
+                      :min-height "100vh")
+                    `(nav
+                      :text-align "center"
+                      :top 0)
+                    `(details
+                      :display "inline"
+                      :margin "1em")
+                    `(h1
+                      :font-size "5em"
+                      :margin "0.1em")
+                    `(main
+                      :padding "10%"
+                      :text-align "center"
+                      :display "flex"
+                      :flex-direction "column"
+                      :justify-content "center")
+                    `(.centered
+                      :text-align "center")
+                    `(.button
+                      :min-width "100px")
+                    `(.container
+                      :min-height "100%")
+                    `(.copyright
+                      :position "absolute"
+                      :bottom "1em"
+                      :right "1em"))))
     (:div
      :class "container"
      (:nav
@@ -335,8 +335,8 @@ System information is also saved to clipboard."
                                :color ,theme:on-background
                                :margin-top 0
                                :margin-bottom 0)
-                             ("#title"
-                              :font-size "400%")
+                             `("#title"
+                               :font-size "400%")
                              `("#subtitle"
                                :color ,theme:secondary)
                              `(.section
@@ -347,8 +347,8 @@ System information is also saved to clipboard."
                                :min-height "150px")
                              `("h3"
                                :color ,theme:secondary)
-                             ("ul"
-                              :list-style-type "circle"))))
+                             `("ul"
+                               :list-style-type "circle"))))
       (spinneret:with-html-string
         (:style dashboard-style)
         (:div

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -288,16 +288,14 @@ The version number is saved to clipboard."
       (buffer "*Manual*" 'nyxt/help-mode:help-mode)
     "Show the manual."
     (spinneret:with-html-string
-      (:style (cl-css:css '(("body"
-                             :max-width "80ch"))))
+      (:style (lass:compile-and-write '(body :max-width "80ch")))
       (:raw (manual-content)))))
 
 (define-internal-page-command-global tutorial ()
     (buffer "*Tutorial*" 'nyxt/help-mode:help-mode)
   "Show the tutorial."
   (spinneret:with-html-string
-    (:style (cl-css:css '(("body"
-                           :max-width "80ch"))))
+    (:style (lass:compile-and-write '(body :max-width "80ch")))
     (:h1 "Nyxt tutorial")
     (:p "The following tutorial introduces core concepts and
 basic usage.  For more details, especially regarding configuration, see

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -153,7 +153,7 @@ disabling compositing, you will need to restart Nyxt."))
   (nyxt::html-set-style (theme:themed-css (theme *browser*)
                           (h3
                            :font-size "10px"
-                           :font-family theme:font-family
+                           :font-family #(theme:font-family)
                            :font-weight 500)
                           (tr
                            :font-size "7px")
@@ -333,22 +333,22 @@ System information is also saved to clipboard."
                  (:p (format nil "No bookmarks in ~s." (files:expand (nyxt/bookmark-mode:bookmarks-file mode)))))))))
     (let ((dashboard-style (theme:themed-css (theme *browser*)
                              (body
-                              :background-color theme:background
-                              :color theme:on-background
+                              :background-color #(theme:background)
+                              :color #(theme:on-background)
                               :margin-top 0
                               :margin-bottom 0)
                              ("#title"
                               :font-size "400%")
                              ("#subtitle"
-                              :color theme:secondary)
+                              :color #(theme:secondary))
                              (.section
                               :border-style "solid none none none"
-                              :border-color theme:secondary
+                              :border-color #(theme:secondary)
                               :margin-top "10px"
                               :overflow "scroll"
                               :min-height "150px")
                              ("h3"
-                              :color theme:secondary)
+                              :color #(theme:secondary))
                              ("ul"
                               :list-style-type "circle"))))
       (spinneret:with-html-string

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -581,14 +581,14 @@ every individual class controlling Nyxt interface elements. All such classes hav
           (define-configuration nyxt/style-mode:dark-mode
             ((style
               (theme:themed-css (theme *browser*)
-                (*
-                 :background-color #(theme:background) "!important"
-                 :background-image none "!important"
-                 :color "red" "!important")
-                (a
-                 :background-color #(theme:background) "!important"
-                 :background-image none "!important"
-                 :color "#AAAAAA" "!important"))))))
+                `(*
+                  :background-color ,theme:background "!important"
+                  :background-image none "!important"
+                  :color "red" "!important")
+                `(a
+                  :background-color ,theme:background "!important"
+                  :background-image none "!important"
+                  :color "#AAAAAA" "!important"))))))
         (:p "This snippet alters the " (:nxref :slot 'style :class-name 'nyxt/style-mode:dark-mode)
             " of Nyxt dark mode to have a more theme-compliant colors, using the "
             (:code "theme:themed-css")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -582,25 +582,13 @@ every individual class controlling Nyxt interface elements. All such classes hav
             ((style
               (theme:themed-css (theme *browser*)
                 (*
-                 :background-color (str:concat
-                                    (if (theme:dark-p theme:theme)
-                                        theme:background
-                                        theme:on-background)
-                                    " !important")
-                 :background-image "none !important"
-                 :color (str:concat
-                         (if (theme:dark-p theme:theme)
-                             theme:on-background
-                             theme:background)
-                         " !important"))
+                 :background-color #(theme:background) "!important"
+                 :background-image none "!important"
+                 :color "red" "!important")
                 (a
-                 :background-color (str:concat
-                                    (if (theme:dark-p theme:theme)
-                                        theme:background
-                                        theme:on-background)
-                                    " !important")
-                 :background-image "none !important"
-                 :color (str:concat theme:primary " !important")))))))
+                 :background-color #(theme:background) "!important"
+                 :background-image none "!important"
+                 :color "#AAAAAA" "!important"))))))
         (:p "This snippet alters the " (:nxref :slot 'style :class-name 'nyxt/style-mode:dark-mode)
             " of Nyxt dark mode to have a more theme-compliant colors, using the "
             (:code "theme:themed-css")

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -57,28 +57,28 @@ Bookmarks can be persisted to disk, see the `bookmarks-file' mode slot."
        "m u" 'bookmark-url
        "m d" 'delete-bookmark)))
    (style (theme:themed-css (theme *browser*)
-            ("summary"
-             :background-color #(theme:secondary)
-             :color #(theme:on-secondary)
-             :font-size "14px"
-             :padding "12px"
-             :margin "6px"
-             :border "none"
-             :border-radius "2px"
-             :outline "none"
-             :text-align "left")
+            `("summary"
+              :background-color ,theme:secondary
+              :color ,theme:on-secondary
+              :font-size "14px"
+              :padding "12px"
+              :margin "6px"
+              :border "none"
+              :border-radius "2px"
+              :outline "none"
+              :text-align "left")
             ("dl"
              :margin-left "8px")
             ;; Taken from buffer.lisp to save space for big bookmark lists.
-            (button
-             :background-color #(theme:secondary)
-             :color #(theme:on-secondary)
-             :display "inline-block"
-             :text-decoration "none"
-             :border-radius "2px"
-             :padding "6px"
-             :margin-left "2px"
-             :margin-right "2px")))))
+            `(button
+              :background-color ,theme:secondary
+              :color ,theme:on-secondary
+              :display "inline-block"
+              :text-decoration "none"
+              :border-radius "2px"
+              :padding "6px"
+              :margin-left "2px"
+              :margin-right "2px")))))
 
 (defmethod bookmarks-file ((buffer buffer))
   (bookmarks-file (find-submode 'bookmark-mode buffer)))

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -58,8 +58,8 @@ Bookmarks can be persisted to disk, see the `bookmarks-file' mode slot."
        "m d" 'delete-bookmark)))
    (style (theme:themed-css (theme *browser*)
             ("summary"
-             :background-color theme:secondary
-             :color theme:on-secondary
+             :background-color #(theme:secondary)
+             :color #(theme:on-secondary)
              :font-size "14px"
              :padding "12px"
              :margin "6px"
@@ -71,8 +71,8 @@ Bookmarks can be persisted to disk, see the `bookmarks-file' mode slot."
              :margin-left "8px")
             ;; Taken from buffer.lisp to save space for big bookmark lists.
             (button
-             :background-color theme:secondary
-             :color theme:on-secondary
+             :background-color #(theme:secondary)
+             :color #(theme:on-secondary)
              :display "inline-block"
              :text-decoration "none"
              :border-radius "2px"

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -67,8 +67,8 @@ Bookmarks can be persisted to disk, see the `bookmarks-file' mode slot."
               :border-radius "2px"
               :outline "none"
               :text-align "left")
-            ("dl"
-             :margin-left "8px")
+            `("dl"
+              :margin-left "8px")
             ;; Taken from buffer.lisp to save space for big bookmark lists.
             `(button
               :background-color ,theme:secondary

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -191,15 +191,15 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
     (panel-buffer "*Bookmarks panel*")
   "Shows all the bookmarks in a compact panel-buffer layout."
   (spinneret:with-html-string
-    (:style (cl-css:css
-             '((p
-                :font-size "12px"
-                :margin "0"
-                :white-space "nowrap"
-                :overflow-x "hidden"
-                :text-overflow "ellipsis")
-               (div
-                :padding-bottom "10px"))))
+    (:style (lass:compile-and-write
+             '(p
+               :font-size "12px"
+               :margin 0
+               :white-space nowrap
+               :overflow-x nidden
+               :text-overflow ellipsis)
+             '(div
+               :padding-bottom "10px")))
     (:body
      (:h1 "Bookmarks")
      (or (let ((bookmarks (files:content (bookmarks-file (current-buffer)))))

--- a/source/mode/buffer-listing.lisp
+++ b/source/mode/buffer-listing.lisp
@@ -100,12 +100,12 @@ With LINEAR-VIEW-P, list buffers linearly instead."
                                            (nyxt::switch-buffer :buffer buffer)))
                           (:span :title (title buffer) :class "title" (title buffer)))))))
     (spinneret:with-html-string
-      (:style (cl-css:css
-               '((".button"
-                  :white-space "nowrap"
-                  :overflow-x "hidden"
-                  :display "block"
-                  :text-overflow "ellipsis"))))
+      (:style (lass:compile-and-write
+               '(.button
+                 :white-space nowrap
+                 :overflow-x hidden
+                 :display block
+                 :text-overflow ellipsis)))
       (:body
        (:h1 "Buffers")
        (:button :class "button"

--- a/source/mode/diff.lisp
+++ b/source/mode/diff.lisp
@@ -9,18 +9,18 @@
 (define-mode diff-mode ()
   "Diff mode is used to view the diffs between two buffers."
   ((style (theme:themed-css (theme *browser*)
-            (".nyxt-diff-insert"
-             :background-color "#bbeabb"
-             :text-decoration "none")
-            ("ins.nyxt-diff-replace"
-             :background-color "#bbeabb"
-             :text-decoration "none")
-            (".nyxt-diff-delete"
-             :background-color "#efcbcf"
-             :text-decoration "none")
-            ("del.nyxt-diff-replace"
-             :background-color "#efcbcf"
-             :text-decoration "none"))
+            `(".nyxt-diff-insert"
+              :background-color "#bbeabb"
+              :text-decoration "none")
+            `("ins.nyxt-diff-replace"
+              :background-color "#bbeabb"
+              :text-decoration "none")
+            `(".nyxt-diff-delete"
+              :background-color "#efcbcf"
+              :text-decoration "none")
+            `("del.nyxt-diff-replace"
+              :background-color "#efcbcf"
+              :text-decoration "none"))
           :documentation "Diff colours for its visual representation.
 They're based on the modus-operandi theme by Protesilaos Stavrou, which follows
 the highest standard on accessibility."))

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -575,7 +575,7 @@ of buffers."
                           :left "0"
                           :right "0"
                           :bottom "0"
-                          :background theme:on-background
+                          :background #(theme:on-background)
                           :z-index #.(1- (expt 2 31)))))
         (selection-rectangle-style (theme:themed-css (theme *browser*)
                                      ("#nyxt-rectangle-selection"
@@ -584,8 +584,8 @@ of buffers."
                                       :left "0"
                                       :border-style "dotted"
                                       :border-width "1px"
-                                      :border-color theme:on-background
-                                      :background-color theme:on-background
+                                      :border-color #(theme:on-background)
+                                      :background-color #(theme:on-background)
                                       :opacity 0.05
                                       :z-index #.(1- (expt 2 30))))))
     (ps-labels :async t

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -587,7 +587,7 @@ of buffers."
                                        :border-color ,theme:on-background
                                        :background-color ,theme:on-background
                                        :opacity 0.05
-                                       :z-index #.(1- (expt 2 30))))))
+                                       :z-index ,(1- (expt 2 30))))))
     (ps-labels :async t
       ((add-overlay
         (overlay-style selection-rectangle-style)

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -569,25 +569,25 @@ of buffers."
 (defun frame-element-select ()
   "Allow the user to draw a frame around elements to select them."
   (let ((overlay-style (theme:themed-css (theme *browser*)
-                         ("#nyxt-overlay"
-                          :position "fixed"
-                          :top "0"
-                          :left "0"
-                          :right "0"
-                          :bottom "0"
-                          :background #(theme:on-background)
-                          :z-index #.(1- (expt 2 31)))))
+                         `("#nyxt-overlay"
+                           :position "fixed"
+                           :top "0"
+                           :left "0"
+                           :right "0"
+                           :bottom "0"
+                           :background ,theme:on-background
+                           :z-index #.(1- (expt 2 31)))))
         (selection-rectangle-style (theme:themed-css (theme *browser*)
-                                     ("#nyxt-rectangle-selection"
-                                      :position "absolute"
-                                      :top "0"
-                                      :left "0"
-                                      :border-style "dotted"
-                                      :border-width "1px"
-                                      :border-color #(theme:on-background)
-                                      :background-color #(theme:on-background)
-                                      :opacity 0.05
-                                      :z-index #.(1- (expt 2 30))))))
+                                     `("#nyxt-rectangle-selection"
+                                       :position "absolute"
+                                       :top "0"
+                                       :left "0"
+                                       :border-style "dotted"
+                                       :border-width "1px"
+                                       :border-color ,theme:on-background
+                                       :background-color ,theme:on-background
+                                       :opacity 0.05
+                                       :z-index #.(1- (expt 2 30))))))
     (ps-labels :async t
       ((add-overlay
         (overlay-style selection-rectangle-style)

--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -160,8 +160,8 @@ appearance in the buffer when they are setf'd."
   "Display list of downloads."
   ((style (theme:themed-css (theme *browser*)
             (".download"
-             :background-color theme:background
-             :color theme:on-background
+             :background-color #(theme:background)
+             :color #(theme:on-background)
              :margin-top "10px"
              :padding-left "5px"
              :brightness "80%"
@@ -170,7 +170,7 @@ appearance in the buffer when they are setf'd."
              :overflow "auto"
              :white-space "nowrap")
             (".download-url a"
-             :color theme:on-background
+             :color #(theme:on-background)
              :font-size "small")
             (".status p"
              :display "inline-block"
@@ -179,10 +179,10 @@ appearance in the buffer when they are setf'd."
              :height "20px"
              :width "100%")
             (".progress-bar-base"
-             :background-color theme:primary
+             :background-color #(theme:primary)
              :height "100%")
             (".progress-bar-fill"
-             :background-color theme:secondary
+             :background-color #(theme:secondary)
              :height "100%"))))
   (:toggler-command-p nil))
 

--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -159,31 +159,31 @@ appearance in the buffer when they are setf'd."
 (define-mode download-mode ()
   "Display list of downloads."
   ((style (theme:themed-css (theme *browser*)
-            (".download"
-             :background-color #(theme:background)
-             :color #(theme:on-background)
-             :margin-top "10px"
-             :padding-left "5px"
-             :brightness "80%"
-             :border-radius "3px")
+            `(".download"
+              :background-color ,theme:background
+              :color ,theme:on-background
+              :margin-top "10px"
+              :padding-left "5px"
+              :brightness "80%"
+              :border-radius "3px")
             (".download-url"
              :overflow "auto"
              :white-space "nowrap")
-            (".download-url a"
-             :color #(theme:on-background)
-             :font-size "small")
+            `(".download-url a"
+              :color ,theme:on-background
+              :font-size "small")
             (".status p"
              :display "inline-block"
              :margin-right "10px")
             (".progress-bar-container"
              :height "20px"
              :width "100%")
-            (".progress-bar-base"
-             :background-color #(theme:primary)
-             :height "100%")
-            (".progress-bar-fill"
-             :background-color #(theme:secondary)
-             :height "100%"))))
+            `(".progress-bar-base"
+              :background-color ,theme:primary
+              :height "100%")
+            `(".progress-bar-fill"
+              :background-color ,theme:secondary
+              :height "100%"))))
   (:toggler-command-p nil))
 
 

--- a/source/mode/download.lisp
+++ b/source/mode/download.lisp
@@ -166,18 +166,18 @@ appearance in the buffer when they are setf'd."
               :padding-left "5px"
               :brightness "80%"
               :border-radius "3px")
-            (".download-url"
-             :overflow "auto"
-             :white-space "nowrap")
+            `(".download-url"
+              :overflow "auto"
+              :white-space "nowrap")
             `(".download-url a"
               :color ,theme:on-background
               :font-size "small")
-            (".status p"
-             :display "inline-block"
-             :margin-right "10px")
-            (".progress-bar-container"
-             :height "20px"
-             :width "100%")
+            `(".status p"
+              :display "inline-block"
+              :margin-right "10px")
+            `(".progress-bar-container"
+              :height "20px"
+              :width "100%")
             `(".progress-bar-base"
               :background-color ,theme:primary
               :height "100%")

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -19,25 +19,25 @@
     :documentation "Whether the hinting prompt buffer is collapsed to the input line.")
    (style
     (theme:themed-css (theme *browser*)
-      (".nyxt-hint"
-       :background-color #(theme:background)
-       :color #(theme:on-background)
-       :font-family "monospace,monospace"
-       :padding "0px 0.3em"
-       :border-color #(theme:primary)
-       :border-radius "0.3em"
-       :border-width "0.2em"
-       :border-style "solid"
-       :z-index #.(1- (expt 2 31)))
-      (".nyxt-hint.nyxt-mark-hint"
-       :background-color #(theme:secondary)
-       :color #(theme:on-secondary)
-       :font-weight "bold")
-      (".nyxt-hint.nyxt-select-hint"
-       :background-color #(theme:accent)
-       :color #(theme:on-accent))
-      (".nyxt-element-hint"
-       :background-color #(theme:accent)))
+      `(".nyxt-hint"
+        :background-color ,theme:background
+        :color ,theme:on-background
+        :font-family "monospace,monospace"
+        :padding "0px 0.3em"
+        :border-color ,theme:primary
+        :border-radius "0.3em"
+        :border-width "0.2em"
+        :border-style "solid"
+        :z-index #.(1- (expt 2 31)))
+      `(".nyxt-hint.nyxt-mark-hint"
+        :background-color ,theme:secondary
+        :color ,theme:on-secondary
+        :font-weight "bold")
+      `(".nyxt-hint.nyxt-select-hint"
+        :background-color ,theme:accent
+        :color ,theme:on-accent)
+      `(".nyxt-element-hint"
+        :background-color ,theme:accent))
     :documentation "The style of the hint overlays.")
    (show-hint-scope-p
     nil

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -20,24 +20,24 @@
    (style
     (theme:themed-css (theme *browser*)
       (".nyxt-hint"
-       :background-color theme:background
-       :color theme:on-background
+       :background-color #(theme:background)
+       :color #(theme:on-background)
        :font-family "monospace,monospace"
        :padding "0px 0.3em"
-       :border-color theme:primary
+       :border-color #(theme:primary)
        :border-radius "0.3em"
        :border-width "0.2em"
        :border-style "solid"
        :z-index #.(1- (expt 2 31)))
       (".nyxt-hint.nyxt-mark-hint"
-       :background-color theme:secondary
-       :color theme:on-secondary
+       :background-color #(theme:secondary)
+       :color #(theme:on-secondary)
        :font-weight "bold")
       (".nyxt-hint.nyxt-select-hint"
-       :background-color theme:accent
-       :color theme:on-accent)
+       :background-color #(theme:accent)
+       :color #(theme:on-accent))
       (".nyxt-element-hint"
-       :background-color theme:accent))
+       :background-color #(theme:accent)))
     :documentation "The style of the hint overlays.")
    (show-hint-scope-p
     nil

--- a/source/mode/history-tree.lisp
+++ b/source/mode/history-tree.lisp
@@ -13,15 +13,15 @@
                :padding 0
                :list-style "none")
             (body
-             :background theme:background
-             :color theme:on-background
+             :background #(theme:background)
+             :color #(theme:on-background)
              :line-height "initial")
             (".current-buffer a"
-             :color theme:on-background)
+             :color #(theme:on-background))
             (".current-buffer a:hover"
              :opacity 0.5)
             (".other-buffer a"
-             :color theme:primary)
+             :color #(theme:primary))
             (".other-buffer a:hover"
              :opacity 0.5)
             (li
@@ -34,8 +34,8 @@
              :content "' '"
              :position "absolute"
              :width "1px"
-             :background-color theme:on-background ; is this right???
-             :color theme:background
+             :background-color #(theme:on-background) ; is this right???
+             :color #(theme:background)
              :top "5px"
              :bottom "-12px"
              :left "-10px")
@@ -48,8 +48,8 @@
              :content "' '"
              :position "absolute"
              :width "1px"
-             :background-color theme:on-background ; is this right???
-             :color theme:background
+             :background-color #(theme:on-background) ; is this right???
+             :color #(theme:background)
              :top "5px"
              :bottom "7px"
              :height "7px"
@@ -60,7 +60,7 @@
              :left "-10px"
              :width "10px"
              :height "1px"
-             :background-color theme:on-background ; is this right?
-             :color theme:background
+             :background-color #(theme:on-background) ; is this right?
+             :color #(theme:background)
              :top "12px"))))
   (:toggler-command-p nil))

--- a/source/mode/history-tree.lisp
+++ b/source/mode/history-tree.lisp
@@ -9,27 +9,27 @@
   "Mode for history-tree listing."
   ((visible-in-status-p nil)
    (style (theme:themed-css (theme *browser*)
-            (* :margin 0
-               :padding 0
-               :list-style "none")
+            `(* :margin 0
+                :padding 0
+                :list-style "none")
             `(body
               :background ,theme:background
               :color ,theme:on-background
               :line-height "initial")
             `(".current-buffer a"
               :color ,theme:on-background)
-            (".current-buffer a:hover"
-             :opacity 0.5)
+            `(".current-buffer a:hover"
+              :opacity 0.5)
             `(".other-buffer a"
               :color ,theme:primary)
-            (".other-buffer a:hover"
-             :opacity 0.5)
-            (li
-             :white-space "nowrap")
-            ("ul li"
-             :margin-left "15px"
-             :position "relative"
-             :padding-left "5px")
+            `(".other-buffer a:hover"
+              :opacity 0.5)
+            `(li
+              :white-space "nowrap")
+            `("ul li"
+              :margin-left "15px"
+              :position "relative"
+              :padding-left "5px")
             `("ul li::before"
               :content "' '"
               :position "absolute"
@@ -39,10 +39,10 @@
               :top "5px"
               :bottom "-12px"
               :left "-10px")
-            ("body > ul > li:first-child::before"
-             :top "12px")
-            ("ul li:not(:first-child):last-child::before"
-             :display "none")
+            `("body > ul > li:first-child::before"
+              :top "12px")
+            `("ul li:not(:first-child):last-child::before"
+              :display "none")
             `("ul li:only-child::before"
               :display "list-item"
               :content "' '"

--- a/source/mode/history-tree.lisp
+++ b/source/mode/history-tree.lisp
@@ -12,16 +12,16 @@
             (* :margin 0
                :padding 0
                :list-style "none")
-            (body
-             :background #(theme:background)
-             :color #(theme:on-background)
-             :line-height "initial")
-            (".current-buffer a"
-             :color #(theme:on-background))
+            `(body
+              :background ,theme:background
+              :color ,theme:on-background
+              :line-height "initial")
+            `(".current-buffer a"
+              :color ,theme:on-background)
             (".current-buffer a:hover"
              :opacity 0.5)
-            (".other-buffer a"
-             :color #(theme:primary))
+            `(".other-buffer a"
+              :color ,theme:primary)
             (".other-buffer a:hover"
              :opacity 0.5)
             (li
@@ -30,37 +30,37 @@
              :margin-left "15px"
              :position "relative"
              :padding-left "5px")
-            ("ul li::before"
-             :content "' '"
-             :position "absolute"
-             :width "1px"
-             :background-color #(theme:on-background) ; is this right???
-             :color #(theme:background)
-             :top "5px"
-             :bottom "-12px"
-             :left "-10px")
+            `("ul li::before"
+              :content "' '"
+              :position "absolute"
+              :width "1px"
+              :background-color ,theme:on-background ; is this right??
+              :color ,theme:background
+              :top "5px"
+              :bottom "-12px"
+              :left "-10px")
             ("body > ul > li:first-child::before"
              :top "12px")
             ("ul li:not(:first-child):last-child::before"
              :display "none")
-            ("ul li:only-child::before"
-             :display "list-item"
-             :content "' '"
-             :position "absolute"
-             :width "1px"
-             :background-color #(theme:on-background) ; is this right???
-             :color #(theme:background)
-             :top "5px"
-             :bottom "7px"
-             :height "7px"
-             :left "-10px")
-            ("ul li::after"
-             :content "' '"
-             :position "absolute"
-             :left "-10px"
-             :width "10px"
-             :height "1px"
-             :background-color #(theme:on-background) ; is this right?
-             :color #(theme:background)
-             :top "12px"))))
+            `("ul li:only-child::before"
+              :display "list-item"
+              :content "' '"
+              :position "absolute"
+              :width "1px"
+              :background-color ,theme:on-background ; is this right??
+              :color ,theme:background
+              :top "5px"
+              :bottom "7px"
+              :height "7px"
+              :left "-10px")
+            `("ul li::after"
+              :content "' '"
+              :position "absolute"
+              :left "-10px"
+              :width "10px"
+              :height "1px"
+              :background-color ,theme:on-background ; is this right
+              :color ,theme:background
+              :top "12px"))))
   (:toggler-command-p nil))

--- a/source/mode/list-history.lisp
+++ b/source/mode/list-history.lisp
@@ -11,6 +11,6 @@
    (style (theme:themed-css (theme *browser*)
             `(a
               :color ,theme:on-background)
-            ("a:hover"
-             :opacity 0.5))))
+            `("a:hover"
+              :opacity 0.5))))
   (:toggler-command-p nil))

--- a/source/mode/list-history.lisp
+++ b/source/mode/list-history.lisp
@@ -10,7 +10,7 @@
   ((visible-in-status-p nil)
    (style (theme:themed-css (theme *browser*)
             (a
-             :color theme:on-background)
+             :color #(theme:on-background))
             ("a:hover"
              :opacity 0.5))))
   (:toggler-command-p nil))

--- a/source/mode/list-history.lisp
+++ b/source/mode/list-history.lisp
@@ -9,8 +9,8 @@
   "Mode for listing history."
   ((visible-in-status-p nil)
    (style (theme:themed-css (theme *browser*)
-            (a
-             :color #(theme:on-background))
+            `(a
+              :color ,theme:on-background)
             ("a:hover"
              :opacity 0.5))))
   (:toggler-command-p nil))

--- a/source/mode/no-procrastinate.lisp
+++ b/source/mode/no-procrastinate.lisp
@@ -27,16 +27,16 @@
     :type no-procrastinate-hosts-file
     :documentation "File where hosts associated to procrastination are saved.")
    (style (theme:themed-css (theme *browser*)
-            ("summary"
-             :background-color #(theme:secondary)
-             :color            #(theme:on-secondary)
-             :font-size        "14px"
-             :padding          "16px"
-             :margin           "6px"
-             :width            "100%"
-             :border           "none"
-             :outline          "none"
-             :text-align       "left")))
+            `("summary"
+              :background-color ,theme:secondary
+              :color            ,theme:on-secondary
+              :font-size        "14px"
+              :padding          "16px"
+              :margin           "6px"
+              :width            "100%"
+              :border           "none"
+              :outline          "none"
+              :text-align       "left")))
    (nyxt/blocker-mode:hostlists
     (list (nyxt/blocker-mode:make-hostlist
            :hosts (mapcar #'(lambda (y) (hostname y))

--- a/source/mode/no-procrastinate.lisp
+++ b/source/mode/no-procrastinate.lisp
@@ -28,8 +28,8 @@
     :documentation "File where hosts associated to procrastination are saved.")
    (style (theme:themed-css (theme *browser*)
             ("summary"
-             :background-color theme:secondary
-             :color            theme:on-secondary
+             :background-color #(theme:secondary)
+             :color            #(theme:on-secondary)
              :font-size        "14px"
              :padding          "16px"
              :margin           "6px"

--- a/source/mode/plaintext-editor.lisp
+++ b/source/mode/plaintext-editor.lisp
@@ -25,8 +25,8 @@ To enable it, add this to your configuration file:
              :outline "none"
              :padding "5px"
              :autofocus "true"
-             :background-color theme:background
-             :color theme:on-background))))
+             :background-color #(theme:background)
+             :color #(theme:on-background)))))
   (:toggler-command-p nil))
 
 (defmethod markup ((editor plaintext-editor-mode))

--- a/source/mode/plaintext-editor.lisp
+++ b/source/mode/plaintext-editor.lisp
@@ -12,8 +12,8 @@ To enable it, add this to your configuration file:
   ((visible-in-status-p nil)
    (rememberable-p nil)
    (style (theme:themed-css (theme *browser*)
-            ("body"
-             :margin 0)
+            `("body"
+              :margin 0)
             `("#editor"
               :margin 0
               :position "absolute"

--- a/source/mode/plaintext-editor.lisp
+++ b/source/mode/plaintext-editor.lisp
@@ -14,19 +14,19 @@ To enable it, add this to your configuration file:
    (style (theme:themed-css (theme *browser*)
             ("body"
              :margin 0)
-            ("#editor"
-             :margin 0
-             :position "absolute"
-             :top "0"
-             :right "0"
-             :bottom "0"
-             :left "0"
-             :border "none"
-             :outline "none"
-             :padding "5px"
-             :autofocus "true"
-             :background-color #(theme:background)
-             :color #(theme:on-background)))))
+            `("#editor"
+              :margin 0
+              :position "absolute"
+              :top "0"
+              :right "0"
+              :bottom "0"
+              :left "0"
+              :border "none"
+              :outline "none"
+              :padding "5px"
+              :autofocus "true"
+              :background-color ,theme:background
+              :color ,theme:on-background))))
   (:toggler-command-p nil))
 
 (defmethod markup ((editor plaintext-editor-mode))

--- a/source/mode/reading-line.lisp
+++ b/source/mode/reading-line.lisp
@@ -37,7 +37,7 @@ mode."
               :left "0"
               :width "100%"
               :background-color ,theme:primary
-              :z-index #.(1- (expt 2 31)) ; 32 bit signed integer max
+              :z-index ,(1- (expt 2 31)) ; 32 bit signed integer max
               :opacity "15%"
               :height "20px"))
           :documentation "The CSS applied to the reading line.")))

--- a/source/mode/reading-line.lisp
+++ b/source/mode/reading-line.lisp
@@ -31,15 +31,15 @@ mode."
        "K" 'reading-line-cursor-up
        "J" 'reading-line-cursor-down)))
    (style (theme:themed-css (theme *browser*)
-            ("#reading-line-cursor"
-             :position "absolute"
-             :top "10px"
-             :left "0"
-             :width "100%"
-             :background-color #(theme:primary)
-             :z-index #.(1- (expt 2 31)) ; 32 bit signed integer max
-             :opacity "15%"
-             :height "20px"))
+            `("#reading-line-cursor"
+              :position "absolute"
+              :top "10px"
+              :left "0"
+              :width "100%"
+              :background-color ,theme:primary
+              :z-index #.(1- (expt 2 31)) ; 32 bit signed integer max
+              :opacity "15%"
+              :height "20px"))
           :documentation "The CSS applied to the reading line.")))
 
 (define-command jump-to-reading-line-cursor (&key (buffer (current-buffer)))

--- a/source/mode/reading-line.lisp
+++ b/source/mode/reading-line.lisp
@@ -36,7 +36,7 @@ mode."
              :top "10px"
              :left "0"
              :width "100%"
-             :background-color theme:primary
+             :background-color #(theme:primary)
              :z-index #.(1- (expt 2 31)) ; 32 bit signed integer max
              :opacity "15%"
              :height "20px"))

--- a/source/mode/remembrance.lisp
+++ b/source/mode/remembrance.lisp
@@ -53,9 +53,9 @@ Set to 0 to disable.")
     :documentation "Discard cached entry if its `last-update' is older than this.")
    ;; TODO: `style' belongs to a separate mode, doesn't it?  Same question as with `history-tree-mode'.
    (style (theme:themed-css (theme *browser*)
-            (* :margin 0
-               :padding 0
-               :list-style "none")))))
+            `(* :margin 0
+                :padding 0
+                :list-style "none")))))
 
 (defmethod initialize-instance :after ((mode remembrance-mode) &key)
   (let ((path (files:expand (cache-path mode))))

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -115,15 +115,15 @@ Features:
              :height "95vh"
              :width "97vw"
              :margin "1em")
-            (.input
-             :background-color #(theme:secondary)
+            `(.input
+             :background-color ,theme:secondary
              :width "99%"
              :padding 0
              :margin "1em 0")
             (.button
              :display "inline")
-            (.input-buffer
-             :color #(theme:on-accent)
+            `(.input-buffer
+             :color ,theme:on-accent
              :opacity "0.9"
              :border "none"
              :outline "none"

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -116,14 +116,14 @@ Features:
              :width "97vw"
              :margin "1em")
             (.input
-             :background-color theme:secondary
+             :background-color #(theme:secondary)
              :width "99%"
              :padding 0
              :margin "1em 0")
             (.button
              :display "inline")
             (.input-buffer
-             :color theme:on-accent
+             :color #(theme:on-accent)
              :opacity "0.9"
              :border "none"
              :outline "none"

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -105,23 +105,23 @@ Features:
        "K" 'move-cell-up
        "J" 'move-cell-down)))
    (style (theme:themed-css (theme *browser*)
-            (*
-             :font-family "monospace,monospace")
-            (body
-             :margin "0")
-            ("#container"
-             :display "flex"
-             :flex-flow "column"
-             :height "95vh"
-             :width "97vw"
-             :margin "1em")
+            `(*
+              :font-family "monospace,monospace")
+            `(body
+              :margin "0")
+            `("#container"
+              :display "flex"
+              :flex-flow "column"
+              :height "95vh"
+              :width "97vw"
+              :margin "1em")
             `(.input
              :background-color ,theme:secondary
              :width "99%"
              :padding 0
              :margin "1em 0")
-            (.button
-             :display "inline")
+            `(.button
+              :display "inline")
             `(.input-buffer
              :color ,theme:on-accent
              :opacity "0.9"
@@ -131,15 +131,15 @@ Features:
              :margin "3px"
              :autofocus "true"
              :width "99%")
-            ("#evaluations"
-             :font-size "12px"
-             :flex-grow "1"
-             :overflow-y "auto"
-             :overflow-x "auto")
-            (.controls
-             :position "absolute"
-             :bottom "1em"
-             :right "1em"))
+            `("#evaluations"
+              :font-size "12px"
+              :flex-grow "1"
+              :overflow-y "auto"
+              :overflow-x "auto")
+            `(.controls
+              :position "absolute"
+              :bottom "1em"
+              :right "1em"))
           :documentation "The CSS applied to a REPL when it is set-up.")
    (evaluations
     (list (make-instance 'evaluation :input "\"Hello, Nyxt!\""))

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -12,14 +12,14 @@
    (style
     (theme:themed-css (theme *browser*)
       (".nyxt-search-node .nyxt-hint"
-       :background-color theme:secondary
-       :color theme:on-secondary
+       :background-color #(theme:secondary)
+       :color #(theme:on-secondary)
        :padding "0px"
        :border-radius "0px"
        :z-index #.(1- (expt 2 31)))
       (".nyxt-search-node > .nyxt-hint.nyxt-select-hint"
-       :background-color theme:accent
-       :color theme:on-accent))
+       :background-color #(theme:accent)
+       :color #(theme:on-accent)))
     :documentation "The style of the search overlays.")
    (keyscheme-map
     (define-keyscheme-map "search-buffer-mode" ()

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -11,15 +11,15 @@
    (rememberable-p nil)
    (style
     (theme:themed-css (theme *browser*)
-      (".nyxt-search-node .nyxt-hint"
-       :background-color #(theme:secondary)
-       :color #(theme:on-secondary)
-       :padding "0px"
-       :border-radius "0px"
-       :z-index #.(1- (expt 2 31)))
-      (".nyxt-search-node > .nyxt-hint.nyxt-select-hint"
-       :background-color #(theme:accent)
-       :color #(theme:on-accent)))
+      `(".nyxt-search-node .nyxt-hint"
+        :background-color ,theme:secondary
+        :color ,theme:on-secondary
+        :padding "0px"
+        :border-radius "0px"
+        :z-index #.(1- (expt 2 31)))
+      `(".nyxt-search-node > .nyxt-hint.nyxt-select-hint"
+        :background-color ,theme:accent
+        :color ,theme:on-accent))
     :documentation "The style of the search overlays.")
    (keyscheme-map
     (define-keyscheme-map "search-buffer-mode" ()

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -40,9 +40,9 @@ Gemini support is a bit more chaotic, but you can override `line->html' for
     :documentation "The number of redirections that Gemini resources are allowed to make.")
    (style (theme:themed-css (nyxt::theme *browser*)
             (body
-             :background-color theme:background)
+             :background-color #(theme:background))
             (pre
-             :background-color theme:secondary
+             :background-color #(theme:secondary)
              :padding "2px"
              :margin "0"
              :border-radius 0)
@@ -50,11 +50,11 @@ Gemini support is a bit more chaotic, but you can override `line->html' for
              :margin "0 3px 3px 0"
              :font-size "15px")
             (.search
-             :background-color theme:accent
-             :color theme:on-accent)
+             :background-color #(theme:accent)
+             :color #(theme:on-accent))
             (.error
-             :background-color theme:accent
-             :color theme:on-accent
+             :background-color #(theme:accent)
+             :color #(theme:on-accent)
              :padding "1em 0"))))
   (:toggler-command-p nil))
 

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -46,9 +46,9 @@ Gemini support is a bit more chaotic, but you can override `line->html' for
               :padding "2px"
               :margin "0"
               :border-radius 0)
-            (.button
-             :margin "0 3px 3px 0"
-             :font-size "15px")
+            `(.button
+              :margin "0 3px 3px 0"
+              :font-size "15px")
             `(.search
               :background-color ,theme:accent
               :color ,theme:on-accent)

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -39,23 +39,23 @@ Gemini support is a bit more chaotic, but you can override `line->html' for
     5
     :documentation "The number of redirections that Gemini resources are allowed to make.")
    (style (theme:themed-css (nyxt::theme *browser*)
-            (body
-             :background-color #(theme:background))
-            (pre
-             :background-color #(theme:secondary)
-             :padding "2px"
-             :margin "0"
-             :border-radius 0)
+            `(body
+              :background-color ,theme:background)
+            `(pre
+              :background-color ,theme:secondary
+              :padding "2px"
+              :margin "0"
+              :border-radius 0)
             (.button
              :margin "0 3px 3px 0"
              :font-size "15px")
-            (.search
-             :background-color #(theme:accent)
-             :color #(theme:on-accent))
-            (.error
-             :background-color #(theme:accent)
-             :color #(theme:on-accent)
-             :padding "1em 0"))))
+            `(.search
+              :background-color ,theme:accent
+              :color ,theme:on-accent)
+            `(.error
+              :background-color ,theme:accent
+              :color ,theme:on-accent
+              :padding "1em 0"))))
   (:toggler-command-p nil))
 
 ;;; Gopher rendering.

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -56,30 +56,30 @@ some point.")
 selection over prompt buffer suggestions.")
      (style
       (theme:themed-css (theme *browser*)
-        (*
-         :font-family "monospace,monospace"
-         :font-size "14px"
-         :line-height "18px")
-        (body
-         :overflow "hidden"
-         :margin "0"
-         :padding "0")
+        `(*
+          :font-family "monospace,monospace"
+          :font-size "14px"
+          :line-height "18px")
+        `(body
+          :overflow "hidden"
+          :margin "0"
+          :padding "0")
         `("#prompt-area"
          :background-color ,theme:primary
          :color ,theme:on-primary
          :display "grid"
          :grid-template-columns "auto auto 1fr auto"
          :width "100%")
-        ("#prompt"
-         :padding-left "10px"
-         :line-height "26px")
-        ("#prompt-extra"
-         :line-height "26px"
-         :padding-right "7px")
-        ("#prompt-modes"
-         :line-height "26px"
-         :padding-left "3px"
-         :padding-right "3px")
+        `("#prompt"
+          :padding-left "10px"
+          :line-height "26px")
+        `("#prompt-extra"
+          :line-height "26px"
+          :padding-right "7px")
+        `("#prompt-modes"
+          :line-height "26px"
+          :padding-left "3px"
+          :padding-right "3px")
         `("#input"
          :background-color ,theme:background
          :color ,theme:on-background
@@ -89,11 +89,11 @@ selection over prompt buffer suggestions.")
          :padding "3px"
          :width "100%"
          :autofocus "true")
-        (".source"
-         :margin-left "10px"
-         :margin-top "15px")
-        (".source-glyph"
-         :margin-right "3px")
+        `(".source"
+          :margin-left "10px"
+          :margin-top "15px")
+        `(".source-glyph"
+          :margin-right "3px")
         `(".source-name"
          :background-color ,theme:secondary
          :color ,theme:on-secondary
@@ -112,18 +112,18 @@ selection over prompt buffer suggestions.")
          :margin-left "16px"
          :width "100%"
          :table-layout "fixed")
-        (".source-content td"
-         :white-space "nowrap"
-         :height "20px"
-         :overflow "auto")
+        `(".source-content td"
+          :white-space "nowrap"
+          :height "20px"
+          :overflow "auto")
         `(".source-content th"
          :background-color ,theme:primary
          :color ,theme:on-primary
          :font-weight "normal"
          :padding-left "3px"
          :text-align "left")
-        (".source-content td::-webkit-scrollbar"
-         :display "none")
+        `(".source-content td::-webkit-scrollbar"
+          :display "none")
         `("#selection"
          :background-color ,theme:accent
          :color ,theme:on-accent)
@@ -132,8 +132,8 @@ selection over prompt buffer suggestions.")
           :color ,theme:on-secondary
           :font-weight "bold")
         `(.selected
-         :background-color ,theme:primary
-         :color ,theme:on-primary))
+          :background-color ,theme:primary
+          :color ,theme:on-primary))
       :documentation "The CSS applied to a prompt-buffer when it is set-up.")
      (override-map
       (make-keymap "override-map")

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -65,8 +65,8 @@ selection over prompt buffer suggestions.")
          :margin "0"
          :padding "0")
         ("#prompt-area"
-         :background-color theme:primary
-         :color theme:on-primary
+         :background-color #(theme:primary)
+         :color #(theme:on-primary)
          :display "grid"
          :grid-template-columns "auto auto 1fr auto"
          :width "100%")
@@ -81,8 +81,8 @@ selection over prompt buffer suggestions.")
          :padding-left "3px"
          :padding-right "3px")
         ("#input"
-         :background-color theme:background
-         :color theme:on-background
+         :background-color #(theme:background)
+         :color #(theme:on-background)
          :opacity 0.9
          :border "none"
          :outline "none"
@@ -95,20 +95,20 @@ selection over prompt buffer suggestions.")
         (".source-glyph"
          :margin-right "3px")
         (".source-name"
-         :background-color theme:secondary
-         :color theme:on-secondary
+         :background-color #(theme:secondary)
+         :color #(theme:on-secondary)
          :padding-left "5px"
          :line-height "24px")
         ("#suggestions"
-         :background-color theme:background
-         :color theme:on-background
+         :background-color #(theme:background)
+         :color #(theme:on-background)
          :overflow-y "hidden"
          :overflow-x "hidden"
          :height "100%"
          :width "100%")
         (".source-content"
-         :background-color theme:background
-         :color theme:on-background
+         :background-color #(theme:background)
+         :color #(theme:on-background)
          :margin-left "16px"
          :width "100%"
          :table-layout "fixed")
@@ -117,23 +117,23 @@ selection over prompt buffer suggestions.")
          :height "20px"
          :overflow "auto")
         (".source-content th"
-         :background-color theme:primary
-         :color theme:on-primary
+         :background-color #(theme:primary)
+         :color #(theme:on-primary)
          :font-weight "normal"
          :padding-left "3px"
          :text-align "left")
         (".source-content td::-webkit-scrollbar"
          :display "none")
         ("#selection"
-         :background-color theme:accent
-         :color theme:on-accent)
+         :background-color #(theme:accent)
+         :color #(theme:on-accent))
         (.marked
-         :background-color theme:secondary
-         :color theme:on-secondary
+         :background-color #(theme:secondary)
+         :color #(theme:on-secondary)
          :font-weight "bold")
         (.selected
-         :background-color theme:primary
-         :color theme:on-primary))
+         :background-color #(theme:primary)
+         :color #(theme:on-primary)))
       :documentation "The CSS applied to a prompt-buffer when it is set-up.")
      (override-map
       (make-keymap "override-map")

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -64,9 +64,9 @@ selection over prompt buffer suggestions.")
          :overflow "hidden"
          :margin "0"
          :padding "0")
-        ("#prompt-area"
-         :background-color #(theme:primary)
-         :color #(theme:on-primary)
+        `("#prompt-area"
+         :background-color ,theme:primary
+         :color ,theme:on-primary
          :display "grid"
          :grid-template-columns "auto auto 1fr auto"
          :width "100%")
@@ -80,9 +80,9 @@ selection over prompt buffer suggestions.")
          :line-height "26px"
          :padding-left "3px"
          :padding-right "3px")
-        ("#input"
-         :background-color #(theme:background)
-         :color #(theme:on-background)
+        `("#input"
+         :background-color ,theme:background
+         :color ,theme:on-background
          :opacity 0.9
          :border "none"
          :outline "none"
@@ -94,21 +94,21 @@ selection over prompt buffer suggestions.")
          :margin-top "15px")
         (".source-glyph"
          :margin-right "3px")
-        (".source-name"
-         :background-color #(theme:secondary)
-         :color #(theme:on-secondary)
+        `(".source-name"
+         :background-color ,theme:secondary
+         :color ,theme:on-secondary
          :padding-left "5px"
          :line-height "24px")
-        ("#suggestions"
-         :background-color #(theme:background)
-         :color #(theme:on-background)
+        `("#suggestions"
+         :background-color ,theme:background
+         :color ,theme:on-background
          :overflow-y "hidden"
          :overflow-x "hidden"
          :height "100%"
          :width "100%")
-        (".source-content"
-         :background-color #(theme:background)
-         :color #(theme:on-background)
+        `(".source-content"
+         :background-color ,theme:background
+         :color ,theme:on-background
          :margin-left "16px"
          :width "100%"
          :table-layout "fixed")
@@ -116,24 +116,24 @@ selection over prompt buffer suggestions.")
          :white-space "nowrap"
          :height "20px"
          :overflow "auto")
-        (".source-content th"
-         :background-color #(theme:primary)
-         :color #(theme:on-primary)
+        `(".source-content th"
+         :background-color ,theme:primary
+         :color ,theme:on-primary
          :font-weight "normal"
          :padding-left "3px"
          :text-align "left")
         (".source-content td::-webkit-scrollbar"
          :display "none")
-        ("#selection"
-         :background-color #(theme:accent)
-         :color #(theme:on-accent))
-        (.marked
-         :background-color #(theme:secondary)
-         :color #(theme:on-secondary)
-         :font-weight "bold")
-        (.selected
-         :background-color #(theme:primary)
-         :color #(theme:on-primary)))
+        `("#selection"
+         :background-color ,theme:accent
+         :color ,theme:on-accent)
+        `(.marked
+          :background-color ,theme:secondary
+          :color ,theme:on-secondary
+          :font-weight "bold")
+        `(.selected
+         :background-color ,theme:primary
+         :color ,theme:on-primary))
       :documentation "The CSS applied to a prompt-buffer when it is set-up.")
      (override-map
       (make-keymap "override-map")

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -69,8 +69,8 @@ the generic functions on `status-buffer'.  Finally set the `window'
    (message-buffer-style
     (theme:themed-css (theme *browser*)
       (body
-       :background-color theme:background
-       :color theme:on-background
+       :background-color #(theme:background)
+       :color #(theme:on-background)
        :font-size "12px"
        :padding 0
        :padding-left "4px"

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -30,7 +30,7 @@ It's a function of the window argument that returns the title as a string.")
     :export nil
     :documentation "A list of panel buffers appearing on the window.")
    (prompt-buffer-channel
-    (make-channel) ; TODO: Rename `prompt-buffer-ready-channel'?
+    (make-channel)                 ; TODO: Rename `prompt-buffer-ready-channel'?
     :export nil
     :documentation "A channel one may listen to if waiting
 for the prompt buffer to be available.
@@ -68,13 +68,13 @@ the generic functions on `status-buffer'.  Finally set the `window'
     :documentation "The height of the message buffer in pixels.")
    (message-buffer-style
     (theme:themed-css (theme *browser*)
-      (body
-       :background-color #(theme:background)
-       :color #(theme:on-background)
-       :font-size "12px"
-       :padding 0
-       :padding-left "4px"
-       :margin 0)))
+      `(body
+        :background-color ,theme:background
+        :color ,theme:on-background
+        :font-size "12px"
+        :padding 0
+        :padding-left "4px"
+        :margin 0)))
    (prompt-buffer-open-height
     256
     :documentation "The height of the prompt buffer when open.")


### PR DESCRIPTION
# Description

This is a prototype to gather feedback on whether we want LASS in our themes. The benefits are:
- Less macrology (we can remove `theme::requote-rule` and I'd be glad when this abomination is gone).
- Support for media queries and a more powerful rule syntax with `:and` and `:or` selector composition.
- Built-in value injection with `#(syntax)`.
The downsides are:
- We need to quote every rule (this might change if I research it some more).
- The syntax for value injection if not familiar.
- We now have to use quasi-quotes to allow inline code evaluation.
  - Is it a downside, actually? Especially given that there's no more `requore-rule` that was enabling the inline evaluation, but was sacrifising lots of flexibility.

# Discussion

@aadcg, @Ambrevar, @jmercouris, does `theme:themed-css2` look right to you? If it does, I'll replace `themed-css` with it, use it everywhere, and send a patch with LASS to Guix.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.