### PR TITLE
Fix nil browser

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -33,7 +33,7 @@ inherited from the superclasses.")
     :documentation "Unique identifier for a buffer.")
    ;; TODO: Or maybe a dead-buffer should just be a buffer history?
    (profile
-    (global-profile)
+    (profile *browser*)
     :type nyxt-profile
     :documentation "Buffer profiles are used to specialize the behavior of
 various parts, such as the path of all data files.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -441,9 +441,7 @@ query is not a valid URL, or the first keyword is not recognized.")
     :documentation "Select a download engine to use, such as `:lisp' or
 `:renderer'.")
    (history-file
-    (if *browser*
-        (history-file *browser*)
-        (make-instance 'history-file))
+    (history-file *browser*)
     :type history-file
     :documentation "File where to save the global history used by this buffer.
 See also `history-file' in `browser' for the global history restored on startup,
@@ -1009,9 +1007,7 @@ BUFFER's modes."
 (hooks:define-hook-type buffer (function (buffer)))
 
 (define-command make-buffer (&rest args &key (title "") modes
-                             (url (if *browser*
-                                      (default-new-buffer-url *browser*)
-                                      (quri:uri (nyxt-url 'new))))
+                             (url (default-new-buffer-url *browser*))
                              parent-buffer
                              no-history-p (load-url-p t) (buffer-class 'web-buffer)
                              &allow-other-keys)
@@ -1136,10 +1132,9 @@ This is a low-level function.  See `buffer-delete' for the high-level version."
   (gethash id (slot-value *browser* 'buffers)))
 
 (defun buffers-set (id buffer)
-  (when *browser*
-    (setf (gethash id (slot-value *browser* 'buffers)) buffer)
-    ;; Force setf call so that slot is seen as changed, e.g. by status buffer watcher.
-    (setf (slot-value *browser* 'buffers) (slot-value *browser* 'buffers))))
+  (setf (gethash id (slot-value *browser* 'buffers)) buffer)
+  ;; Force setf call so that slot is seen as changed, e.g. by status buffer watcher.
+  (setf (slot-value *browser* 'buffers) (slot-value *browser* 'buffers)))
 
 (defun buffers-delete (id)
   (remhash id (slot-value *browser* 'buffers))
@@ -1148,8 +1143,7 @@ This is a low-level function.  See `buffer-delete' for the high-level version."
 
 (export-always 'window-list)
 (defun window-list ()
-  (when *browser*
-    (alex:hash-table-values (windows *browser*))))
+  (alex:hash-table-values (windows *browser*)))
 
 (defun dummy-buffer-p (buffer)
   (eq 'buffer (type-of buffer)))

--- a/source/configuration-commands.lisp
+++ b/source/configuration-commands.lisp
@@ -54,9 +54,7 @@ On error, return the condition as a first value and the backtrace as second valu
                                       (let ((backtrace (with-output-to-string (stream)
                                                          (uiop:print-backtrace :stream stream :condition c))))
                                         (throw 'lisp-file-error
-                                          (if *browser*
-                                              (error-in-new-window "*Config file errors*" (princ-to-string c) backtrace)
-                                              (values c backtrace)))))))
+                                          (error-in-new-window "*Config file errors*" (princ-to-string c) backtrace))))))
                 (unsafe-load))))))))
 
 (define-command load-file ()

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -358,7 +358,7 @@ To discover the default value of a slot or all slots of a class, use the
   (or %buffer
       (alex:if-let ((w (or window (current-window))))
         (active-buffer w)
-        (when *browser*
+        (progn
           (log:debug "No active window, picking last active buffer.")
           (last-active-buffer)))))
 

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -563,7 +563,7 @@ say to develop Nyxt or extensions.")
                                 (uiop:relativize-pathname-directory (call-next-method))))
           (defmethod files:resolve ((profile dev-profile) (file history-file))
             "Persist history to default location."
-            (files:resolve (global-profile) file))
+            (files:resolve (profile *browser*) file))
           (define-configuration buffer
             "Make new profile the default."
             ((profile (make-instance (or (find-profile-class (getf *options* :profile)) 'dev-profile))))))

--- a/source/message.lisp
+++ b/source/message.lisp
@@ -10,14 +10,13 @@
                       log4cl:+log-level-warn+
                       log4cl:+log-level-error+))
     (uiop:print-backtrace))
-  (when *browser*
-    (push
-     ;; TODO: Include time in *Messages* entries.
-     ;; (make-instance 'log4cl:pattern-layout :conversion-pattern "<%p> [%D{%H:%M:%S}] %m%n" )
-     (with-output-to-string (s)
-       (log4cl-impl:layout-to-stream
-        (slot-value appender 'log4cl-impl:layout) s logger level log-func))
-     (slot-value *browser* 'messages-content))))
+  (push
+   ;; TODO: Include time in *Messages* entries.
+   ;; (make-instance 'log4cl:pattern-layout :conversion-pattern "<%p> [%D{%H:%M:%S}] %m%n" )
+   (with-output-to-string (s)
+     (log4cl-impl:layout-to-stream
+      (slot-value appender 'log4cl-impl:layout) s logger level log-func))
+   (slot-value *browser* 'messages-content)))
 
 (defmacro %echo (text &key (logger 'log:info))
   "Echo TEXT in the message buffer.

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -493,7 +493,7 @@ response.  The BODY is wrapped with `with-protect'."
          (gtk:gtk-box-pack-start horizontal-box-layout panel-buffer-container-right :expand nil)
          (gtk:gtk-box-pack-start root-box-layout horizontal-box-layout :expand t :fill t)
 
-         (setf message-view (make-web-view (global-profile) nil))
+         (setf message-view (make-web-view (profile *browser*) nil))
          (gtk:gtk-box-pack-end root-box-layout message-container :expand nil)
          (gtk:gtk-box-pack-start message-container message-view :expand t)
          (setf (gtk:gtk-widget-size-request message-container)
@@ -504,7 +504,7 @@ response.  The BODY is wrapped with `with-protect'."
          (setf (gtk:gtk-widget-size-request status-container)
                (list -1 (height status-buffer)))
 
-         (setf prompt-buffer-view (make-web-view (global-profile) nil))
+         (setf prompt-buffer-view (make-web-view (profile *browser*) nil))
          (gtk:gtk-box-pack-end root-box-layout prompt-buffer-container :expand nil)
          (gtk:gtk-box-pack-start prompt-buffer-container prompt-buffer-view :expand t)
          (setf (gtk:gtk-widget-size-request prompt-buffer-container)

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -179,9 +179,9 @@ It skips configuration files and other data files like the history."))))
       (mapc #'destroy-thread* (non-terminating-threads *browser*))
       (ffi-kill-browser *browser*)
       ;; Reset global state.
-      (setf *browser* nil
-            *options* nil)
       (uninstall *renderer*)
+      (setf *browser* (make-instance 'browser)
+            *options* nil)
       ;; On FreeBSD this may cause freeze. Also we have to pass
       ;; FINISH-OUTPUT = NIL in FFI-INITIALIZE.
       #-freebsd
@@ -541,6 +541,10 @@ Finally, run the browser, load URL-STRINGS if any, then run
   (log:info "Source location: ~s" (files:expand *source-directory*))
 
   (install *renderer*)
+
+  (unless (find-if (sera:eqs 'messages-appender) (log4cl:all-appenders)
+                   :key #'sera:class-name-of)
+    (log4cl:add-appender log4cl:*root-logger* (make-instance 'messages-appender)))
 
   (when (getf *options* :profile)
     (alex:if-let ((profile-class (find-profile-class (getf *options* :profile))))

--- a/source/user-files.lisp
+++ b/source/user-files.lisp
@@ -13,13 +13,8 @@
   (:documentation "With the default profile all data is persisted to the
 standard locations."))
 
-(export-always 'global-profile)
-(defun global-profile ()
-  "The profile to use in the absence of buffers and on browser-less variables."
-  (profile *browser*))
-
 (define-class nyxt-file (files:gpg-file)
-  ((files:profile (global-profile))
+  ((files:profile (profile *browser*))
    (files:on-external-modification 'files:reload)
    (editable-p
     t

--- a/source/user-files.lisp
+++ b/source/user-files.lisp
@@ -16,11 +16,7 @@ standard locations."))
 (export-always 'global-profile)
 (defun global-profile ()
   "The profile to use in the absence of buffers and on browser-less variables."
-  (or
-   (when *browser* (profile *browser*))
-   (alex:when-let ((profile-class (find-profile-class (getf *options* :profile))))
-     (make-instance profile-class))
-   (make-instance 'nyxt-profile)))
+  (profile *browser*))
 
 (define-class nyxt-file (files:gpg-file)
   ((files:profile (global-profile))


### PR DESCRIPTION
# Description

Follow-up to #2666.

This ensures `*browser*` is always bound, thus removing a whole class of potential errors.

Fixes #2670.

# Discussion

Can we set `*browser*` at compile time and save it in the image?

# To do:

- [ ] Merge #2666 first.
- [ ] Test!

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [ ] I have pulled from master before submitting this PR
- [ ] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
