### PR TITLE
Add customizable status bar placement

### DIFF
--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -451,7 +451,8 @@ response.  The BODY is wrapped with `with-protect'."
                   prompt-buffer-view
                   status-buffer status-container
                   message-container message-view
-                  key-string-buffer) window
+                  key-string-buffer)
+         window
        (unless gtk-object
          (setf gtk-object (make-instance 'gtk:gtk-window
                                          :type :toplevel
@@ -486,6 +487,9 @@ response.  The BODY is wrapped with `with-protect'."
          ;; receive input, for instance to create a new buffer.
          (setf nyxt::active-buffer (make-instance 'input-buffer))
 
+         (when (eq (status-buffer-position window) :top)
+           (gtk:gtk-box-pack-start root-box-layout status-container :expand nil))
+
          ;; Add the views to the box layout and to the window
          (gtk:gtk-box-pack-start main-buffer-container (gtk-object nyxt::active-buffer) :expand t :fill t)
          (gtk:gtk-box-pack-start horizontal-box-layout panel-buffer-container-left :expand nil)
@@ -499,7 +503,9 @@ response.  The BODY is wrapped with `with-protect'."
          (setf (gtk:gtk-widget-size-request message-container)
                (list -1 (message-buffer-height window)))
 
-         (gtk:gtk-box-pack-end root-box-layout status-container :expand nil)
+         (when (eq (status-buffer-position window) :bottom)
+           (gtk:gtk-box-pack-end root-box-layout status-container :expand nil))
+
          (gtk:gtk-box-pack-start status-container (gtk-object status-buffer) :expand t)
          (setf (gtk:gtk-widget-size-request status-container)
                (list -1 (height status-buffer)))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -63,6 +63,10 @@ The channel is popped when a prompt buffer is hidden.")
 To modify the status buffer appearance and behavior, subclass it and specialize
 the generic functions on `status-buffer'.  Finally set the `window'
 `status-buffer' slot to an instance of this subclass.")
+   (status-buffer-position
+    :bottom
+    :type (member :top :bottom)
+    :documentation "The position where to place the status buffer in the GTK window.")
    (message-buffer-height
     16
     :documentation "The height of the message buffer in pixels.")


### PR DESCRIPTION
# Description

This allows users to choose whether to place the status buffer at the top of the GTK window. I'm of the belief that status bars should be at eye-level for optimal ergonomics. 


# Discussion

Mention there any suspicious parts of the new code, or the ideas that you'd like to discuss in regards to this change.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [-] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
