### PR TITLE
Fix the architecture of some modes

### DIFF
--- a/source/mode/certificate-exception.lisp
+++ b/source/mode/certificate-exception.lisp
@@ -19,10 +19,16 @@ See the `add-domain-to-certificate-exceptions' command."
                            :type (list-of string))))
 
 (defmethod enable ((mode certificate-exception-mode) &key)
-  (setf (certificate-exceptions (buffer mode)) (certificate-exceptions mode)))
+  (let ((buffer (buffer mode)))
+    (if (network-buffer-p buffer)
+        (setf (certificate-exceptions buffer) (certificate-exceptions mode))
+        (echo "~a is not a network buffer. Nothing to be done." buffer))))
 
 (defmethod disable ((mode certificate-exception-mode) &key)
-  (setf (certificate-exceptions (buffer mode)) nil))
+  (let ((buffer (buffer mode)))
+    (if (network-buffer-p buffer)
+        (setf (certificate-exceptions buffer) nil)
+        (echo "~a is not a network buffer. Nothing to be done." buffer))))
 
 (define-command add-domain-to-certificate-exceptions (&optional (buffer (current-buffer)))
   "Add the current hostname to the buffer's certificate exception list.

--- a/tests/offline/mode/certificate-exception.lisp
+++ b/tests/offline/mode/certificate-exception.lisp
@@ -4,7 +4,7 @@
 (in-package :nyxt/tests)
 
 (define-test toggle-certificate-exception-mode ()
-  (let ((buffer (make-instance 'network-and-modable-buffer)))
+  (let ((buffer (make-instance 'modable-buffer)))
     (with-current-buffer buffer
       (assert-true (enable-modes* 'nyxt/certificate-exception-mode:certificate-exception-mode
                                   buffer))


### PR DESCRIPTION
# Description

In PR #2685 I made the following observation: instantiating a `modable-buffer` is _not_ always enough to `enable` a mode in it.

This seems odd. If I am a mode, all I should need is a modable-buffer to be enabled. 

When a mode is enabled, it means that it can _potentially_ act the way it was developed. Why only potentially? Because some pre-requisites might not be met. 

And why should we enable a mode when pre-requisites aren't met? If Nyxt was a program where we don't trust our users, it would be a good idea to limit and prevent the user from doing something off the charts.

An alternative to my proposal is: when pre-requisites aren't met, the mode is not allowed to be enabled. But, instead of raising a condition, it should gracefully exit the attempt to enable it.

No strong opinion, but it would be good to have everyone on the same page here. @Ambrevar @aartaka @jmercouris 

Take a look at the changes for a concrete example - `certificate-exception-mode`.





# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [ ] I have pulled from master before submitting this PR
- [ ] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [ ] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
