### PR TITLE
Unify height and width handling for buffers & other widgets

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -595,7 +595,9 @@ regular commands, such as "
    (:li "Renderers are now first class objects, see the " (:code "renderer") " class."
         " It's possible to change renderer from a same REPL session.")
    (:li (:nxref :command 'set-url) " and " (:nxref :command 'set-url-new-buffer) " accept the "
-        (:code ":URL") " keyword argument and load it when provided."))
+        (:code ":URL") " keyword argument and load it when provided.")
+   (:li "New " (:nxref :function 'ffi-height) " and " (:nxref :function 'ffi-width)
+        " methods to unify most of the height & width methods used before."))
 
   (:h3 "Bug fixes")
   (:ul

--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -103,12 +103,6 @@ Usually setf-able."))
   (:setter-p t)
   (:documentation "Return the WINDOW message buffer height as a number.
 Setf-able."))
-;; FIXME: Is not implemented as `ffi-height', because `hide-prompt-buffer' needs
-;; deleting _prompt container_, not adjusting the size of prompt buffer.
-(define-ffi-generic ffi-window-prompt-buffer-height (window)
-  (:setter-p t)
-  (:documentation "Return the WINDOW prompt buffer height as a number.
-Setf-able. If set to 0, delete the prompt widget."))
 
 (define-ffi-generic ffi-buffer-make (buffer)
   (:documentation "Make BUFFER widget."))

--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -86,27 +86,29 @@ SIDE is one of `:left' or `:right'."))
 (define-ffi-generic ffi-window-delete-panel-buffer (window buffer)
   (:documentation "Unbind the panel BUFFER widget from WINDOW."))
 
-(define-ffi-generic ffi-window-panel-buffer-width (window buffer)
+(define-ffi-generic ffi-height (object)
   (:setter-p t)
-  (:documentation "Return the panel BUFFER width as a number.
-Setf-able."))
-(define-ffi-generic ffi-window-prompt-buffer-height (window)
+  (:documentation "Return the OBJECT height in pixels as a number.
+Dispatches over: `buffer', `status-buffer'.
+Usually setf-able."))
+(define-ffi-generic ffi-width (object)
   (:setter-p t)
-  (:documentation "Return the WINDOW prompt buffer height as a number.
-Setf-able."))
-(define-ffi-generic ffi-window-status-buffer-height (window)
-  (:setter-p t)
-  (:documentation "Return the WINDOW status buffer height as a number.
-Setf-able."))
+  (:documentation "Return the OBJECT width in pixels as a number.
+Dispatches over: `buffer', `panel-buffer'.
+Usually setf-able."))
+
+;; FIXME: Cannot yet be implemented as an `ffi-height', because there's nothing
+;; to dispatch on.
 (define-ffi-generic ffi-window-message-buffer-height (window)
   (:setter-p t)
   (:documentation "Return the WINDOW message buffer height as a number.
 Setf-able."))
-
-(define-ffi-generic ffi-buffer-height (buffer)
-  (:documentation "Return the BUFFER height in pixels as a number."))
-(define-ffi-generic ffi-buffer-width (buffer)
-  (:documentation "Return the BUFFER width in pixels as a number."))
+;; FIXME: Is not implemented as `ffi-height', because `hide-prompt-buffer' needs
+;; deleting _prompt container_, not adjusting the size of prompt buffer.
+(define-ffi-generic ffi-window-prompt-buffer-height (window)
+  (:setter-p t)
+  (:documentation "Return the WINDOW prompt buffer height as a number.
+Setf-able. If set to 0, delete the prompt widget."))
 
 (define-ffi-generic ffi-buffer-make (buffer)
   (:documentation "Make BUFFER widget."))

--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -89,12 +89,12 @@ SIDE is one of `:left' or `:right'."))
 (define-ffi-generic ffi-height (object)
   (:setter-p t)
   (:documentation "Return the OBJECT height in pixels as a number.
-Dispatches over: `buffer', `status-buffer'.
+Dispatches over: `window', `buffer', `status-buffer'.
 Usually setf-able."))
 (define-ffi-generic ffi-width (object)
   (:setter-p t)
   (:documentation "Return the OBJECT width in pixels as a number.
-Dispatches over: `buffer', `panel-buffer'.
+Dispatches over: `window', `buffer', `panel-buffer'.
 Usually setf-able."))
 
 ;; FIXME: Cannot yet be implemented as an `ffi-height', because there's nothing

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -545,7 +545,7 @@ of buffers."
                              (title heading)))
                     (when (rest group)
                       (:raw (sera:mapconcat #'headings->html (list (group-headings (rest group))) "")))))))))
-    (setf (ffi-window-panel-buffer-width (current-window) panel-buffer) 400)
+    (setf (ffi-width panel-buffer) 400)
     (spinneret:with-html-string
       (:h1 "Headings")
       (:raw (headings->html (group-headings (get-headings)))))))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -187,7 +187,7 @@ See also `hide-prompt-buffer'."
     (push prompt-buffer (active-prompt-buffers (window prompt-buffer)))
     (calispel:! (prompt-buffer-channel (window prompt-buffer)) prompt-buffer)
     (prompt-render prompt-buffer)
-    (setf (ffi-window-prompt-buffer-height (window prompt-buffer))
+    (setf (ffi-height prompt-buffer)
           (case height
             (:default (prompt-buffer-open-height (window prompt-buffer)))
             (:fit-to-prompt
@@ -229,7 +229,7 @@ See also `show-prompt-buffer'."
     (if (active-prompt-buffers window)
         (let ((next-prompt-buffer (first (active-prompt-buffers window))))
           (show-prompt-buffer next-prompt-buffer))
-        (setf (ffi-window-prompt-buffer-height window) 0))))
+        (setf (ffi-height prompt-buffer) 0))))
 
 (defun suggestion-and-mark-count (prompt-buffer suggestions marks
                                   &key multi-selection-p pad-p)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1219,6 +1219,13 @@ See `finalize-buffer'."
   (gdk:gdk-rectangle-width
    (gtk:gtk-widget-get-allocation (nyxt/renderer/gtk::gtk-object buffer))))
 
+(define-ffi-method ffi-height ((buffer gtk-window))
+  (gdk:gdk-rectangle-height
+   (gtk:gtk-widget-get-allocation (nyxt/renderer/gtk::gtk-object buffer))))
+(define-ffi-method ffi-width ((buffer gtk-window))
+  (gdk:gdk-rectangle-width
+   (gtk:gtk-widget-get-allocation (nyxt/renderer/gtk::gtk-object buffer))))
+
 (defun process-file-chooser-request (web-view file-chooser-request)
   (declare (ignore web-view))
   (with-protect ("Failed to process file chooser request: ~a" :condition)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1193,7 +1193,7 @@ See `finalize-buffer'."
 
 (define-ffi-method ffi-window-prompt-buffer-height ((window gtk-window))
   (nth-value 1 (gtk:gtk-widget-size-request (prompt-buffer-container window))))
-(define-ffi-method (setf ffi-window-prompt-buffer-height) (height (window gtk-window))
+(define-ffi-method (setf ffi-window-prompt-buffer-height) ((height integer) (window gtk-window))
   (setf (gtk:gtk-widget-size-request (prompt-buffer-container window))
         (list -1 height))
   (if (eql 0 height)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1176,9 +1176,9 @@ See `finalize-buffer'."
   (unless nyxt::*headless-p*
     (gtk:gtk-widget-show (gtk-object buffer))))
 
-(define-ffi-method ffi-window-panel-buffer-width ((window gtk-window) (buffer panel-buffer))
+(define-ffi-method ffi-width ((buffer panel-buffer))
   (nth-value 1 (gtk:gtk-widget-size-request (gtk-object buffer))))
-(define-ffi-method (setf ffi-window-panel-buffer-width) (width (window gtk-window) (buffer panel-buffer))
+(define-ffi-method (setf ffi-width) (width (buffer panel-buffer))
   (setf (gtk:gtk-widget-size-request (gtk-object buffer))
         (list width -1)))
 
@@ -1200,10 +1200,10 @@ See `finalize-buffer'."
       (gtk:gtk-widget-grab-focus (gtk-object (nyxt::active-buffer window)))
       (gtk:gtk-widget-grab-focus (prompt-buffer-view window))))
 
-(define-ffi-method ffi-window-status-buffer-height ((window gtk-window))
-  (nth-value 1 (gtk:gtk-widget-size-request (status-container window))))
-(define-ffi-method (setf ffi-window-status-buffer-height) (height (window gtk-window))
-  (setf (gtk:gtk-widget-size-request (status-container window))
+(define-ffi-method ffi-height ((buffer status-buffer))
+  (nth-value 1 (gtk:gtk-widget-size-request (status-container (window buffer)))))
+(define-ffi-method (setf ffi-height) (height (buffer status-buffer))
+  (setf (gtk:gtk-widget-size-request (status-container (window buffer)))
         (list -1 height)))
 
 (define-ffi-method ffi-window-message-buffer-height ((window gtk-window))
@@ -1212,10 +1212,10 @@ See `finalize-buffer'."
   (setf (gtk:gtk-widget-size-request (message-container window))
         (list -1 height)))
 
-(define-ffi-method ffi-buffer-height ((buffer gtk-buffer))
+(define-ffi-method ffi-height ((buffer gtk-buffer))
   (gdk:gdk-rectangle-height
    (gtk:gtk-widget-get-allocation (nyxt/renderer/gtk::gtk-object buffer))))
-(define-ffi-method ffi-buffer-width ((buffer gtk-buffer))
+(define-ffi-method ffi-width ((buffer gtk-buffer))
   (gdk:gdk-rectangle-width
    (gtk:gtk-widget-get-allocation (nyxt/renderer/gtk::gtk-object buffer))))
 

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1191,14 +1191,17 @@ See `finalize-buffer'."
          (setf (panel-buffers-right window) (remove buffer (panel-buffers-right window)))
          (gtk:gtk-container-remove (panel-buffer-container-right window) (gtk-object buffer)))))
 
-(define-ffi-method ffi-window-prompt-buffer-height ((window gtk-window))
-  (nth-value 1 (gtk:gtk-widget-size-request (prompt-buffer-container window))))
-(define-ffi-method (setf ffi-window-prompt-buffer-height) ((height integer) (window gtk-window))
-  (setf (gtk:gtk-widget-size-request (prompt-buffer-container window))
+(define-ffi-method ffi-height ((buffer prompt-buffer))
+  (nth-value 1 (gtk:gtk-widget-size-request (prompt-buffer-container (window buffer)))))
+(define-ffi-method (setf ffi-height) ((height integer) (buffer prompt-buffer))
+  "Sets the prompt height.
+As a special case, setting height to 0 means hiding prompt buffer and focusing
+the `active-buffer'."
+  (setf (gtk:gtk-widget-size-request (prompt-buffer-container (window buffer)))
         (list -1 height))
   (if (eql 0 height)
-      (gtk:gtk-widget-grab-focus (gtk-object (nyxt::active-buffer window)))
-      (gtk:gtk-widget-grab-focus (prompt-buffer-view window))))
+      (gtk:gtk-widget-grab-focus (gtk-object (nyxt::active-buffer (window buffer))))
+      (gtk:gtk-widget-grab-focus (prompt-buffer-view (window buffer)))))
 
 (define-ffi-method ffi-height ((buffer status-buffer))
   (nth-value 1 (gtk:gtk-widget-size-request (status-container (window buffer)))))

--- a/source/web-extensions-callbacks.lisp
+++ b/source/web-extensions-callbacks.lisp
@@ -34,8 +34,8 @@
                        t nil))
       #+webkit2-mute
       ("audible" . ,(not (ffi-muted-p buffer)))
-      ("height" . ,(ffi-buffer-height buffer))
-      ("width" . ,(ffi-buffer-width buffer))
+      ("height" . ,(ffi-height buffer))
+      ("width" . ,(ffi-width buffer))
       ("highlighted" . ,(eq buffer (nyxt::active-buffer (current-window))))
       ("id" . ,(or (parse-integer (id buffer) :junk-allowed t) 0))
       ("incognito" . ,(nosave-buffer-p buffer))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -77,10 +77,11 @@ the generic functions on `status-buffer'.  Finally set the `window'
         :margin 0)))
    (prompt-buffer-open-height
     ;; Ensures that 10 suggestions are vertically shown, while the last entry
-    ;; appears truncated thus making it clear that more follow.
-    ;; It's also set exactly to a third of the default Nyxt window height
-    ;; (768:256).
-    256
+    ;; appears truncated thus making it clear that more follow. It's also set
+    ;; exactly to a third of Nyxt window height.
+    :unbound
+    :reader nil
+    :writer t
     :documentation "The height of the prompt buffer when open.")
    (input-dispatcher
     'dispatch-input-event
@@ -123,6 +124,12 @@ The handlers take the window as argument."))
     (setf (id window) (new-id))
     (setf (slot-value browser 'last-active-window) window))
   window)
+
+(defmethod prompt-buffer-open-height ((window window))
+  (if (slot-boundp window 'prompt-buffer-open-height)
+      (slot-value window 'prompt-buffer-open-height)
+      (setf (slot-value window 'prompt-buffer-open-height)
+            (round (/ (ffi-height window) 3)))))
 
 (defmethod print-object ((window window) stream)
   (print-unreadable-object (window stream :type t :identity t)

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -231,10 +231,10 @@ When `skip-renderer-resize' is non-nil, don't ask the renderer to fullscreen the
         (ffi-window-maximize window))))
 
 (defun enable-status-buffer (&optional (window (current-window)))
-  (setf (ffi-window-status-buffer-height window) (height (status-buffer window))))
+  (setf (ffi-height (status-buffer window)) (height (status-buffer window))))
 
 (defun disable-status-buffer (&optional (window (current-window)))
-  (setf (ffi-window-status-buffer-height window) 0))
+  (setf (ffi-height (status-buffer window)) 0))
 
 (defun enable-message-buffer (&optional (window (current-window)))
   (setf (ffi-window-message-buffer-height window) (message-buffer-height window)))
@@ -257,7 +257,7 @@ If SHOW-P is provided:
   (cond ((and show-provided-p show-p)
          (enable-status-buffer window))
         ((and (not show-provided-p)
-              (zerop (ffi-window-status-buffer-height window)))
+              (zerop (ffi-height (status-buffer window))))
          (enable-status-buffer window))
         (t (disable-status-buffer window))))
 


### PR DESCRIPTION
# Description

We used to have a disjoint zoo of height&width methods:
- `ffi-window-status-buffer-height`,
- `ffi-buffer-height`,
- `ffi-buffer-width`,
- `ffi-window-panel-buffer-width`,
- `ffi-window-prompt-buffer-height`.

Now we have just two: `ffi-width` and `ffi-height`, which are dispatchabel over most Nyxt widget-related classes (which means `window` and `buffer` with descendants.

# Discussion

What I don't like is that status, message, and panel buffer containters are stored inside the `window`, so adjusting the height of those requires always resorting to `window`. While it's not much problem, it's not exactly of a design, and we're best to move those `gtk-object`s of these special buffers into their own classes and not touch `window` in `ffi-width`/`ffi-height` at all.

As an additional pain point, message buffer doesn't even have a class, which made me:
- Retain `ffi-window-message-buffer-height`,
- And leave `message-buffer-style` with `message-buffer-height` inside `window`. 

Given that we have at least several properties that clearly belong to `message-buffer`, I believe we have to move it into a separate class. This way, we'll have a more unified API for message buffer (`style`, `ffi-height`) and will be able to backport all the niceties regular buffers have, to `message-buffer` too.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.