### PR TITLE
Fix startup page

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -75,6 +75,9 @@ various parts, such as the path of all data files.")
              :border-width "0px"
              :padding "6px"
              :margin "2px")
+            (.button.accent
+             :background-color theme:accent
+             :color theme:on-accent)
             (.link
              :all "unset"
              :text-decoration "underline"
@@ -83,8 +86,7 @@ various parts, such as the path of all data files.")
             (".link:hover"
              :opacity 0.8)
             (.accent
-             :background-color theme:accent
-             :color theme:on-accent)
+             :color theme:accent)
             (|.button:hover|
              :opacity 0.8)
             (|.button:visited|


### PR DESCRIPTION
# Description

Fix UI styling.

Fixes [this issue](https://github.com/atlas-engineer/nyxt/commit/f6307328626601e7358dee0d2c04c116b2e044fa#commitcomment-88844270).

# Discussion

I took a different approach than that suggested by @aartaka in the aforementioned issue. I find it simpler and more effective.

@aartaka can you confirm that the UI on the REPL's side looks as it should? Thanks.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
