### PR TITLE
Auto-adjust the prompt listing to the content in it.

### DIFF
--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -111,7 +111,7 @@ selection over prompt buffer suggestions.")
           :color ,theme:on-background
           :margin-left "16px"
           :width "100%"
-          :table-layout "fixed"
+          :table-layout auto ; So that content is laid-out in a smarter way.
           (td
            :white-space "nowrap"
            :height "20px"


### PR DESCRIPTION
# Description

This adds auto-adjustment of suggestion listing to all prompt sources. It's convenient, because it allows to display all the content at once in the auto-laid-out table. The downsides are that:
- Prompt is jittering a lot when scrolling, because we create a new table on every scroll event.
- The columns can get terribly uneven, and one of those can occupy all the allocated space, so we have to take care to now put anything extremely long in those.

As an example of both these adjantages and disadvantages, open Nyxt with this patch and trigger `execute-command`.

Fixes #2675.

# Discussion

Maybe there are other ways to make it more intuitive of a display, without this jitter (it annoys me, yes). Maybe render all the table below the screen space? This way it's going to auto-adjust to a more of a median value, I guess...

CC @jmercouris, @aadcg, @lansingthomas

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.