### PR TITLE
WIP: Persist buffer state to history (for modes, tags and more)

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -267,6 +267,10 @@ This method should be called by the renderer after instantiating the web view
 of BUFFER."
   (unless no-hook-p
     (hooks:run-hook (buffer-make-hook browser) buffer))
+  ;; Modes may be initialized without a `buffer' slot (e.g. when deserialized).
+  (mapc (lambda (mode)
+          (setf (buffer mode) buffer))
+        (slot-value buffer 'modes))
   (mapc #'enable (slot-value buffer 'modes))
   (enable-modes* (append (reverse (default-modes buffer))
                          (uiop:ensure-list extra-modes))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -348,11 +348,12 @@ Return non-NIL of history was restored, NIL otherwise."
                        (gethash (htree:creator-id owner) old-id->new-id)))
                (htree:owners history))
       (setf (htree:owners history) new-owners))
-    (alex:when-let ((latest-id (first
-                                (first
-                                 (sort-by-time (alex:hash-table-alist (htree:owners history))
-                                               :key (compose #'htree:last-access #'rest))))))
-      (switch-buffer :buffer (buffers-get latest-id)))))
+    (alex:when-let* ((latest-id (first
+                                 (first
+                                  (sort-by-time (alex:hash-table-alist (htree:owners history))
+                                                :key (compose #'htree:last-access #'rest)))))
+                     (buffer (buffers-get latest-id)))
+      (switch-buffer :buffer buffer))))
 
 (defmethod files:deserialize ((profile nyxt-profile) (file history-file) raw-content &key)
   "Restore the global/buffer-local history and session from the PATH."

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -199,14 +199,11 @@ lot."
         (*print-length* nil))
     ;; We need to make sure current package is :nyxt so that symbols are printed
     ;; with consistent namespaces.
-    (write
-     (with-input-from-string (in (with-output-to-string (out)
-                                   (s-serialization:serialize-sexp
-                                    (list +version+ (files:content file))
-                                    out)))
-       ;; We READ the output of serialize-sexp to make it more
-       ;; human-readable.
-       (safe-read in))
+    (pretty-print
+     (with-output-to-string (out)
+       (s-serialization:serialize-sexp
+        (list +version+ (files:content file))
+        out))
      :stream stream)))
 
 ;; REVIEW: This works around the issue of cl-prevalence to deserialize structs

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -334,10 +334,14 @@ Return non-NIL of history was restored, NIL otherwise."
                                     (htree:owner history owner-id))))
                  ;; Node-less owners can safely be ignored.
                  (when current-node
-                   (let ((new-buffer (make-buffer :title (title (htree:data current-node))
-                                                  :history-file history-file
-                                                  :url (url (htree:data current-node))
-                                                  :load-url-p nil)))
+                   (let ((new-buffer (alex:if-let ((data (htree:data owner)))
+                                       (with-input-from-string (in data)
+                                         (s-serialization:deserialize-sexp in))
+                                       ;; In case buffer was not serialized:
+                                       (make-buffer :title (title (htree:data current-node))
+                                                    :history-file history-file
+                                                    :url (url (htree:data current-node))
+                                                    :load-url-p nil))))
                      (setf (gethash owner-id old-id->new-id) (id new-buffer))
                      (setf (gethash (id new-buffer) new-owners) owner))))))
             (alex:hash-table-alist (htree:owners history)))

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -592,6 +592,16 @@ If there is no corresponding keymap, return nil."
 
 (defmethod s-serialization:serializable-slots ((object mode))
   "Discard keymaps which can be quite verbose."
-  (delete 'keyscheme-map
-          (mapcar #'closer-mop:slot-definition-name
-                  (closer-mop:class-slots (class-of object)))))
+  (set-difference (call-next-method)
+                  '(keyscheme-map
+                    style)))
+
+(defmethod s-serialization::deserialize-sexp-slot ((self mode) slot-name slot-value deserialized-objects)
+  (if (url-slot-p (class-of self) slot-name)
+      (url slot-value)
+      (s-serialization::deserialize-sexp-internal slot-value deserialized-objects)))
+
+(defmethod s-serialization::deserialize-sexp-slot ((self mode) slot-name slot-value deserialized-objects)
+  (if (timestamp-slot-p (class-of self) slot-name)
+      (time:parse-timestring slot-value)
+      (s-serialization::deserialize-sexp-internal slot-value deserialized-objects)))

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -595,13 +595,3 @@ If there is no corresponding keymap, return nil."
   (set-difference (call-next-method)
                   '(keyscheme-map
                     style)))
-
-(defmethod s-serialization::deserialize-sexp-slot ((self mode) slot-name slot-value deserialized-objects)
-  (if (url-slot-p (class-of self) slot-name)
-      (url slot-value)
-      (s-serialization::deserialize-sexp-internal slot-value deserialized-objects)))
-
-(defmethod s-serialization::deserialize-sexp-slot ((self mode) slot-name slot-value deserialized-objects)
-  (if (timestamp-slot-p (class-of self) slot-name)
-      (time:parse-timestring slot-value)
-      (s-serialization::deserialize-sexp-internal slot-value deserialized-objects)))

--- a/source/mode/autofill.lisp
+++ b/source/mode/autofill.lisp
@@ -58,6 +58,17 @@ it will be in conflict with common-lisp:fill."))
               (string (lambda () (autofill-fill autofill)))
               (function (autofill-fill autofill)))))
 
+(defmethod s-serialization:serialize-sexp-slot ((self autofill) (slot (eql 'fill))
+                                      stream serialization-state)
+  (declare (ignore serialization-state))
+  (let ((value (slot-value self slot)))
+    (prin1
+     (or (if (stringp value)
+             value
+             (nyxt::maybe-function-name value))
+         "")
+     stream)))
+
 (define-class autofill-source (prompter:source)
   ((prompter:name "Autofills")
    (prompter:constructor (autofills (find-submode 'autofill-mode)))

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -208,6 +208,11 @@ The `input' should be a valid Lisp code `read'-able in the `eval-package'.
 - and sets `raised-condition' (if any) to a wrapper class managing raised
   condition debugging."))
 
+(defmethod s-serialization:serialize-sexp-slot ((self lisp-cell) (slot (eql 'eval-package))
+                                                stream serialization-state)
+  (declare (ignore serialization-state))
+  (prin1 (package-name (slot-value self slot)) stream))
+
 (define-class cell-source (prompter:source)
   ((prompter:name "Cell types")
    (prompter:constructor (mopu:subclasses (find-class 'cell nil)))))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -114,6 +114,14 @@ failures."))
   (append (call-next-method)
           `(("Context" ,(context-name buffer)))))
 
+(defmethod s-serialization:serializable-slots ((buffer gtk-buffer))
+  "Discard gtk-object which cannot be serialized."
+  (set-difference
+   (mapcar #'closer-mop:slot-definition-name
+           (closer-mop:class-slots (class-of buffer)))
+   '(gtk-object
+     handler-ids)))
+
 (defclass webkit-web-context (webkit:webkit-web-context) ()
   (:metaclass gobject:gobject-class))
 

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -33,6 +33,13 @@ Simple completion functions can be built via `make-search-completion-function'")
   (:export-class-name-p t)
   (:export-accessor-names-p t))
 
+(defmethod s-serialization:serialize-sexp-slot ((self search-engine) (slot (eql 'completion-function))
+                                                stream serialization-state)
+  (declare (ignore serialization-state))
+  (prin1
+   (nyxt::maybe-function-name (slot-value self slot))
+   stream))
+
 (defmethod fallback-url ((engine search-engine))
   (or (slot-value engine 'fallback-url)
       (quri:uri (format nil (search-url engine) ""))))

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -248,6 +248,10 @@ If it cannot be derived, return an empty `quri:uri'."
            (or (ignore-errors (quri:uri thing))
                (quri:uri "")))))
 
+(defmethod coerce-slot (new-value instance (slot-type (eql 'quri:uri)))
+  (declare (ignorable instance slot-type))
+  (ensure-url new-value))
+
 (-> url-empty-p ((or quri:uri string null)) boolean)
 (export-always 'url-empty-p)
 (defun url-empty-p (url)

--- a/source/utilities.lisp
+++ b/source/utilities.lisp
@@ -193,6 +193,16 @@ This is useful if you do not trust the input."
     (uiop:with-safe-io-syntax (:package package)
       (read input-stream eof-error-p eof-value recursive-p))))
 
+(export-always 'pretty-print)
+(defun pretty-print (s &key (stream t))
+  "Format s-expression in string S using the pretty printer."
+  (write
+   (with-input-from-string (in s)
+     ;; We READ the output of serialize-sexp to make it more
+     ;; human-readable.
+     (safe-read in))
+   :stream stream))
+
 (export-always 'safe-sort)
 (defun safe-sort (s &key (predicate #'string-lessp) (key #'string))
   "Sort sequence S of objects by KEY using PREDICATE."


### PR DESCRIPTION
# Description

This persists buffer modes (and more buffer data) in history.  This is useful so that on restart, modes are restored (which can be critical e.g. for privacy).

Fixes #2064 and #2583 (not yet).
Fixes #2036.

# How to test

- Make sure your cl-prevalence is up-to-date.

# Discussion

- [x] Is the design sane?
  In my opinion, yes, as it makes only minimal modifications to the Htree library, while adding a Nyxt core class that's easily extensible to add more buffer-related data to persist in the future.

- [x] Can we better serialize and deserialize URIs and timestamp?  The problem is that until now we used to serialize them as strings, but then how can Nyxt know which string is a URI, a timestamp, or just a string?
  An option would be to use reader macros, for instance `(local-time:enable-read-macros)`.  But that would break history backward compatibility.  Thoughts?

  - Another suggestion by @aartaka: Introduce `uri-sepcifier` and `timestamp-specifier` which accept strings, then write accessors to automatically replace the string with the structured version.  With a bit of MOP we could derive a general solution.
  - Better option: `coerce-slot`, which automatically coerce the value to the desired type.

# To do:

- [ ] Replace current dead buffers with serialized buffers.  Benefit: less risk for memory leaks.
- [x] Squash commits since this PR commit history is a mess.
- [x] Update cl-prevalence in submodules and Guix once patch is merged upstream. 
- [ ] Tests!
- [ ] Add a `tags` slot and persist it.
- [ ] Add tag-related commands.  See https://github.com/atlas-engineer/nyxt/issues/2583#issuecomment-1298379178
- [ ] Fix auto-rules which prevents any good use of this PR:
  - [ ] Currently auto-rules remove modes from the list of disabling them.
  - [ ] Reloading a page removes the manually enabled modes.  Example:
    - Go to https://en.wikipedia.org
    - Enable no-script-mode.
    - Reload: BOOM!  no-script-mode is gone.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
