### PR TITLE
prompt-buffer: Adjust prompt column widths based on content.

### DIFF
--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -683,6 +683,13 @@ If the `active-attributes' slot is NIL, return all attributes keys."
           (cons (attributes-keys-default source)
                 (apply #'remove-from-seq (attributes-keys-non-default source) value)))))
 
+(export-always 'all-attribute-values)
+(defmethod all-attribute-values (attribute-key (source source))
+  "Return all ATTRIBUTE-KEY values from SOURCE."
+  (mapcar (alex:compose #'first
+                        (alex:rcurry #'str:s-assoc-value attribute-key))
+          (mapcar #'attributes (suggestions source))))
+
 (export-always 'active-attributes)
 (defmethod active-attributes ((suggestion suggestion)
                               &key (source (error "Source required"))

--- a/libraries/prompter/prompter-source.lisp
+++ b/libraries/prompter/prompter-source.lisp
@@ -347,6 +347,13 @@ call."))
     (loop for pair in (call-next-method)
           for key = (first pair)
           for value = (second pair)
+          ;; NOTE: Duplicate keys are bad, because searching the alist by key
+          ;; will always return the first occurrence, and never the second.
+          when (member key keys :test #'string-equal)
+            do (warn "Duplicate attribute names found in ~a: ~a.
+Attribute names should be unique for prompter to correctly filter those."
+                     source key)
+          collect key into keys
           ;; FIXME: Having six (string-t for keys and string-function-t for
           ;; values) branches would be more correct, but does that matter enough
           ;; to bother?

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -242,6 +242,7 @@
                (:file "tests/offline/user-script-parsing")
                (:file "tests/offline/mode")
                (:file "tests/offline/mode/process")
+               (:file "tests/offline/prompt-buffer")
                (:file "tests/online/urls")))
 
 (defsystem "nyxt/benchmark"

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -568,7 +568,9 @@ locally and is cleared after every session.")
 Nyxt-internal-pages.")
     (:li "The rules file is now moved to auto-rules.lisp (instead of the old
 auto-mode-rules.lisp)."))
-   (:li "Startup is more robust against corrupted history files."))
+   (:li "Startup is more robust against corrupted history files.")
+   (:li "Prompt buffer attribute columns adjust to their content, allowing for a better
+overview of lengthy attributes."))
 
   (:h3 "Programming interface")
   (:ul

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -304,12 +304,22 @@ See also `show-prompt-buffer'."
                                        ;; accept a list of keys.
                                        (prompter:all-attribute-values key source)))
             collect width into widths
-  (:documentation "Compute the widths of SOURCE attribute columns (as percent).
-            finally (return (clip-extremes (width-normalization widths))))))
-Returns a list of ratios that sum up to one.
-Uses the WIDTH-FUNCTION (by default computing average length of non-blank
-attribute values) to derive the width of the list of attribute
-values. WIDTH-FUNCTION is a function accepting a list of strings and returning
+            ;; Attributes keys set to empty strings aren't allowed, so widths is
+            ;; never a list whose elements are all zeros.  In such a scenario,
+            ;; width-normalization would error with DIVISION-BY-ZERO.
+            finally (return (width-normalization widths)))))
+  (:documentation "Return a list of unit ratio representative of the length of each
+of SOURCE's attributes in terms of number of characters.
+
+The sum of all ratios equals one.
+
+Useful to set column width for each of SOURCE's attributes. The ratios sum to
+one.
+
+Uses WIDTH-FUNCTION to derive the representative width of the list of attribute
+values.
+;; WIDTH-FUNCTION should a rations accepting a list of numbers returning a number.
+WIDTH-FUNCTION is a function accepting a list of strings and returning
 an integer."))
 
 (defun render-attributes (source prompt-buffer)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -310,11 +310,9 @@ See also `show-prompt-buffer'."
                                 into new-widths
                             finally (return new-widths))))
                    (t widths))))
-             (ratio-widths (widths)
-               "Compute the percentage of the screen that attributes with WIDTHS should occupy."
-               (let* ((total (reduce #'+ widths)))
-                 (mapcar (lambda (w) (if (zerop total) 0 (/ w total)))
-                         widths))))
+             (width-normalization (width-list)
+               (let ((total (reduce #'+ widths)))
+                 (mapcar (lambda (w) (/ w total)) widths))))
       ;; FIXME: This loop ignores attribute names in the attribute width
       ;; computation. Because of this, attribute names could theoretically get
       ;; cropped if the values are short enough. This is bad, but not exactly
@@ -326,14 +324,14 @@ See also `show-prompt-buffer'."
                                        (mapcar #'fourth (prompter:active-attributes (first suggestions) :source source)))
                                       (some-fourth (some #'identity fourth-attributes))
                                       (coefficients (substitute 1 nil fourth-attributes)))
-                        (return (ratio-widths coefficients)))
+                        (return (width-normalization coefficients)))
             for key in (prompter:active-attributes-keys source)
             for width
               = (funcall width-function (mapcar (compose #'first (rcurry #'str:s-assoc-value key))
                                                 attributes))
             collect width into widths
-            finally (return (clip-extremes (ratio-widths widths))))))
   (:documentation "Compute the widths of SOURCE attribute columns (as percent).
+            finally (return (clip-extremes (width-normalization widths))))))
 Returns a list of ratios that sum up to one.
 Uses the WIDTH-FUNCTION (by default computing average length of non-blank
 attribute values) to derive the width of the list of attribute

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -312,25 +312,13 @@ See also `show-prompt-buffer'."
                             finally (return new-widths))))
                    (t widths))))
              (width-normalization (width-list)
-      ;; FIXME: This loop ignores attribute names in the attribute width
-      ;; computation. Because of this, attribute names could theoretically get
-      ;; cropped if the values are short enough. This is bad, but not exactly
-      ;; critical.
-      (loop with suggestions = (prompter:suggestions source)
-            with attributes = (mapcar (rcurry #'prompter:active-attributes :source source) suggestions)
-            ;; This is to process column width as fourth object attribute element.
-            initially (sera:and-let* ((fourth-attributes
-                                       (mapcar #'fourth (prompter:active-attributes (first suggestions) :source source)))
-                                      (some-fourth (some #'identity fourth-attributes))
-                                      (coefficients (substitute 1 nil fourth-attributes)))
-                        (return (width-normalization coefficients)))
-            for key in (prompter:active-attributes-keys source)
-            for width
-              = (funcall width-function (mapcar (compose #'first (rcurry #'str:s-assoc-value key))
-                                                attributes))
                ;; this should not eval to (/ 0 0) by construction
                (let ((total (reduce #'+ width-list)))
                  (mapcar (lambda (w) (/ w total)) width-list))))
+      (loop for key in (prompter:active-attributes-keys source)
+            for width = (funcall width-function
+                                 (cons key
+                                       (prompter:all-attribute-values key source)))
             collect width into widths
   (:documentation "Compute the widths of SOURCE attribute columns (as percent).
             finally (return (clip-extremes (width-normalization widths))))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -312,8 +312,6 @@ See also `show-prompt-buffer'."
                             finally (return new-widths))))
                    (t widths))))
              (width-normalization (width-list)
-               (let ((total (reduce #'+ widths)))
-                 (mapcar (lambda (w) (/ w total)) widths))))
       ;; FIXME: This loop ignores attribute names in the attribute width
       ;; computation. Because of this, attribute names could theoretically get
       ;; cropped if the values are short enough. This is bad, but not exactly
@@ -331,6 +329,8 @@ See also `show-prompt-buffer'."
               = (funcall width-function (mapcar (compose #'first (rcurry #'str:s-assoc-value key))
                                                 attributes))
                ;; this should not eval to (/ 0 0) by construction
+               (let ((total (reduce #'+ width-list)))
+                 (mapcar (lambda (w) (/ w total)) width-list))))
             collect width into widths
   (:documentation "Compute the widths of SOURCE attribute columns (as percent).
             finally (return (clip-extremes (width-normalization widths))))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -288,8 +288,10 @@ See also `show-prompt-buffer'."
   ;; to the empty string, and therefore
   ;; (mapcar #'length (remove-if #'str:blankp attribute-values))
   ;; can be NIL.
-  (alex:median (uiop:ensure-list (mapcar #'length
-                                         (remove-if #'str:blankp attribute-values)))))
+  (alex:if-let ((non-blank-lengths
+                 (uiop:ensure-list (mapcar #'length (remove-if #'str:blankp attribute-values)))))
+    (alex:median non-blank-lengths)
+    0))
 
 (defgeneric attribute-widths (source &key width-function)
   (:method (source &key (width-function #'average-attribute-width))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -280,7 +280,11 @@ See also `show-prompt-buffer'."
                                        (sort-modes-for-status (modes prompt-buffer)))))))))
 
 (defun attribute-widths (source)
-  (loop for key in (prompter:active-attributes-keys source)
+  "Compute the widths of SOURCE attribute columns (as percent).
+Returns a list of integers, the sum of which should be roughly equal to 100.
+Uses the average length of attribute values to derive the width."
+  (loop with suggestions = (prompter:suggestions source)
+        for key in (prompter:active-attributes-keys source)
         for width
           = (loop for suggestion in suggestions
                   sum (length (second (assoc key (prompter:active-attributes suggestion :source source)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -294,6 +294,7 @@ Uses the average length of attribute values to derive the width."
                                                      (/* w total))))))
                      widths)))
     (loop with suggestions = (prompter:suggestions source)
+          with attributes = (mapcar (rcurry #'prompter:active-attributes :source source) suggestions)
           ;; This is to process column width as fourth object attribute element.
           initially (sera:and-let* ((fourth-attributes
                                      (mapcar #'fourth (prompter:active-attributes (first suggestions) :source source)))
@@ -304,11 +305,8 @@ Uses the average length of attribute values to derive the width."
           for key in (prompter:active-attributes-keys source)
           for width
             = (let* ((values (remove-if #'str:blankp
-                                        (mapcar (compose
-                                                 #'first
-                                                 (rcurry #'str:s-assoc-value key)
-                                                 (rcurry #'prompter:active-attributes :source source))
-                                                suggestions)))
+                                        (mapcar (compose #'first (rcurry #'str:s-assoc-value key))
+                                                attributes)))
                      (total (reduce #'+ values :key #'length)))
                 (/* total (length values)))
           collect width into widths

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -288,8 +288,8 @@ Uses the average length of attribute values to derive the width."
         for key in (prompter:active-attributes-keys source)
         for width
           = (loop for suggestion in suggestions
-                  sum (length (second (assoc key (prompter:active-attributes suggestion :source source)
-                                             :test #'string=))))
+                  sum (length (first (str:s-assoc-value
+                                      (prompter:active-attributes suggestion :source source) key))))
         collect width into widths
         sum width into total
         finally (return (mapcar (lambda (w) (+ 10 (round (* (- 100 mandatory-space)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -283,21 +283,20 @@ See also `show-prompt-buffer'."
   "Compute the widths of SOURCE attribute columns (as percent).
 Returns a list of integers, the sum of which should be roughly equal to 100.
 Uses the average length of attribute values to derive the width."
-  (flet ((ratio-widths (widths total mandatory-space)
-           (mapcar (lambda (w) (+ 10 (round (* (- 100 mandatory-space)
-                                               (if (zerop total)
+  (flet ((ratio-widths (widths total)
+           (mapcar (lambda (w) (+ (/ 100 (length widths) 2)
+                                  (round (* 50 (if (zerop total)
                                                    0
                                                    (/ w total))))))
                    widths)))
     (loop with suggestions = (prompter:suggestions source)
-          with mandatory-space = (* 10 (length (prompter:active-attributes-keys source)))
           ;; This is to process column width as fourth object attribute element.
           initially (sera:and-let* ((fourth-attributes
                                      (mapcar #'fourth (prompter:active-attributes (first suggestions) :source source)))
                                     (some-fourth (some #'identity fourth-attributes))
                                     (coefficients (substitute 1 nil fourth-attributes))
                                     (total (reduce #'+ coefficients)))
-                      (return (ratio-widths coefficients total mandatory-space)))
+                      (return (ratio-widths coefficients total)))
           for key in (prompter:active-attributes-keys source)
           for width
             = (loop for suggestion in suggestions
@@ -305,7 +304,7 @@ Uses the average length of attribute values to derive the width."
                                         (prompter:active-attributes suggestion :source source) key))))
           collect width into widths
           sum width into total
-          finally (return (ratio-widths widths total mandatory-space)))))
+          finally (return (ratio-widths widths total)))))
 
 (defun render-attributes (source prompt-buffer)
   (spinneret:with-html-string

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -317,6 +317,10 @@ See also `show-prompt-buffer'."
                                                        0
                                                        (/ w total)))))
                          widths))))
+      ;; FIXME: This loop ignores attribute names in the attribute width
+      ;; computation. Because of this, attribute names could theoretically get
+      ;; cropped if the values are short enough. This is bad, but not exactly
+      ;; critical.
       (loop with suggestions = (prompter:suggestions source)
             with attributes = (mapcar (rcurry #'prompter:active-attributes :source source) suggestions)
             ;; This is to process column width as fourth object attribute element.

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -295,6 +295,51 @@ Uses the average length of attribute values to derive the width."
         finally (return (mapcar (lambda (w) (+ 10 (round (* (- 100 mandatory-space) (/ w total)))))
                                 widths))))
 
+(defun render-attributes (source prompt-buffer)
+  (spinneret:with-html-string
+    (when (prompter:suggestions source)
+      (:table :class "source-content"
+              (:colgroup
+               (dolist (width (attribute-widths source))
+                 (:col :style (format nil "width: ~d%" width))))
+              (:tr :style (if (or (eq (prompter:hide-attribute-header-p source) :always)
+                                  (and (eq (prompter:hide-attribute-header-p source) :single)
+                                       (sera:single (prompter:active-attributes-keys source))))
+                              "display:none;"
+                              "display:revert;")
+                   (loop for attribute-key in (prompter:active-attributes-keys source)
+                         collect (:th (spinneret::escape-string attribute-key))))
+              (loop
+                ;; TODO: Only print as many lines as fit the height.
+                ;; But how can we know in advance?
+                with max-suggestion-count = 10
+                repeat max-suggestion-count
+                with cursor-index = (prompter:selected-suggestion-position prompt-buffer)
+                for suggestion-index from (max 0 (- cursor-index (/ max-suggestion-count 2)))
+                for suggestion in (nthcdr suggestion-index (prompter:suggestions source))
+                collect
+                (let ((suggestion-index suggestion-index)
+                      (cursor-index cursor-index))
+                  (:tr :id (when (equal (list suggestion source)
+                                        (multiple-value-list (prompter:selected-suggestion prompt-buffer)))
+                             "selection")
+                       :class (when (prompter:marked-p source (prompter:value suggestion))
+                                "marked")
+                       :onmousedown (when (mouse-support-p prompt-buffer)
+                                      (ps:ps
+                                        (nyxt/ps:lisp-eval
+                                         (:title "return-selection" :buffer prompt-buffer)
+                                         (prompter::select (current-prompt-buffer)
+                                           (- suggestion-index cursor-index))
+                                         (prompter:return-selection
+                                          (nyxt::current-prompt-buffer)))))
+                       (loop for (nil attribute attribute-display)
+                               in (prompter:active-attributes suggestion :source source)
+                             collect (:td :title attribute
+                                          (if attribute-display
+                                              (:raw attribute-display)
+                                              (spinneret::escape-string attribute)))))))))))
+
 (export 'prompt-render-suggestions)
 (defmethod prompt-render-suggestions ((prompt-buffer prompt-buffer))
   "Refresh the rendering of the suggestion list.
@@ -302,7 +347,6 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
   (let* ((sources (prompter:sources prompt-buffer))
          (current-source-index (position (current-source prompt-buffer) sources))
          (last-source-index (1- (length sources))))
-    ;; TODO: Factor out attribute printing.
     (flet ((source->html (source)
              (spinneret:with-html-string
                (:div :class "source"
@@ -322,47 +366,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                            (if (prompter:ready-p source)
                                ""
                                "(In progress...)"))
-                     (when (prompter:suggestions source)
-                       (:table :class "source-content"
-                               (:colgroup
-                                (dolist (width (nyxt::attribute-widths source))
-                                  (:col :style (format nil "width: ~d%" width))))
-                               (:tr :style (if (or (eq (prompter:hide-attribute-header-p source) :always)
-                                                   (and (eq (prompter:hide-attribute-header-p source) :single)
-                                                        (sera:single (prompter:active-attributes-keys source))))
-                                               "display:none;"
-                                               "display:revert;")
-                                    (loop for attribute-key in (prompter:active-attributes-keys source)
-                                          collect (:th (spinneret::escape-string attribute-key))))
-                               (loop ;; TODO: Only print as many lines as fit the height.  But how can we know in advance?
-                                     ;; Maybe first make the table, then add the element one by one _if_ there are into view.
-                                     with max-suggestion-count = 10
-                                     repeat max-suggestion-count
-                                     with cursor-index = (prompter:selected-suggestion-position prompt-buffer)
-                                     for suggestion-index from (max 0 (- cursor-index (/ max-suggestion-count 2)))
-                                     for suggestion in (nthcdr suggestion-index (prompter:suggestions source))
-                                     collect
-                                     (let ((suggestion-index suggestion-index)
-                                           (cursor-index cursor-index))
-                                       (:tr :id (when (equal (list suggestion source)
-                                                             (multiple-value-list (prompter:selected-suggestion prompt-buffer)))
-                                                  "selection")
-                                            :class (when (prompter:marked-p source (prompter:value suggestion))
-                                                     "marked")
-                                            :onmousedown (when (mouse-support-p prompt-buffer)
-                                                           (ps:ps
-                                                             (nyxt/ps:lisp-eval
-                                                              (:title "return-selection" :buffer prompt-buffer)
-                                                              (prompter::select (current-prompt-buffer)
-                                                                (- suggestion-index cursor-index))
-                                                              (prompter:return-selection
-                                                               (nyxt::current-prompt-buffer)))))
-                                            (loop for (nil attribute attribute-display)
-                                                    in (prompter:active-attributes suggestion :source source)
-                                                  collect (:td :title attribute
-                                                               (if attribute-display
-                                                                   (:raw attribute-display)
-                                                                   (spinneret::escape-string attribute)))))))))))))
+                     (:raw (render-attributes source prompt-buffer))))))
       (ps-eval :buffer prompt-buffer
         (setf (ps:@ (nyxt/ps:qs document "#suggestions") |innerHTML|)
               (ps:lisp

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -292,7 +292,10 @@ Uses the average length of attribute values to derive the width."
                                              :test #'string=))))
         collect width into widths
         sum width into total
-        finally (return (mapcar (lambda (w) (+ 10 (round (* (- 100 mandatory-space) (/ w total)))))
+        finally (return (mapcar (lambda (w) (+ 10 (round (* (- 100 mandatory-space)
+                                                            (if (zerop total)
+                                                                0
+                                                                (/ w total))))))
                                 widths))))
 
 (defun render-attributes (source prompt-buffer)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -346,7 +346,7 @@ an integer."))
       (:table :class "source-content"
               (:colgroup
                (dolist (width (attribute-widths source))
-                 (:col :style (format nil "width: ~f%" width))))
+                 (:col :style (format nil "width: ~,2f%" (* 100 width)))))
               (:tr :style (if (or (eq (prompter:hide-attribute-header-p source) :always)
                                   (and (eq (prompter:hide-attribute-header-p source) :single)
                                        (sera:single (prompter:active-attributes-keys source))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -290,10 +290,10 @@ See also `show-prompt-buffer'."
   (:method (source &key (width-function #'average-attribute-width))
     (labels ((clip-extremes (widths)
                (let* ((length (length widths))
-                      (minimal-size (/ 100 length 2)))
+                      (minimal-size (/ 1 length 2)))
                  (cond
                    ((= 1 length)
-                    (list 100))
+                    (list 1))
                    ((some (rcurry #'< minimal-size) widths)
                     (let* ((lacking (remove-if-not #'plusp
                                                    (mapcar (curry #'- minimal-size) widths)))
@@ -313,9 +313,7 @@ See also `show-prompt-buffer'."
              (ratio-widths (widths)
                "Compute the percentage of the screen that attributes with WIDTHS should occupy."
                (let* ((total (reduce #'+ widths)))
-                 (mapcar (lambda (w) (* 100 (if (zerop total)
-                                                0
-                                                (/ w total))))
+                 (mapcar (lambda (w) (if (zerop total) 0 (/ w total)))
                          widths))))
       ;; FIXME: This loop ignores attribute names in the attribute width
       ;; computation. Because of this, attribute names could theoretically get
@@ -336,7 +334,7 @@ See also `show-prompt-buffer'."
             collect width into widths
             finally (return (clip-extremes (ratio-widths widths))))))
   (:documentation "Compute the widths of SOURCE attribute columns (as percent).
-Returns a list of integers, the sum of which should be roughly equal to 100.
+Returns a list of ratios that sum up to one.
 Uses the WIDTH-FUNCTION (by default computing average length of non-blank
 attribute values) to derive the width of the list of attribute
 values. WIDTH-FUNCTION is a function accepting a list of strings and returning

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -290,7 +290,7 @@ See also `show-prompt-buffer'."
   (:method (source &key (width-function #'average-attribute-width))
     (labels ((clip-extremes (widths)
                (let* ((length (length widths))
-                      (minimal-size (round (/ 100 length 2))))
+                      (minimal-size (/ 100 length 2)))
                  (cond
                    ((= 1 length)
                     (list 100))
@@ -303,19 +303,19 @@ See also `show-prompt-buffer'."
                             when (< width minimal-size)
                               collect minimal-size into new-widths
                             else
-                              collect (round (- width
-                                                (* lack
-                                                   (/ width
-                                                      (reduce #'+ abundant)))))
+                              collect (- width
+                                         (* lack
+                                            (/ width
+                                               (reduce #'+ abundant))))
                                 into new-widths
                             finally (return new-widths))))
                    (t widths))))
              (ratio-widths (widths)
                "Compute the percentage of the screen that attributes with WIDTHS should occupy."
                (let* ((total (reduce #'+ widths)))
-                 (mapcar (lambda (w) (round (* 100 (if (zerop total)
-                                                       0
-                                                       (/ w total)))))
+                 (mapcar (lambda (w) (* 100 (if (zerop total)
+                                                0
+                                                (/ w total))))
                          widths))))
       ;; FIXME: This loop ignores attribute names in the attribute width
       ;; computation. Because of this, attribute names could theoretically get
@@ -348,7 +348,7 @@ an integer."))
       (:table :class "source-content"
               (:colgroup
                (dolist (width (attribute-widths source))
-                 (:col :style (format nil "width: ~d%" width))))
+                 (:col :style (format nil "width: ~f%" width))))
               (:tr :style (if (or (eq (prompter:hide-attribute-header-p source) :always)
                                   (and (eq (prompter:hide-attribute-header-p source) :single)
                                        (sera:single (prompter:active-attributes-keys source))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -283,12 +283,13 @@ See also `show-prompt-buffer'."
 ;; That would make this more generic -- fn that accepts a list of numbers and
 ;; outputs a number.
 (defun average-attribute-width (attribute-values)
-  (let* ((values (remove-if #'str:blankp attribute-values))
-         (total (reduce #'+ values :key #'length)))
-    ;; this should not eval to (/ 0 0) by construction
-    (if (zerop (length values))
-        0
-        (/ total (length values)))))
+  ;; The workaround is due to comment on line 401 of this file.
+  ;; While the prompt buffer is being draw some of the attributes are still set
+  ;; to the empty string, and therefore
+  ;; (mapcar #'length (remove-if #'str:blankp attribute-values))
+  ;; can be NIL.
+  (alex:median (uiop:ensure-list (mapcar #'length
+                                         (remove-if #'str:blankp attribute-values)))))
 
 (defgeneric attribute-widths (source &key width-function)
   (:method (source &key (width-function #'average-attribute-width))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -282,6 +282,7 @@ See also `show-prompt-buffer'."
 (defun average-attribute-width (attribute-values)
   (let* ((values (remove-if #'str:blankp attribute-values))
          (total (reduce #'+ values :key #'length)))
+    ;; this should not eval to (/ 0 0) by construction
     (if (zerop (length values))
         0
         (/ total (length values)))))
@@ -329,6 +330,7 @@ See also `show-prompt-buffer'."
             for width
               = (funcall width-function (mapcar (compose #'first (rcurry #'str:s-assoc-value key))
                                                 attributes))
+               ;; this should not eval to (/ 0 0) by construction
             collect width into widths
   (:documentation "Compute the widths of SOURCE attribute columns (as percent).
             finally (return (clip-extremes (width-normalization widths))))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -284,6 +284,7 @@ See also `show-prompt-buffer'."
 Returns a list of integers, the sum of which should be roughly equal to 100.
 Uses the average length of attribute values to derive the width."
   (loop with suggestions = (prompter:suggestions source)
+        with mandatory-space = (* 10 (length (prompter:active-attributes-keys source)))
         for key in (prompter:active-attributes-keys source)
         for width
           = (loop for suggestion in suggestions
@@ -291,7 +292,7 @@ Uses the average length of attribute values to derive the width."
                                              :test #'string=))))
         collect width into widths
         sum width into total
-        finally (return (mapcar (lambda (w) (round (* 100 (/ w total))))
+        finally (return (mapcar (lambda (w) (+ 10 (round (* (- 100 mandatory-space) (/ w total)))))
                                 widths))))
 
 (export 'prompt-render-suggestions)

--- a/tests/offline/prompt-buffer.lisp
+++ b/tests/offline/prompt-buffer.lisp
@@ -6,18 +6,41 @@
 (unless lparallel:*kernel* (setf lparallel:*kernel*
                                  (lparallel:make-kernel (or (serapeum:count-cpus) 1))))
 
-(define-class twice-source (prompter:source)
-  ((prompter:name "Twice-repeated suggestions")))
+(define-class test-source (prompter:source)
+  ;; The number of suggestions is only relevant to access the algorithm's
+  ;; performance, so it suffices to use a single suggestion for general testing.
+  ((prompter:name "Test")
+   (prompter:constructor '("suggestion"))))
 
-(defmethod prompter:object-attributes ((object string) (source twice-source))
-  `(("Once" ,object)
-    ("Twice" ,(str:concat object object))))
+(defun set-test-source-object-attributes (lst)
+  "Set `prompter:object-attributes' following LST properties:
+Its length LST dictates the number of attributes.
+Each element dictates the number of times a suggestion is concatenated."
+  (defmethod prompter:object-attributes ((object string) (source test-source))
+    (do ((index 0 (1+ index))
+         (result '() (cons `("Attribute" ,(str:repeat (nth index lst) object))
+                           result)))
+        ((eq index (length lst)) (nreverse result)))))
 
-(define-test smart-attribute-widths ()
-  (assert-equal
-   (list (round (/ 100 3))
-         (round (* 2 (/ 100 3))))
-   (nyxt::attribute-widths
-    (make-instance 'twice-source
-                   :constructor (mapcar (curry #'format nil "~R")
-                                        (alex:iota 100))))))
+;; TODO Add to lisp-unit2.
+(defun random-in-range (start end)
+  (+ start (random (+ 1 (- end start)))))
+
+(define-test constant-size-attributes ()
+  (let ((n-attributes (random-in-range 1 10)))
+    ;; How to shup up the fact that the method is being redefined?
+    (set-test-source-object-attributes (make-list n-attributes :initial-element 1))
+    (assert-equal (make-list n-attributes :initial-element (/ 100 n-attributes))
+                  (nyxt::attribute-widths (make-instance 'test-source)))))
+
+(define-test ratio-between-two-attributes ()
+  (let ((ratio (random-in-range 1 4)))
+    (set-test-source-object-attributes `(1 ,ratio))
+    (assert-equal (mapcar (curry #'* 100)
+                          (list (/ 1 (1+ ratio)) (/ ratio (1+ ratio))))
+                  (nyxt::attribute-widths (make-instance 'test-source)))
+    ;; Test symmetry.
+    (set-test-source-object-attributes `(,ratio 1))
+    (assert-equal (mapcar (curry #'* 100)
+                          (list (/ ratio (1+ ratio)) (/ 1 (1+ ratio))))
+                  (nyxt::attribute-widths (make-instance 'test-source)))))

--- a/tests/offline/prompt-buffer.lisp
+++ b/tests/offline/prompt-buffer.lisp
@@ -10,7 +10,7 @@
   ;; The number of suggestions is only relevant to access the algorithm's
   ;; performance, so it suffices to use a single suggestion for general testing.
   ((prompter:name "Test")
-   (prompter:constructor '("foo1"))))
+   (prompter:constructor '("Foo1"))))
 
 (defun set-test-source-object-attributes (lst)
   "Set `prompter:object-attributes' following LST properties:
@@ -18,7 +18,8 @@ Its length LST dictates the number of attributes.
 Each element dictates the number of times a suggestion is concatenated."
   (defmethod prompter:object-attributes ((object string) (source test-source))
     (do ((index 0 (1+ index))
-         (result '() (cons `(,(str:concat "foo" (princ-to-string index))
+         (result '() (cons `(,(str:repeat (nth index lst)
+                                (str:concat "Foo" (princ-to-string index)))
                              ,(str:repeat (nth index lst) object))
                            result)))
         ((eq index (length lst)) (nreverse result)))))

--- a/tests/offline/prompt-buffer.lisp
+++ b/tests/offline/prompt-buffer.lisp
@@ -15,12 +15,8 @@
 
 (define-test smart-attribute-widths ()
   (assert-equal
-   ;; This is because we split 50% of the width between all the attributes
-   ;; evenly (thus 25) and then add the average sizes of attributes relative to
-   ;; each other (thus 1*(50/3) and 2*(50/3)---the second attribute is twice as
-   ;; big as the first one).
-   (list (+ 25 (round (/ 50 3)))
-         (+ 25 (round (* 2 (/ 50 3)))))
+   (list (round (/ 100 3))
+         (round (* 2 (/ 100 3))))
    (nyxt::attribute-widths
     (make-instance 'twice-source
                    :constructor (mapcar (curry #'format nil "~R")

--- a/tests/offline/prompt-buffer.lisp
+++ b/tests/offline/prompt-buffer.lisp
@@ -1,0 +1,27 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nyxt/tests)
+
+(unless lparallel:*kernel* (setf lparallel:*kernel*
+                                 (lparallel:make-kernel (or (serapeum:count-cpus) 1))))
+
+(define-class twice-source (prompter:source)
+  ((prompter:name "Twice-repeated suggestions")))
+
+(defmethod prompter:object-attributes ((object string) (source twice-source))
+  `(("Once" ,object)
+    ("Twice" ,(str:concat object object))))
+
+(define-test smart-attribute-widths ()
+  (assert-equal
+   ;; This is because we split 50% of the width between all the attributes
+   ;; evenly (thus 25) and then add the average sizes of attributes relative to
+   ;; each other (thus 1*(50/3) and 2*(50/3)---the second attribute is twice as
+   ;; big as the first one).
+   (list (+ 25 (round (/ 50 3)))
+         (+ 25 (round (* 2 (/ 50 3)))))
+   (nyxt::attribute-widths
+    (make-instance 'twice-source
+                   :constructor (mapcar (curry #'format nil "~R")
+                                        (alex:iota 100))))))

--- a/tests/offline/prompt-buffer.lisp
+++ b/tests/offline/prompt-buffer.lisp
@@ -31,17 +31,15 @@ Each element dictates the number of times a suggestion is concatenated."
   (let ((n-attributes (random-in-range 1 10)))
     ;; How to shup up the fact that the method is being redefined?
     (set-test-source-object-attributes (make-list n-attributes :initial-element 1))
-    (assert-equal (make-list n-attributes :initial-element (/ 100 n-attributes))
+    (assert-equal (make-list n-attributes :initial-element (/ 1 n-attributes))
                   (nyxt::attribute-widths (make-instance 'test-source)))))
 
 (define-test ratio-between-two-attributes ()
   (let ((ratio (random-in-range 1 4)))
     (set-test-source-object-attributes `(1 ,ratio))
-    (assert-equal (mapcar (curry #'* 100)
-                          (list (/ 1 (1+ ratio)) (/ ratio (1+ ratio))))
+    (assert-equal (list (/ 1 (1+ ratio)) (/ ratio (1+ ratio)))
                   (nyxt::attribute-widths (make-instance 'test-source)))
     ;; Test symmetry.
     (set-test-source-object-attributes `(,ratio 1))
-    (assert-equal (mapcar (curry #'* 100)
-                          (list (/ ratio (1+ ratio)) (/ 1 (1+ ratio))))
+    (assert-equal (list (/ ratio (1+ ratio)) (/ 1 (1+ ratio)))
                   (nyxt::attribute-widths (make-instance 'test-source)))))

--- a/tests/offline/prompt-buffer.lisp
+++ b/tests/offline/prompt-buffer.lisp
@@ -18,7 +18,8 @@ Its length LST dictates the number of attributes.
 Each element dictates the number of times a suggestion is concatenated."
   (defmethod prompter:object-attributes ((object string) (source test-source))
     (do ((index 0 (1+ index))
-         (result '() (cons `("Attribute" ,(str:repeat (nth index lst) object))
+         (result '() (cons `(,(str:concat "Attribute" (princ-to-string index))
+                             ,(str:repeat (nth index lst) object))
                            result)))
         ((eq index (length lst)) (nreverse result)))))
 

--- a/tests/offline/prompt-buffer.lisp
+++ b/tests/offline/prompt-buffer.lisp
@@ -10,7 +10,7 @@
   ;; The number of suggestions is only relevant to access the algorithm's
   ;; performance, so it suffices to use a single suggestion for general testing.
   ((prompter:name "Test")
-   (prompter:constructor '("suggestion"))))
+   (prompter:constructor '("foo1"))))
 
 (defun set-test-source-object-attributes (lst)
   "Set `prompter:object-attributes' following LST properties:
@@ -18,7 +18,7 @@ Its length LST dictates the number of attributes.
 Each element dictates the number of times a suggestion is concatenated."
   (defmethod prompter:object-attributes ((object string) (source test-source))
     (do ((index 0 (1+ index))
-         (result '() (cons `(,(str:concat "Attribute" (princ-to-string index))
+         (result '() (cons `(,(str:concat "foo" (princ-to-string index))
                              ,(str:repeat (nth index lst) object))
                            result)))
         ((eq index (length lst)) (nreverse result)))))


### PR DESCRIPTION
# Description

A second shot at #2682, this time looking at prompt content and deciding the size based on the average length of the content in the suggestion attributes. Here's how it looks:

![adjusted-prompt-execute](https://user-images.githubusercontent.com/57838654/205307772-c71ea92b-9e59-44bb-b723-633caf7c72a3.png)
![adjusted-prompt-buffers](https://user-images.githubusercontent.com/57838654/205307785-223c4259-a991-42fd-9b3e-6b18d43624af.png)

Fixes #2675.
Fixes #2684.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.