### PR TITLE
Startup hooks as browser slots

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -576,6 +576,9 @@ auto-mode-rules.lisp)."))
    (:li "Generate methods instead of functions in " (:nxref :function 'define-parenscript)
         " and " (:nxref :function 'define-parenscript-async)
         " to ease hooking into those with, for example, " (:code ":around") " methods.")
+   (:li (:nxref :slot 'after-init-hook :class-name 'browser) " and "
+        (:nxref :slot 'after-startup-hook :class-name 'browser)
+        " are browser slots, instead of global variables they used to be.")
    (:li "Allow the command argument to " (:nxref :function 'ffi-add-context-menu-action)
         " to be an arbitrary function.")
    (:li "New package nicknames:"

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -44,25 +44,6 @@ It can be initialized with
 It's possible to run multiple interfaces of Nyxt at the same time.  You can
 let-bind *browser* to temporarily switch interface.")
 
-(declaim (type hooks:hook-void *after-init-hook*))
-(export-always '*after-init-hook*)
-(defvar *after-init-hook* (make-instance 'hooks:hook-void)
-  "The entry-point object to configure everything in Nyxt.
-The hook takes no argument.
-
-This hook is run after the `*browser*' is instantiated and before the
-`startup' is run.
-
-A handler can be added with:
-
-  (hooks:add-hook *after-init-hook* 'my-foo-function)")
-
-(declaim (type hooks:hook-void *after-startup-hook*))
-(export-always '*after-startup-hook*)
-(defvar *after-startup-hook* (make-instance 'hooks:hook-void)
-  "Hook run when the browser is started and ready for interaction.
-The handlers take no argument.")
-
 (defvar *interactive-p* nil
   "When non-nil, allow prompt buffers during BODY execution.
 This is useful to spot potential blocks when non-interactive code (for instance

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -467,8 +467,8 @@ specify which input and output values are expected.")
                   " that removes the handler right after it's completed.")))
         (:p "Many hooks are executed at different points in Nyxt, among others:")
         (:ul
-         (:li "Global hooks, such as " (:nxref :variable '*after-init-hook*)
-              " or " (:nxref :variable '*after-startup-hook*) ".")
+         (:li "Global hooks, such as " (:nxref :slot 'after-init-hook :class-name 'browser)
+              " or " (:nxref :slot 'after-startup-hook :class-name 'browser) ".")
          (:li "Window- or buffer-related hooks.")
          (:ul
           (:li (:nxref :slot 'window-make-hook :class-name 'window) " for when a new window is created.")
@@ -757,11 +757,11 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
   ((restore-session-on-startup-p nil)))
 
 ;; Load the URL of Nyxt repository by default in all new buffers.
-;; Alternatively, call `buffer-load' in `*after-startup-hook*'.
+;; Alternatively, call `buffer-load' in `after-startup-hook'.
 \(define-configuration browser
   ((default-new-buffer-url (quri:uri \"https://github.com/atlas-engineer/nyxt\"))))
 
-\(hooks:on *after-startup-hook* ()
+\(hooks:on (after-startup-hook *browser*) (browser)
   ;; Once the page's done loading, do your thing.
   (hooks:once-on (buffer-loaded-hook (current-buffer)) (buffer)
     ;; It's sometimes necessary to sleep, as `buffer-loaded-hook' fires when the

--- a/source/migration.lisp
+++ b/source/migration.lisp
@@ -165,4 +165,8 @@ major versions."
 
   (scheme-keymap)
   (:p (:code "scheme-keymap") " is now "
-      (:code "get-keymap") "."))
+      (:code "get-keymap") ".")
+
+  (*after-init-hook* *after-startup-hook*)
+  (:p "Those are " (:nxref :slot 'after-init-hook :class-name 'browser) " and "
+      (:nxref :slot 'after-startup-hook :class-name 'browser) "now."))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -530,7 +530,7 @@ First load `*auto-config-file*' if any.
 Then load `*config-file*' if any.
 Instantiate `*browser*'.
 Finally, run the browser, load URL-STRINGS if any, then run
-`*after-init-hook*'."
+`after-init-hook'."
   (let ((log-path (files:expand *log-file*)))
     (unless (files:nil-pathname-p log-path)
       (uiop:delete-file-if-exists log-path) ; Otherwise `log4cl' appends.
@@ -583,7 +583,7 @@ Finally, run the browser, load URL-STRINGS if any, then run
            (let ((*package* (find-package :cl))) ; Switch package to use non-nicknamed packages.
              (write-to-string
               `(hooks:add-hook
-                nyxt:*after-init-hook*
+                (nyxt:after-init-hook nyxt:*browser*)
                 (make-instance
                  'hooks:handler
                  :fn (lambda ()

--- a/tests/executable/config.lisp
+++ b/tests/executable/config.lisp
@@ -49,7 +49,7 @@
    "--eval"
    (let ((*package* #.*package*))
      (write-to-string
-      `(hooks:once-on nyxt:*after-startup-hook* ()
+      `(hooks:once-on (nyxt:after-startup-hook nyxt:*browser*) (browser)
          (handler-case (progn ,@args)
            (condition (c)
              (log:error "~a" c)

--- a/tests/renderer-offline/execute-command-eval.lisp
+++ b/tests/renderer-offline/execute-command-eval.lisp
@@ -5,7 +5,11 @@
 
 (define-test execute-command-1+ ()
   (let ((channel (nyxt::make-channel 1)))
-    (hooks:once-on nyxt:*after-startup-hook* ()
+    (nyxt:start :no-config t :no-auto-config t
+                :headless t
+                :socket "/tmp/nyxt-test.socket"
+                :profile "test")
+    (hooks:once-on (nyxt:after-startup-hook nyxt:*browser*) (browser)
       (hooks:once-on (nyxt:prompt-buffer-ready-hook nyxt:*browser*)
           (prompt-buffer)
         (prompter:all-ready-p prompt-buffer)
@@ -18,10 +22,6 @@
       (nyxt:run-thread "run execute-command"
         (let ((nyxt::*interactive-p* t))
           (nyxt:execute-command))))
-    (nyxt:start :no-config t :no-auto-config t
-                :headless t
-                :socket "/tmp/nyxt-test.socket"
-                :profile "test")
     (let ((result (calispel:? channel)))
       (assert-eq '1+ (first result))
       (assert-eq 3 (second result))))

--- a/tests/renderer-offline/remembrance.lisp
+++ b/tests/renderer-offline/remembrance.lisp
@@ -36,10 +36,9 @@
 
 (define-test remembrance ()
   (nyxt:start :no-config t :no-auto-config t
-              :headless t
               :socket "/tmp/nyxt-test.socket"
               :profile "test")
-  (wait-on-handler nyxt:*after-startup-hook* ()
+  (wait-on-handler (nyxt:after-startup-hook nyxt:*browser*) (browser)
     (nyxt:enable-modes* 'nyxt/remembrance-mode:remembrance-mode (nyxt:current-buffer)))
   (let ((mode (nyxt:find-submode 'nyxt/remembrance-mode:remembrance-mode)))
     (assert-equality 'uiop:pathname-equal

--- a/tests/renderer-package.lisp
+++ b/tests/renderer-package.lisp
@@ -33,8 +33,12 @@
 
 (defun test-set-url (url)
   (let ((url-channel (nyxt::make-channel 1)))
-    (hooks:once-on nyxt:*after-startup-hook* ()
-      (hooks:once-on (nyxt:prompt-buffer-ready-hook nyxt:*browser*)
+    (nyxt:start :no-config t :no-auto-config t
+                :headless t
+                :socket "/tmp/nyxt-test.socket"
+                :profile "test")
+    (hooks:once-on (nyxt:after-startup-hook *browser*) (browser)
+      (hooks:once-on (nyxt:prompt-buffer-ready-hook browser)
           (prompt-buffer)
         (prompter:all-ready-p prompt-buffer)
         (nyxt:set-prompt-buffer-input url prompt-buffer)
@@ -46,9 +50,5 @@
         ;; TODO: Test if thread returns.
         (let ((nyxt::*interactive-p* t))
           (nyxt:set-url))))
-    (nyxt:start :no-config t :no-auto-config t
-                :headless t
-                :socket "/tmp/nyxt-test.socket"
-                :profile "test")
     (assert-string= url (calispel:? url-channel 5))
     (nyxt:quit)))


### PR DESCRIPTION
# Description

This moves the clunky `*after-(init|startup)-hook*` into `browser` slots.

Fixes #2665.

# Discussion

I don't like that in our testing code we `nyxt:start` and then set the handlers. While it works for now, it's terribly temporarity-dependent and is unlikely to work forever.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [X] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
