### PR TITLE
Leverage clss ordered select

### DIFF
--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -424,20 +424,19 @@ ID is a buffer `id'."
 (defun get-headings (&key (buffer (current-buffer)))
   (ps-labels :buffer buffer
     ((heading-scroll-position
-      (element)
+      :buffer buffer (element)
       (ps:chain (nyxt/ps:qs-nyxt-id document (ps:lisp (nyxt/dom:get-nyxt-id element)))
                 (get-bounding-client-rect) y)))
-    (sort (map 'list
-               (lambda (e)
-                 (make-instance 'heading :inner-text (plump:text e)
-                                         :element e
-                                         :buffer buffer
-                                         :keywords (ignore-errors
-                                                    (analysis:extract-keywords
-                                                     (plump:text (plump:next-element e))))
-                                         :scroll-position (heading-scroll-position e)))
-               (clss:select "h1, h2, h3, h4, h5, h6" (document-model buffer)))
-          #'< :key (compose #'parse-integer #'nyxt/dom:get-nyxt-id #'element))))
+    (map 'list
+         (lambda (e)
+           (make-instance 'heading :inner-text (plump:text e)
+                                   :element e
+                                   :buffer buffer
+                                   :keywords (ignore-errors
+                                              (analysis:extract-keywords
+                                               (plump:text (plump:next-element e))))
+                                   :scroll-position (heading-scroll-position e)))
+         (clss:ordered-select "h1, h2, h3, h4, h5, h6" (document-model buffer)))))
 
 (defun current-heading (&optional (buffer (current-buffer)))
   (alex:when-let* ((scroll-position (document-scroll-position buffer))

--- a/source/mode/tts.lisp
+++ b/source/mode/tts.lisp
@@ -34,14 +34,13 @@ Example:
   "Fetch the text in buffer that matches `selector` and send it off to the TTS."
   (if (executable mode)
       (let* ((tags
-               (sort (handler-case
-                         (coerce
-                          (clss:select (selector mode) (document-model (buffer mode)))
-                          'list)
-                       (error ()
-                         (log:warn "tts-mode: no document-model available.")
-                         nil))
-                     #'< :key (compose #'parse-integer #'nyxt/dom:get-nyxt-id)))
+               (handler-case
+                   (coerce
+                    (clss:ordered-select (selector mode) (document-model (buffer mode)))
+                    'list)
+                 (error ()
+                   (log:warn "tts-mode: no document-model available.")
+                   nil)))
              ;; TODO properly handle punctuation like Emacspeak does
              (text (str:remove-punctuation
                     (with-output-to-string (s)


### PR DESCRIPTION
# Description

I've extracted these changes from #2529 since they're not directly related to `search-buffer`.


# Discussion

@aartaka, all of these change were done by you, if you still remember! Can we merge it?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [x] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
