### PR TITLE
Fix global profile and make renderer first class objects

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -100,7 +100,8 @@
                 :serial t
                 :depends-on ("Utilities")
                 :components
-                ((:file "global")
+                ((:file "renderer")
+                 (:file "global")
                  (:file "concurrency")
                  (:file "gpg")
                  (:file "user-files")

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -47,7 +47,14 @@ Without handler, return ARG.  This is an acceptable `combination' for
   (:metaclass interface-class))
 
 (define-class browser (renderer-browser)
-  ((remote-execution-p
+  ((profile
+    (global-profile)
+    :type nyxt-profile
+    :documentation "Global profile used to specialize the behavior of
+various parts, such as the path of all data files.
+This profile is used when there is no context buffer.
+See also the `profile' slot in the `buffer' class.")
+   (remote-execution-p
     nil
     :type boolean
     :documentation "Whether code sent to the socket gets executed.  You must
@@ -244,6 +251,12 @@ windows.
 A typical Nyxt session encompasses a single instance of this class, but nothing
 prevents otherwise.")
   (:metaclass user-class))
+
+(defmethod initialize-instance :after ((browser browser)
+                                       &key (history-file (make-instance 'history-file :profile (profile browser)))
+                                       &allow-other-keys)
+  "Ensure `history-file' uses the browser profile."
+  (setf (history-file browser) history-file))
 
 (defmethod theme ((ignored (eql nil)))
   "Fallback theme in case there `*browser*' is NIL."

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1148,7 +1148,8 @@ This is a low-level function.  See `buffer-delete' for the high-level version."
 
 (export-always 'window-list)
 (defun window-list ()
-  (alex:hash-table-values (windows *browser*)))
+  (when *browser*
+    (alex:hash-table-values (windows *browser*))))
 
 (defun dummy-buffer-p (buffer)
   (eq 'buffer (type-of buffer)))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -33,10 +33,11 @@ inherited from the superclasses.")
     :documentation "Unique identifier for a buffer.")
    ;; TODO: Or maybe a dead-buffer should just be a buffer history?
    (profile
-    *global-profile*
+    (global-profile)
     :type nyxt-profile
     :documentation "Buffer profiles are used to specialize the behavior of
-various parts, such as the path of all data files.")
+various parts, such as the path of all data files.
+See also the `profile' slot in the `browser' class.")
    (url (quri:uri ""))
    (url-at-point (quri:uri ""))
    (title "")

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -441,7 +441,9 @@ query is not a valid URL, or the first keyword is not recognized.")
     :documentation "Select a download engine to use, such as `:lisp' or
 `:renderer'.")
    (history-file
-    (history-file *browser*)
+    (if *browser*
+        (history-file *browser*)
+        (make-instance 'history-file))
     :type history-file
     :documentation "File where to save the global history used by this buffer.
 See also `history-file' in `browser' for the global history restored on startup,
@@ -1006,7 +1008,11 @@ BUFFER's modes."
 
 (hooks:define-hook-type buffer (function (buffer)))
 
-(define-command make-buffer (&rest args &key (title "") modes (url (default-new-buffer-url *browser*)) parent-buffer
+(define-command make-buffer (&rest args &key (title "") modes
+                             (url (if *browser*
+                                      (default-new-buffer-url *browser*)
+                                      (quri:uri (nyxt-url 'new))))
+                             parent-buffer
                              no-history-p (load-url-p t) (buffer-class 'web-buffer)
                              &allow-other-keys)
   "Create a new buffer.

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -589,7 +589,10 @@ support as an example application for this feature.")
    (:li "Universal describe-* commands have been replaced with new sources for the
 regular commands, such as "
         (:code "function-non-nyxt-source") ", " (:code "function-internal-source")
-        " and so on."))
+        " and so on.")
+   (:li "The " (:code "browser") " class has a " (:code "profile") " slot.")
+   (:li "Renderers are now first class objects, see the " (:code "renderer") " class."
+        " It's possible to change renderer from a same REPL session."))
 
   (:h3 "Bug fixes")
   (:ul

--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -740,7 +740,7 @@ A command is a special kind of function that can be called with
              (getf +guix-build-information+ :version)))
     (str:concat
      "Nyxt version: " +version+ +newline+
-     "Renderer version: " +renderer+ +newline+
+     "Renderer: " (name *renderer*) +newline+
      "Operating system kernel: " (software-type) " " (software-version) +newline+
      "Lisp implementation: " (lisp-implementation-type) " " (lisp-implementation-version)
      #+sbcl

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -78,10 +78,10 @@ is 4005, default set to 4006 in Nyxt to avoid collisions).")
   "The port that Slynk will open a new server on (default Emacs Sly port
 is 4005, default set to 4006 in Nyxt to avoid collisions).")
 
-(defparameter +renderer+ nil "The renderer used by Nyxt. This value is meant to
-be set to a string by the renderer itself. This variable exists to allow for
-reporting by users, it does not create any functional differences in the
-execution of Nyxt.")
+(declaim (type (maybe renderer) *renderer*))
+(defparameter *renderer* nil
+  "The renderer used by Nyxt.
+It can be changed between two runs of Nyxt when run from a Lisp REPL.")
 
 (alex:define-constant +nyxt-critical-dependencies+
     '(:cl-cffi-gtk

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -312,7 +312,7 @@ useful actions there, including the familiar " (:code "set-url") ", " (:code "hi
                               (intro)))
              "How do I...")))
      (:p :class "copyright"
-         (format nil "Nyxt/~a ~a" +renderer+ +version+)
+         (format nil "Nyxt/~a ~a" (name *renderer*) +version+)
          (:br)
          (format nil "Atlas Engineer LLC, 2018-~a" (time:timestamp-year (time:now)))))))
 

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -563,7 +563,7 @@ say to develop Nyxt or extensions.")
                                 (uiop:relativize-pathname-directory (call-next-method))))
           (defmethod files:resolve ((profile dev-profile) (file history-file))
             "Persist history to default location."
-            (files:resolve *global-profile* file))
+            (files:resolve (global-profile) file))
           (define-configuration buffer
             "Make new profile the default."
             ((profile (make-instance (or (find-profile-class (getf *options* :profile)) 'dev-profile))))))

--- a/source/renderer.lisp
+++ b/source/renderer.lisp
@@ -1,0 +1,20 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nyxt)
+
+(define-class renderer ()
+  ((name "Default"))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (class*:make-name-transformer name))
+  (:documentation "Specialize this class and bind an instance to `*renderer*' to set the default renderer."))
+
+(export-always 'install)
+(defgeneric install (renderer)
+  (:documentation "Setup for renderer.  This may have side effects.
+See also `uninstall'."))
+
+(export-always 'uninstall)
+(defgeneric uninstall (renderer)
+  (:documentation "Revert the side effects induced by `install'."))

--- a/source/renderer/gi-gtk.lisp
+++ b/source/renderer/gi-gtk.lisp
@@ -16,40 +16,62 @@
 For now it is also partly based on `nyxt/renderer/gtk'."))
 (in-package :nyxt/renderer/gi-gtk)
 
-(setf nyxt::+renderer+ "GI-GTK")
 (push :nyxt-gi-gtk *features*)
-(handler-bind ((warning #'muffle-warning))
-  (let ((renderer-thread-name "Nyxt renderer thread"))
-    (defmethod nyxt/renderer/gtk::renderer-thread-p ((renderer (eql "GI-GTK")) &optional (thread (bt:current-thread)))
-      (string= (bt:thread-name thread)
-               #+darwin
-               "thread"
-               #-darwin
-               renderer-thread-name))
-    (defmethod ffi-initialize ((browser nyxt/renderer/gtk:gtk-browser) urls startup-timestamp)
-      "On GNU/Linux we can create a separate thread to launch the GTK
-interface. On Darwin, we must run the GTK thread on the main thread."
-      (declare (ignore urls startup-timestamp))
-      (log:debug "Initializing GI-GTK Interface")
-      (setf (uiop:getenv "WEBKIT_FORCE_SANDBOX") "0")
-      ;; TODO: Do not run the GTK loop again when T?
-      (setf nyxt/renderer/gtk::gtk-running-p t)
-      (flet ((main-func ()
-               (with-protect ("Error on GI-GTK thread: ~a" :condition)
-                 (glib:g-set-prgname "nyxt")
-                 #+GTK-3-4
-                 (gdk:gdk-set-program-class "Nyxt")
-                 (gir:invoke ((gir:ffi "Gtk" "3.0") 'main)))))
-        (call-next-method)
-        #-darwin
-        (let ((main-thread (bt:make-thread #'main-func :name renderer-thread-name)))
-          (unless nyxt::*run-from-repl-p*
-            (bt:join-thread main-thread)
-            ;; See comment about FreeBSD in gtk.lisp
-            (uiop:quit (slot-value browser 'nyxt::exit-code) #+freebsd nil)))
-        #+darwin
-        (main-func)))
 
-    (nyxt/renderer/gtk:define-ffi-method ffi-kill-browser ((browser nyxt/renderer/gtk:gtk-browser))
+(define-class gi-gtk-renderer (nyxt/renderer/gtk:gtk-renderer)
+  ((name "GI-GTK"))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (class*:make-name-transformer name)))
+
+(define-class gi-gtk-browser (nyxt/renderer/gtk:gtk-browser)
+  ()
+  (:export-class-name-p t)
+  (:export-accessor-names-p t)
+  (:accessor-name-transformer (class*:make-name-transformer name)))
+
+(defvar renderer-thread-name "Nyxt renderer thread")
+
+(defmethod nyxt/renderer/gtk::renderer-thread-p ((renderer gi-gtk-renderer)
+                                                 &optional (thread (bt:current-thread)))
+  (string= (bt:thread-name thread)
+           #+darwin
+           "thread"
+           #-darwin
+           renderer-thread-name))
+
+(defmethod ffi-initialize ((browser gi-gtk-browser) urls startup-timestamp)
+  "On GNU/Linux we can create a separate thread to launch the GTK
+interface. On Darwin, we must run the GTK thread on the main thread."
+  (declare (ignore urls startup-timestamp))
+  (log:debug "Initializing GI-GTK Interface")
+  (setf (uiop:getenv "WEBKIT_FORCE_SANDBOX") "0")
+  ;; TODO: Do not run the GTK loop again when T?
+  (setf nyxt/renderer/gtk::gtk-running-p t)
+  (flet ((main-func ()
+           (with-protect ("Error on GI-GTK thread: ~a" :condition)
+             (glib:g-set-prgname "nyxt")
+             #+GTK-3-4
+             (gdk:gdk-set-program-class "Nyxt")
+             (gir:invoke ((gir:ffi "Gtk" "3.0") 'main)))))
+    (call-next-method)
+    #-darwin
+    (let ((main-thread (bt:make-thread #'main-func :name renderer-thread-name)))
       (unless nyxt::*run-from-repl-p*
-        (gir:invoke ((gir:ffi "Gtk" "3.0") 'main-quit))))))
+        (bt:join-thread main-thread)
+        ;; See comment about FreeBSD in gtk.lisp
+        (uiop:quit (slot-value browser 'nyxt::exit-code) #+freebsd nil)))
+    #+darwin
+    (main-func)))
+
+(nyxt/renderer/gtk:define-ffi-method ffi-kill-browser ((browser gi-gtk-browser))
+  (unless nyxt::*run-from-repl-p*
+    (gir:invoke ((gir:ffi "Gtk" "3.0") 'main-quit))))
+
+(defmethod install ((renderer gi-gtk-renderer))
+  (call-next-method)
+  (closer-mop:ensure-class 'renderer-browser
+                           :direct-superclasses '(gi-gtk-browser)
+                           :metaclass 'interface-class))
+
+(setf nyxt::*renderer* (make-instance 'gi-gtk-renderer))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -518,7 +518,7 @@ response.  The BODY is wrapped with `with-protect'."
          (gtk:gtk-box-pack-start horizontal-box-layout panel-buffer-container-right :expand nil)
          (gtk:gtk-box-pack-start root-box-layout horizontal-box-layout :expand t :fill t)
 
-         (setf message-view (make-web-view *global-profile* nil))
+         (setf message-view (make-web-view (global-profile) nil))
          (gtk:gtk-box-pack-end root-box-layout message-container :expand nil)
          (gtk:gtk-box-pack-start message-container message-view :expand t)
          (setf (gtk:gtk-widget-size-request message-container)
@@ -529,7 +529,7 @@ response.  The BODY is wrapped with `with-protect'."
          (setf (gtk:gtk-widget-size-request status-container)
                (list -1 (height status-buffer)))
 
-         (setf prompt-buffer-view (make-web-view *global-profile* nil))
+         (setf prompt-buffer-view (make-web-view (global-profile) nil))
          (gtk:gtk-box-pack-end root-box-layout prompt-buffer-container :expand nil)
          (gtk:gtk-box-pack-start prompt-buffer-container prompt-buffer-view :expand t)
          (setf (gtk:gtk-widget-size-request prompt-buffer-container)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -178,6 +178,9 @@ It skips configuration files and other data files like the history."))))
             (uiop:delete-file-if-exists socket))))
       (mapc #'destroy-thread* (non-terminating-threads *browser*))
       (ffi-kill-browser *browser*)
+      ;; Reset global state.
+      (setf *browser* nil
+            *options* nil)
       ;; On FreeBSD this may cause freeze. Also we have to pass
       ;; FINISH-OUTPUT = NIL in FFI-INITIALIZE.
       #-freebsd

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -181,6 +181,7 @@ It skips configuration files and other data files like the history."))))
       ;; Reset global state.
       (setf *browser* nil
             *options* nil)
+      (uninstall *renderer*)
       ;; On FreeBSD this may cause freeze. Also we have to pass
       ;; FINISH-OUTPUT = NIL in FFI-INITIALIZE.
       #-freebsd

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -418,7 +418,7 @@ Examples:
   ;; Extensions should be made accessible straight from the beginning,
   ;; e.g. before a script is run.
   (declare #.(cons 'ignorable %start-args))
-  (unless +renderer+
+  (unless *renderer*
     (log:warn "No renderer set, Nyxt will not be able to render pages.  Try:
 
 \(progn
@@ -538,6 +538,9 @@ Finally, run the browser, load URL-STRINGS if any, then run
       (log:config :backup nil :pattern *log-pattern* :daily log-path)))
   (format t "Nyxt version ~a~&" +version+)
   (log:info "Source location: ~s" (files:expand *source-directory*))
+
+  (install *renderer*)
+
   (when (getf *options* :profile)
     (alex:if-let ((profile-class (find-profile-class (getf *options* :profile))))
       (log:info "Profile: ~s" (profile-name profile-class))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -537,9 +537,7 @@ Finally, run the browser, load URL-STRINGS if any, then run
   (log:info "Source location: ~s" (files:expand *source-directory*))
   (when (getf *options* :profile)
     (alex:if-let ((profile-class (find-profile-class (getf *options* :profile))))
-      (progn
-        (setf *global-profile* (make-instance profile-class))
-        (log:info "Profile: ~s" (profile-name profile-class)))
+      (log:info "Profile: ~s" (profile-name profile-class))
       (log:warn "Profile not found: ~s" (getf *options* :profile))))
   (let* ((urls (strings->urls url-strings))
          (thread (when (files:expand *socket-file*)

--- a/source/user-files.lisp
+++ b/source/user-files.lisp
@@ -13,12 +13,17 @@
   (:documentation "With the default profile all data is persisted to the
 standard locations."))
 
-(export-always '*global-profile*)
-(defvar *global-profile* (make-instance 'nyxt-profile)
-  "The profile to use in the absence of buffers and on browser-less variables.")
+(export-always 'global-profile)
+(defun global-profile ()
+  "The profile to use in the absence of buffers and on browser-less variables."
+  (or
+   (when *browser* (profile *browser*))
+   (alex:when-let ((profile-class (find-profile-class (getf *options* :profile))))
+     (make-instance profile-class))
+   (make-instance 'nyxt-profile)))
 
 (define-class nyxt-file (files:gpg-file)
-  ((files:profile *global-profile*)
+  ((files:profile (global-profile))
    (files:on-external-modification 'files:reload)
    (editable-p
     t

--- a/tests/offline/global-history.lisp
+++ b/tests/offline/global-history.lisp
@@ -14,8 +14,7 @@
 (define-test global-history ()
   ;; Set profile to nosave to inhibit serialization / deserialization.
   ;; TODO: We should still test serialization and deserialization.
-  (let* ((nyxt:*global-profile* (make-instance 'test-profile))
-         (*browser* (make-instance 'browser))
+  (let* ((*browser* (make-instance 'browser :profile (make-instance 'test-profile)))
          (buffer (nyxt::make-buffer)))
     (nyxt:with-current-buffer buffer
       (let ((file (history-file buffer)))
@@ -51,7 +50,7 @@
   (let* ((history-path (make-instance 'history-file
                                       :base-path (asdf:system-relative-pathname
                                                   :nyxt "tests/test-data/broken-history.lisp")))
-         (history (files:read-file nyxt:*global-profile* history-path)))
+         (history (files:read-file (global-profile) history-path)))
     (assert-eq 2
                (hash-table-count (htree:owners history)))
     (assert-eq 3


### PR DESCRIPTION
# Description

In an attempt to make tests more reproducible and less stateful, and more generally everything less stateful, I've implemented some important changes:

- `*global-profile*` is now `(global-profile)`.
- Renderers are now first class objects!
  - It's possible to switch renderers between two instances from the same REPL!
  - The dirty package lock violations are all gone.
  - It's now easier to see thanks to `install` where each renderer hooks itself in.

Fixes #2663 and #2619.

Prepares the fix for #2609.


# Discussion

The `(history-file browser)` initialization is too specific:

```lisp
(defmethod initialize-instance :after ((browser browser)
                                       &key (history-file nil history-file-p)
                                       &allow-other-keys)
  "Ensure `history-file' uses the browser profile."
  (setf (history-file browser)
        (if history-file-p
            history-file
            (make-instance 'history-file :profile (profile browser)))))
```

Can we be more general than that?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
