### PR TITLE
Prompter object attributes display

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -403,8 +403,11 @@ call."))
                   (princ-to-string (rest pair))))
                object))
       (t (call-next-method))))
-  (:documentation "Return an alist of non-dotted pairs (ATTRIBUTE-KEY ATTRIBUTE-VALUE) for OBJECT.
+  (:documentation "Return an alist of non-dotted lists (ATTRIBUTE-KEY ATTRIBUTE-VALUE ...) for OBJECT.
 Attributes are meant to describe the OBJECT in the context of the SOURCE.
+
+The attributes after the first two are for the application specific purposes,
+like format strings or code for element display.
 
 Both returned attribute-keys and attribute-values are strings (if not, they are
 automatically converted to `princ-to-string'). If the attribute value is a
@@ -454,11 +457,6 @@ Suggestions are made with the `suggestion-maker' slot from `source'."))
        (or (not (listp (rest object)))
            (null (rest (rest object))))))
 
-(defun undotted-pair-p (object)
-  (and (listp object)
-       (listp (rest object))
-       (null (rest (rest object)))))
-
 (defun alist-p (object)
   "Return non-nil if OBJECT is an alist, dotted or undotted."
   (and (listp object)
@@ -467,7 +465,7 @@ Suggestions are made with the `suggestion-maker' slot from `source'."))
 (defun undotted-alist-p (object &optional value-type)
   "If VALUE-TYPE is non-nil, check if all values are of the specified type."
   (and (listp object)
-       (every #'undotted-pair-p object)
+       (every #'listp object)
        (or (not value-type)
            (every (lambda (e) (typep (first e) value-type))
                   (mapcar #'rest object)))))

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -407,7 +407,8 @@ call."))
 Attributes are meant to describe the OBJECT in the context of the SOURCE.
 
 The attributes after the first two are for the application specific purposes,
-like format strings or code for element display.
+like format strings or code for element display, the calling code can freely use
+those to store arbitrary data.
 
 Both returned attribute-keys and attribute-values are strings (if not, they are
 automatically converted to `princ-to-string'). If the attribute value is a

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -581,6 +581,9 @@ auto-mode-rules.lisp).")))
          (:li  (:code "time") " for " (:code "local-time"))
          (:li  (:code "types") " for " (:code "trivial-types"))
          (:li  (:code "sym") " for " (:code "nsymbols"))))
+   (:li "The third value in the " (:nxref :function 'prompter:object-attributes)
+        " is interpreted as display HTML for the suggestion. See the color-picker
+support as an example application for this feature.")
 
    (:li "Universal describe-* commands have been replaced with new sources for the
 regular commands, such as "

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -338,8 +338,12 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                                                 (- suggestion-index cursor-index))
                                                               (prompter:return-selection
                                                                (nyxt::current-prompt-buffer)))))
-                                            (loop for (nil attribute) in (prompter:active-attributes suggestion :source source)
-                                                  collect (:td :title attribute (:mayberaw attribute))))))))))))
+                                            (loop for (nil attribute attribute-display)
+                                                    in (prompter:active-attributes suggestion :source source)
+                                                  collect (:td :title attribute
+                                                               (if attribute-display
+                                                                   (:raw attribute-display)
+                                                                   attribute))))))))))))
       (ps-eval :buffer prompt-buffer
         (setf (ps:@ (nyxt/ps:qs document "#suggestions") |innerHTML|)
               (ps:lisp

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1348,12 +1348,13 @@ See `finalize-buffer'."
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
 (defmethod prompter:object-attributes ((color string) (source color-source))
-  `(("Name" ,color)
-    ("Color" ,(let ((spinneret:*html-style* :tree))
-                (spinneret:with-html-string
-                  (:span :style (format nil "background-color: ~a; color: ~a; border: 0.3empx solid ~a; border-radius: 0.1em"
-                                        color (contrasting-color color) (contrasting-color color))
-                         color))))))
+  `(("Color"
+     ,color
+     ,(let ((spinneret:*html-style* :tree))
+        (spinneret:with-html-string
+          (:span :style (format nil "background-color: ~a; color: ~a; border: 0.1em solid ~a; border-radius: 0.1em"
+                                color (contrasting-color color) (contrasting-color color))
+                 color))))))
 
 (defun process-color-chooser-request (web-view color-chooser-request)
   (declare (ignore web-view))


### PR DESCRIPTION
# Description

One of the possible shots at #2652: add a third value to `prompter:object-attributes` listing. Simplest solution, and quite intutive one, I believe.

Fixes #2652

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
