### PR TITLE
Silent CCL compiler warnings.

### DIFF
--- a/source/mode/repeat.lisp
+++ b/source/mode/repeat.lisp
@@ -42,7 +42,7 @@ It takes a `repeat-mode' instance as argument.")
     #'(lambda (path-url mode)
         (declare (ignore path-url))
         ;; Needed since the mode object might not have been garbage collected.
-        (setf (repeat-action mode) nil
+        (setf (repeat-action mode) (constantly nil)
               (repeat-count mode) nil
               (repeat-interval mode) 1.0))
     :documentation "See `nyxt/process-mode:cleanup'.")))

--- a/source/mode/watch.lisp
+++ b/source/mode/watch.lisp
@@ -34,7 +34,7 @@
 (define-mode watch-mode (nyxt/repeat-mode:repeat-mode)
   "Reload the current buffer every 5 minutes."
   ((rememberable-p t)
-   (nyxt/repeat-mode:repeat-interval 300)
+   (nyxt/repeat-mode:repeat-interval 300.0)
    (nyxt/repeat-mode:repeat-action
     #'(lambda (mode)
         (reload-buffer (buffer mode))))))


### PR DESCRIPTION
# Description

Fixes #2715

# Discussion

The problem was not directly related to testing.

When a slot is set to a value, CCL seems to be very strict and only allows re-setting it to another value of the same type (regardless of what was passed as `:type` for that slot).

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [x] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
