### PR TITLE
Fix config and socket on startup

### DIFF
--- a/source/configuration-commands.lisp
+++ b/source/configuration-commands.lisp
@@ -48,7 +48,12 @@ On error, return the condition as a first value and the backtrace as second valu
                   (log:debug "Lisp file ~s does not exist." file)))
                nil))
         (if *run-from-repl-p*
-            (unsafe-load)
+            (tagbody
+             loop
+               (restart-case (unsafe-load)
+                 (load-lisp-retry ()
+                   :report "Retry loading Lisp file."
+                   (go loop))))
             (catch 'lisp-file-error
               (handler-bind ((error (lambda (c)
                                       (let ((backtrace (with-output-to-string (stream)


### PR DESCRIPTION
# Description

Does 2 things:

- Add a `load-lisp-retry` restart to `load-lisp` on error.  This is only available from the REPL and can be useful to correct the config file without restarting the whole browser.
- Only create the socket and the listening thread after loading the config file.  This way if there is an error during config load, there won't be a dangling socket / thread left behind.

Fixes #2507.

# Discussion

Mention there any suspicious parts of the new code, or the ideas that you'd like to discuss in regards to this change.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
