### PR TITLE
Leverage `actions-on-current-suggestion` as a list.

### DIFF
--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -242,10 +242,17 @@ For instance, to include images:
            :key #'prompter:value)
         (append matching-hints other-hints))))
    (prompter:selection-actions
-    (unless (fit-to-prompt-p (find-submode 'hint-mode))
-      (lambda (suggestion)
-        (highlight-selected-hint :element suggestion
-                                 :scroll nil))))
+    (list (unless (fit-to-prompt-p (find-submode 'hint-mode))
+            (lambda-command highlight-selected-hint* (suggestion)
+              "Highlight hint."
+              (highlight-selected-hint :element suggestion)))
+          (lambda-command scroll-to-selected-hint* (suggestion)
+            "Highlight and scroll to hint."
+            (highlight-selected-hint :element suggestion :scroll t))
+          (lambda-command copy-selected-hint* (suggestion)
+            "Copy hint URL to clipboard."
+            (highlight-selected-hint :element suggestion :scroll t)
+            (copy-to-clipboard (plump:attribute suggestion "href")))))
    (prompter:marks-actions
     (lambda (marks)
       (let ((%marks (mapcar (lambda (mark) (str:concat "#nyxt-hint-" (identifier mark)))


### PR DESCRIPTION
# Description

After #2555, we can now think about how this new feature translates into something useful for users!

I'd like to collect ideas from you on this topic. @Ambrevar @jmercouris @aartaka 

I've added a dumb example with respect to `hint-mode`. When `actions-on-current-suggestion` is a list, you can set the default action that runs when the current suggestions changes. 

Example: 

- issue `follow-hint` and notice that issuing `select-next` and `select-previous` runs the default action on selection change (highlighting the hint on the web page's buffer)
- issue `set-selection-action` and set for instance `scroll-to-selected-hint`
- notice that now you get highlighting plus scrolling.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [ ] I have pulled from master before submitting this PR
- [ ] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [ ] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
