### PR TITLE
More intuitive history heuristics

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -572,7 +572,9 @@ auto-mode-rules.lisp)."))
    (:li "Startup is more robust against corrupted history files.")
    (:li (:code "diff-mode") " is removed.")
    (:li "History globality can be set on a per-buffer basis. "
-        "See the " (:code "global-history-p") " slot in " (:code "context-buffer") "."))
+        "See the " (:code "global-history-p") " slot in " (:code "context-buffer") ".")
+   (:li (:nxref :slot 'backtrack-to-hubs-p :class-name 'nyxt/history-mode:history-mode)
+        " allows to revisit the \"hub\" URLs you often visit, instead of adding them to history anew."))
 
   (:h3 "Bindings")
   (:ul
@@ -680,4 +682,5 @@ regular commands, such as "
    (:li "Invoke the right WebKit command when cutting text with " (:nxref :function 'ffi-buffer-cut))
    (:li "Fix the display of history suggestions when going forward in history.")
    (:li "Security: all the non-ASCII domain names are shown as IDN punycodes in addition
-to aesthetic display in status buffer.")))
+to aesthetic display in status buffer.")
+   (:li "The canceled page requests are stored to history, making it more consistent.")))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -98,25 +98,6 @@ class."
   "Return a new global history tree for `history-entry' data."
   (htree:make :key 'history-tree-key :initial-owners (when buffer (list (id buffer)))))
 
-(-> history-add (quri:uri &key (:title string) (:buffer buffer)) *)
-(defun history-add (url &key (title "") (buffer (current-buffer)))
-  "Add URL to the global/buffer-local history.
-The `implicit-visits' count is incremented."
-  (files:with-file-content (history (history-file (current-buffer))
-                            :default (make-history-tree))
-    (unless (or (url-empty-p url)
-                ;; If buffer was not registered in the global history, don't
-                ;; proceed.  See `buffer's `customize-instance' `:after' method..
-                (not (htree:owner history (id buffer))))
-      (htree:add-child (make-instance 'history-entry
-                                      :url url
-                                      :title title)
-                       history
-                       (id buffer))
-      (let* ((entry (htree:data (htree:current (htree:owner history (id buffer))))))
-        (setf (title entry) title)
-        (incf (implicit-visits entry))))))
-
 (define-command delete-history-entry (&key (buffer (current-buffer)))
   "Delete queried history entries."
   (let ((entries (prompt

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -243,6 +243,49 @@ follows.")
                                                      :fallback-url "https://reddit.com")
                                       %slot-value%))))))
 
+      (:nsection :title "History"
+        (:p "Nyxt history model is a tree whose nodes are URLs. It branches out through all
+the buffers. If you create a new buffer (via " (:nxref :command 'nyxt/hint-mode:follow-hint-new-buffer)
+" or " (:nxref :command 'make-buffer) "), it becomes a new history branch originating
+from the branch of the previous buffer.")
+        (:p "History can be navigated with the arrow keys in the status buffer, or with
+commands like " (:nxref :command 'nyxt/history-mode:history-backwards) " and "
+            (:nxref :command 'nyxt/history-mode:history-forwards)
+            " (which the arrows are bound to).")
+        (:p "If the beyond-buffer-boundaries behavior sounds like too much to you, or you
+prefer the behavior of Nyxt 2, where the history was still a tree, but was not
+spilling across the buffers, then configure "
+            (:nxref :slot 'nyxt/history-mode:conservative-history-movement-p
+              :class-name 'nyxt/history-mode:history-mode)
+            " to be T. This would make all buffers to have their own history, not connected
+to the other buffers at all. All the history commands (like "
+            (:nxref :command 'nyxt/history-mode:history-backwards) " and "
+            (:nxref :command 'nyxt/history-mode:history-forwards)
+            ") will only work inside the buffer history then.")
+        (:p "Nyxt supra-buffer history has benefits, though: it optimizes browsing patterns
+into more intuitive and productive structures. One particular pattern Nyxt
+history optimizes is hub-and-spoke search, where you keep returning to a certain
+hub to start your search/navigation from a familiar point. You can enable the
+optimization (merely going back in history to the hub page, instead of creating
+a new history node) for this strategy by configuring "
+            (:nxref :slot 'nyxt/history-mode:backtrack-to-hubs-p
+              :class-name 'nyxt/history-mode:history-mode)
+            " to T.")
+        (:p "Another useful side to Nyxt tree-like history are braching-aware history
+commands, like "
+            (:nxref :command 'nyxt/history-mode:history-forwards-query)
+            ", allowing one to choose which branch of history they are going to visit, if
+there are several. If there's only one branch, then this command behaves much
+like regular " (:nxref :command 'nyxt/history-mode:history-forwards) ".")
+        (:p "There are commands that allow to move across all the history before or after
+the current node:")
+        (:ul (list-command-information '(nyxt/history-mode:history-backwards-query
+                                         nyxt/history-mode:history-forwards-all-query
+                                         nyxt/history-mode:history-all-query)))
+        (:p "If you need to know more: most of the optimizations and data structures are
+in " (:nxref :package :history-tree) " library, while most of the Nyxt-specific interface is in "
+(:nxref :package :nyxt/history-tree-mode) "."))
+
       (:nsection :title "Downloads"
         (:p "See the " (:nxref :command 'nyxt/download-mode:list-downloads) " command and the "
             (:nxref :slot 'download-path :class-name 'buffer) " buffer slot documentation."))

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -425,3 +425,7 @@ internally, but this display is clearer and more navigable."
 (defmethod nyxt:on-signal-load-finished ((mode history-mode) url)
   (add-url-to-history url (buffer mode) mode)
   url)
+
+(defmethod nyxt:on-signal-load-canceled ((mode history-mode) url)
+  (add-url-to-history url (buffer mode) mode)
+  url)

--- a/tests/offline/global-history.lisp
+++ b/tests/offline/global-history.lisp
@@ -18,7 +18,7 @@
          (buffer (nyxt::make-buffer)))
     (nyxt:with-current-buffer buffer
       (let ((file (history-file buffer)))
-        (nyxt::history-add (quri:uri "http://example.org"))
+        (nyxt/history-mode::history-add (quri:uri "http://example.org"))
         ;; history has 1 entry
         (assert-eq 1
                    (length (htree:all-data (files:content file))))
@@ -30,7 +30,7 @@
           ;; "value has no title"
           (assert-string= ""
                           (title entry)))
-        (nyxt::history-add (quri:uri "http://example.org") :title "foo")
+        (nyxt/history-mode::history-add (quri:uri "http://example.org") :title "foo")
         ;; "history has still 1 entry after adding same URL"
         (assert-eq 1
                    (length (htree:all-data (files:content file))))
@@ -40,7 +40,7 @@
           ;; "value now has title"
           (assert-string= "foo"
                           (title entry)))
-        (nyxt::history-add (quri:uri "http://example.org/sub"))
+        (nyxt/history-mode::history-add (quri:uri "http://example.org/sub"))
         ;; "history now has 2 entries"
         (assert-eq 2
                    (length (htree:all-data (files:content file))))


### PR DESCRIPTION
# Description

This adds two history improvements utilizing the `htree` and Nyxt features:
- Remembering the requests that were cancelled mid-air, and adding those to history as parents of the ones that replace them.
- Going back in history instead of creating a new child, if the URL opened is already present on the current branch. This way, we utilize the branching nature of the history and re-create the structure of the page in the history tree. The current implementation has downsides:
  - If the "hub" URL (i.e., the one that person returns to) is not the first one they visit, then some of the URLs visited from the hub might actually be recognized as parents of the hub. We need to intelligently sort the history for parent-child/index-page relations and swap the neighbouring nodes if we see them being thus related and misplaced. This all might've sounded unintelligeble, so here's an illustration of what the current logic does and how it might fail:
```
github.com/.../pull/1 ->  github.com/notifications -> github.com/.../pull/3 -> github.com/notifications
                                                                               ^ current node here

Gets optimized into this structure with this PR:

github.com/.../pull/1 ->  github.com/notifications -> github.com/.../pull/3
                          ^ current node here

But then, if one decides to visit github.com/.../pull/1 from the "hub" (github.com/notifications), 
then we end up with a mental mismatch of a model with history structure:

github.com/.../pull/1 ->  github.com/notifications -> github.com/.../pull/3
^ current node here

While it should've been
github.com/notifications -> github.com/.../pull/3
                       |-> github.com/.../pull/1
                           ^ current node here

Because the mental map of the user most probably has /notifications 
as the hub URL that all the journeys start from. github.com/.../pull/1 
is merely a coincidental URL that the browsing started from in one particular session.
```

# Discussion

I'll be happy if we resolve some more problems of our history interface (@jmercouris, note that I'm saying interface here, it's not about `htree` as a structure, it's about us not watching all the corner-cases and blindly putting things into `htree`) as part of this PR, but I am okay with posponing it until later:
- Better canceled link inspection. Simply putting them into history is not always the right decision (can't remember the cases that break it, but there certainly were some, because of which I didn't open this PR three months ago). We need better heuristics for when link canceling is meaningful, and when it's not.
- Properly handling redirection URLs. Right now if there'a redirect from `foo.org#hello` to `foo.org#hi`, we only remember the first one and ignore the second one based on it having the "same URL". There are two issues at play here:
  - Flawed (in some cases like this) URL equality operators, easy to fix.
  - Broken redirection storage, only storing the first URL that started redirect chain. I am not certain about the reasons for that. 
  - I guess that the right behavior for redirects would be to store only the final redirect chain URL in history.
    - Alternatively, we can store all the redirections and all the chain links in history, but mark them as such, so that when one goes `history-backwards` to a redirect URL, they get prompted or automatically intuitively moved to before it, to not trigger the inifinite cycle of redirections.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.
- [X] I have pulled from master before submitting this PR.
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
