### PR TITLE
Safer history restoration

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1093,11 +1093,12 @@ See `make-buffer' for a description of the arguments."
 
 (defmethod buffer-delete ((buffer context-buffer))
   (files:with-file-content (history (history-file buffer))
-    (sera:and-let* ((owner (htree:owner history (id buffer)))
-                    (current (htree:current owner))
-                    (data (htree:data current)))
-      (setf (nyxt::scroll-position data) (nyxt:document-scroll-position buffer))
-      (htree:delete-owner history (id buffer))))
+    (when history
+      (sera:and-let* ((owner (htree:owner history (id buffer)))
+                      (current (htree:current owner))
+                      (data (htree:data current)))
+        (setf (nyxt::scroll-position data) (nyxt:document-scroll-position buffer))
+        (htree:delete-owner history (id buffer)))))
   (call-next-method))
 
 (defun buffer-hide (buffer)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1020,6 +1020,10 @@ LOAD-URL-P controls whether to load URL right at buffer creation."
                         :parent-buffer parent-buffer
                         :no-history-p no-history-p
                         (append
+                         (when no-history-p
+                           (list :history-file
+                                 (make-instance 'history-file
+                                                :profile (make-instance 'nofile-profile))))
                          (unless (url-empty-p url)
                            (list :url url))
                          (uiop:remove-plist-keys '(:title :modes :url :parent-buffer

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -567,7 +567,8 @@ locally and is cleared after every session.")
     (:li "There are default rules for Gopher, Gemini, and
 Nyxt-internal-pages.")
     (:li "The rules file is now moved to auto-rules.lisp (instead of the old
-auto-mode-rules.lisp).")))
+auto-mode-rules.lisp)."))
+   (:li "Startup is more robust against corrupted history files."))
 
   (:h3 "Programming interface")
   (:ul

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -362,8 +362,9 @@ To discover the default value of a slot or all slots of a class, use the
           (log:debug "No active window, picking last active buffer.")
           (last-active-buffer)))))
 
-(defmethod initialize-instance :after ((file nyxt-file) &key)
-  (when (current-buffer)
+(defmethod initialize-instance :after ((file nyxt-file) &key (profile t profile-p) &allow-other-keys)
+  (declare (ignorable profile))
+  (when (and (not profile-p) (current-buffer))
     (setf (files:profile file) (profile (current-buffer)))))
 
 (export-always 'with-current-buffer)


### PR DESCRIPTION
# Description

This fixes a bunch of potential dead locks on startup, as well as some other bugs.

- virtual files no longer trigger the cache.
- `no-history-p` really disables the history of the buffer.
- `buffer-delete` no longer errors for buffers without history.
- Protect against history restoration errors on startup so that we ensure `*after-startup-hook*` and `startup-error-reporter-function` are run.

The potential dead lock is worked around by triggering the window creation first, then trigger the buffer creation + history restoration after waiting for the window creation to complete.

Fixes #2602 (hopefully), #2623 (should mitigate it).

Does _not_ fix the #2624 which seems to be linked to the build system.

Should help for  #2507, #2057.

# To test

You need the latest Nfiles.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
