### PR TITLE
Keepassxc yubikey support

### DIFF
--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -91,8 +91,7 @@
              :input st)))
 
 (defmethod password-correct-p ((password-interface keepassxc-interface))
-  (when (master-password password-interface)
-    (handler-case
-        (list-passwords password-interface)
-      (uiop/run-program:subprocess-error ()
-        nil))))
+  (handler-case
+      (list-passwords password-interface)
+    (uiop/run-program:subprocess-error ()
+      nil)))

--- a/libraries/password-manager/password-keepassxc.lisp
+++ b/libraries/password-manager/password-keepassxc.lisp
@@ -15,6 +15,9 @@
     ""
     :type string
     :documentation "The password to the `password-file'.")
+   (yubikey-slot
+    nil
+    :documentation "Yubikey slot to unlock the `password-file'.")
    (entries-cache
     nil
     :type list
@@ -33,6 +36,8 @@
                               (append (list "ls" "-Rf") ; Recursive flattened.
                                       (when (key-file password-interface)
                                         (list "-k" (uiop:native-namestring (key-file password-interface))))
+                                      (when (yubikey-slot password-interface)
+                                        (list "-y" (yubikey-slot password-interface)))
                                       (list (password-file password-interface)))
                               :input st :output '(:string :stripped t))))
         (setf (entries-cache password-interface)
@@ -46,6 +51,8 @@
               (list "clip")
               (when (key-file password-interface)
                 (list "-k" (uiop:native-namestring (key-file password-interface))))
+              (when (yubikey-slot password-interface)
+                (list "-y" (yubikey-slot password-interface)))
               (list (password-file password-interface) password-name))
              :input st
              :wait-p nil)))
@@ -57,6 +64,8 @@
              (append (list "clip" "--attribute" "username")
                      (when (key-file password-interface)
                        (list "-k" (uiop:native-namestring (key-file password-interface))))
+                     (when (yubikey-slot password-interface)
+                       (list "-y" (yubikey-slot password-interface)))
                      (list (password-file password-interface) password-name))
              :input st
              :wait-p nil)))
@@ -74,6 +83,8 @@
                            "--password-prompt" (password-file password-interface))
                      (when (key-file password-interface)
                        (list "-k" (uiop:native-namestring (key-file password-interface))))
+                     (when (yubikey-slot password-interface)
+                       (list "-y" (yubikey-slot password-interface)))
                      (list (if (str:emptyp password-name)
                                "--generate"
                                password-name)))

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -44,19 +44,18 @@ If PASSWORD-NAME is empty, then generate a new password."))
     password-interface)
   (:documentation "Return the PASSWORD-INTERFACE with all the misfilled fields corrected."))
 
-(defmacro execute (interface arguments &rest run-program-args &key (wait-p t) &allow-other-keys)
-  "Execute the command matching the INTERFACE, with ARGS.
+(defgeneric execute (interface arguments &rest run-program-args &key wait-p &allow-other-keys)
+  (:method ((interface password-interface) (arguments list) &rest run-program-args &key (wait-p t) &allow-other-keys)
+    (apply (if wait-p #'uiop:run-program #'uiop:launch-program)
+           (append (uiop:ensure-list (executable interface)) arguments)
+           (alexandria:remove-from-plist run-program-args :wait-p)))
+  (:documentation "Execute the command matching the INTERFACE, with ARGS.
 
 `uiop:run-program' is used underneath, with RUN-PROGRAM-ARGS being its
 arguments.
 
 When the WAIT-P is NIL, `uiop:launch-program' is used instead of
-`uiop:run-program'."
-  `(,(if wait-p
-         'uiop:run-program
-         'uiop:launch-program)
-    (append (list (executable ,interface)) ,arguments)
-    ,@(alexandria:remove-from-plist run-program-args :wait-p)))
+`uiop:run-program'."))
 
 (defun safe-clipboard-text ()
   "Return clipboard content, or \"\" if the content is not textual."

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -563,6 +563,7 @@ locally and is cleared after every session.")
    (:li (:code "auto-mode")
         " is now incorporated into Nyxt core, with its settings residing in "
         (:nxref :class-name 'modable-buffer) " now.")
+   (:li "Support for key files and Yubikey locking in KeePassXC password interface.")
    (:ul
     (:li "There are default rules for Gopher, Gemini, and
 Nyxt-internal-pages.")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -582,8 +582,32 @@ any of the password interfaces to configure them. Please make sure to
 use the package prefixed class name/slot designators within
 the " (:code "define-configuration") " macro.")
         (:ul
-         (:li (:nxref :command 'nyxt/password-mode:save-new-password) ": Query for name and new password to persist in the database.")
-         (:li (:nxref :command 'nyxt/password-mode:copy-password) ": " (command-docstring-first-sentence 'nyxt/password-mode:copy-password))))
+         (:li (command-markup 'nyxt/password-mode:save-new-password) ": Query for name and new password to persist in the database.")
+         (:li (command-markup 'nyxt/password-mode:copy-password) ": " (command-docstring-first-sentence 'nyxt/password-mode:copy-password)))
+
+        (:nsection :title "KeePassXC support"
+          (:p "The interface for KeePassXC should cover most use-cases for KeePassXC, as it
+supports password database locking with")
+          (:ul
+           (:li (:nxref :slot 'password:master-password :class-name 'password:keepassxc-interface) ",")
+           (:li (:nxref :slot 'password:key-file :class-name 'password:keepassxc-interface) ",")
+           (:li "and " (:nxref :slot 'password:yubikey-slot :class-name 'password:keepassxc-interface)))
+          (:p "To configure KeePassXC interface, you might need to add something like this
+snippet to your config:")
+          (:ncode
+            ;; FIXME: Why does `define-configuration' not work for password
+            ;; interfaces? Something's fishy with user classes...
+            (defmethod initialize-instance :after ((interface password:keepassxc-interface) &key &allow-other-keys)
+              "It's obviously not recommended to set master password here,
+as your config is likely unencrypted and can reveal your password to someone
+peeking at the screen."
+              (setf (password:password-file interface) "/path/to/your/passwords.kdbx"
+                    (password:key-file interface) "/path/to/your/keyfile"
+                    (password:yubikey-slot interface) "1:1111"))
+            (define-configuration nyxt/password-mode:password-mode
+              ((nyxt/password-mode:password-interface (make-instance 'password:keepassxc-interface))))
+            (define-configuration buffer
+              ((default-modes (append (list 'nyxt/password-mode:password-mode) %slot-value%)))))))
 
       (:nsection :title "Appearance"
         (:p "Much of the visual style can be configured by the user. You can use the

--- a/source/mode/password.lisp
+++ b/source/mode/password.lisp
@@ -114,7 +114,7 @@ for which the `executable' slot is non-nil."
           do (setf (password::password-file password-interface)
                    (uiop:native-namestring
                     (prompt1
-                     :prompt "Password database file"
+                     :prompt "Password database file (.kdbx)"
                      :extra-modes 'nyxt/file-manager-mode:file-manager-mode
                      :sources (make-instance 'nyxt/file-manager-mode:file-source
                                              :extensions '("kdbx")))))
@@ -129,10 +129,11 @@ for which the `executable' slot is non-nil."
         unless (password::yubikey-slot password-interface)
           do (if-confirm ("Do you use Yubikey for password database locking")
                  (setf (password::yubikey-slot password-interface)
-                       (prompt1 :prompt "Yubikey slot"
+                       (prompt1 :prompt "Yubikey slot[:port]"
                                 :sources (make-instance 'prompter:raw-source))))
         do (setf (password::master-password password-interface)
-                 (prompt1 :prompt "Database password (leave empty if none)"
+                 (prompt1 :prompt (format nil "Database password for ~a (leave empty if none)"
+                                          (password::password-file password-interface))
                           :sources 'prompter:raw-source
                           :invisible-input-p t))))
 

--- a/source/mode/password.lisp
+++ b/source/mode/password.lisp
@@ -100,7 +100,7 @@ for which the `executable' slot is non-nil."
                      (string-downcase
                       (class-name (class-of (password-interface buffer))))))))
 
-(defmethod execute :before ((password-interface password:keepassxc-interface) (arguments list) &rest run-program-args &key &allow-other-keys)
+(defmethod password::execute :before ((password-interface password:keepassxc-interface) (arguments list) &rest run-program-args &key &allow-other-keys)
   (declare (ignore arguments run-program-args))
   (when (password::yubikey-slot password-interface)
     (echo "Tap your Yubikey to prove KeePassXC database access")))

--- a/source/mode/password.lisp
+++ b/source/mode/password.lisp
@@ -112,16 +112,20 @@ for which the `executable' slot is non-nil."
                     :extra-modes 'nyxt/file-manager-mode:file-manager-mode
                     :sources (make-instance 'nyxt/file-manager-mode:file-source
                                             :extensions '("kdbx"))))))
-  (unless (password::key-file password-interface)
-    (setf (password::key-file password-interface)
-          (uiop:native-namestring
-           (prompt1
-            :prompt "Password database key file (press escape to choose none)"
-            :extra-modes 'nyxt/file-manager-mode:file-manager-mode
-            :sources (make-instance 'nyxt/file-manager-mode:file-source)))))
+  (if-confirm ("Do you use key file for password database locking?")
+      (setf (password::key-file password-interface)
+            (uiop:native-namestring
+             (prompt1
+              :prompt "Password database key file"
+              :extra-modes 'nyxt/file-manager-mode:file-manager-mode
+              :sources (make-instance 'nyxt/file-manager-mode:file-source)))))
+  (if-confirm ("Do you use Yubikey for password database locking")
+      (setf (password::yubikey-slot password-interface)
+            (prompt1 :prompt "Yubikey slot"
+                     :sources (make-instance 'prompter:raw-source))))
   (loop :until (password:password-correct-p password-interface)
         :do (setf (password::master-password password-interface)
-                  (prompt1 :prompt "Database password"
+                  (prompt1 :prompt "Database password (leave empty if none)"
                            :sources 'prompter:raw-source
                            :invisible-input-p t))))
 


### PR DESCRIPTION
# Description

This adds Yubikey support to our KeePass password interface and makes our interface completion logic a bit more flexible to different invariants of KeePass database locking mechanisms.

Fixes #2111

# Discussion

@Anomalocaridid, does that work for you?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
