### PR TITLE
Enable vi-insert whenever we see an input field.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1058,6 +1058,11 @@ BUFFER's modes."
   (dolist (mode (modes buffer))
     (on-signal-button-press mode button-key)))
 
+(export-always 'on-signal-key-press)
+(defmethod on-signal-key-press ((buffer buffer) key)
+  (dolist (mode (modes buffer))
+    (on-signal-key-press mode key)))
+
 (hooks:define-hook-type buffer (function (buffer)))
 
 (define-command make-buffer (&rest args &key (title "") modes

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -681,6 +681,7 @@ regular commands, such as "
 
   (:h3 "Bug fixes")
   (:ul
+   (:li "VI insert mode is triggered in more cases where it should be triggered.")
    (:li "Invoke the right WebKit command when cutting text with " (:nxref :function 'ffi-buffer-cut))
    (:li "Fix the display of history suggestions when going forward in history.")
    (:li "Security: all the non-ASCII domain names are shown as IDN punycodes in addition

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -578,6 +578,10 @@ If there is no corresponding keymap, return nil."
   (declare (ignorable button-key))
   nil)
 
+(defmethod on-signal-key-press ((mode mode) key)
+  (declare (ignorable key))
+  nil)
+
 (defmethod url-sources ((mode mode) actions-on-return)
   (declare (ignore actions-on-return))
   nil)

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -94,9 +94,12 @@ See also `vi-normal-mode' and `vi-insert-mode'."
       (enable-modes* 'nyxt/passthrough-mode:passthrough-mode buffer))))
 
 (defun vi-insert-on-input-fields (buffer)
-  (when (nyxt/document-mode:input-tag-p
-         (ps-eval :buffer buffer (ps:@ document active-element tag-name)))
-    (enable-modes* 'vi-insert-mode buffer)))
+  (if (ps-eval :buffer buffer
+        (if (and (ps:@ document active-element)
+                 (nyxt/ps:element-editable-p (ps:@ document active-element)))
+            ps:t ps:false))
+      (enable-modes* 'vi-insert-mode buffer)
+      (enable-modes* 'vi-normal-mode buffer)))
 
 (defmethod on-signal-load-finished ((mode vi-insert-mode) url)
   (declare (ignore url))
@@ -104,6 +107,10 @@ See also `vi-normal-mode' and `vi-insert-mode'."
   (vi-insert-on-input-fields (buffer mode)))
 
 (defmethod on-signal-button-press ((mode vi-normal-mode) button-key)
+  (when (string= "button1" (keymaps:key-value button-key))
+    (vi-insert-on-input-fields (buffer mode))))
+
+(defmethod on-signal-button-press ((mode vi-insert-mode) button-key)
   (when (string= "button1" (keymaps:key-value button-key))
     (vi-insert-on-input-fields (buffer mode))))
 

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -118,8 +118,8 @@ See also `vi-normal-mode' and `vi-insert-mode'."
   (when (equal "tab" (keymaps:key-value key))
     (vi-insert-on-input-fields (buffer mode))))
 
-(defmethod nyxt/document-mode:element-focused ((mode vi-normal-mode))
-  (enable-modes* 'vi-insert-mode (buffer mode)))
+(defmethod nyxt/dom:focus-select-element :after ((element plump:element))
+  (vi-insert-on-input-fields (current-buffer)))
 
 (defmethod nyxt:mode-status ((status status-buffer) (vi-normal vi-normal-mode))
   (spinneret:with-html-string

--- a/source/mode/vi.lisp
+++ b/source/mode/vi.lisp
@@ -93,16 +93,23 @@ See also `vi-normal-mode' and `vi-insert-mode'."
     (when (passthrough-mode-p mode)
       (enable-modes* 'nyxt/passthrough-mode:passthrough-mode buffer))))
 
+(defun vi-insert-on-input-fields (buffer)
+  (when (nyxt/document-mode:input-tag-p
+         (ps-eval :buffer buffer (ps:@ document active-element tag-name)))
+    (enable-modes* 'vi-insert-mode buffer)))
+
 (defmethod on-signal-load-finished ((mode vi-insert-mode) url)
   (declare (ignore url))
-  (enable-modes* 'vi-normal-mode (buffer mode)))
+  (enable-modes* 'vi-normal-mode (buffer mode))
+  (vi-insert-on-input-fields (buffer mode)))
 
 (defmethod on-signal-button-press ((mode vi-normal-mode) button-key)
-  (let ((buffer (buffer mode)))
-    (when (and (string= "button1" (keymaps:key-value button-key))
-               (nyxt/document-mode:input-tag-p
-                (ps-eval :buffer buffer (ps:@ document active-element tag-name))))
-      (enable-modes* 'vi-insert-mode buffer))))
+  (when (string= "button1" (keymaps:key-value button-key))
+    (vi-insert-on-input-fields (buffer mode))))
+
+(defmethod on-signal-key-press ((mode vi-normal-mode) (key keymaps:key))
+  (when (equal "tab" (keymaps:key-value key))
+    (vi-insert-on-input-fields (buffer mode))))
 
 (defmethod nyxt/document-mode:element-focused ((mode vi-normal-mode))
   (enable-modes* 'vi-insert-mode (buffer mode)))

--- a/source/parenscript-macro.lisp
+++ b/source/parenscript-macro.lisp
@@ -100,10 +100,14 @@
 (defpsmacro element-editable-p (element)
   "Whether ELEMENT is editable."
   `(let ((tag (chain ,element tag-name)))
-     (if (or (string= tag "INPUT")
+     (if (or (and (string= tag "INPUT")
+                  ;; The list of all input types:
+                  ;; https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+                  (not (chain ([] "hidden" "checkbox" "button") (includes (chain ,element type))))
+                  (not (chain ,element disabled)))
              (string= tag "TEXTAREA")
              (chain ,element is-content-editable))
-         t nil)))
+         t f)))
 
 (export-always 'element-drawable-p)
 (defpsmacro element-drawable-p (element)
@@ -111,7 +115,7 @@
   `(if (or (chain ,element offset-width)
            (chain ,element offset-height)
            (chain ,element (get-client-rects) length))
-       t nil))
+       t f))
 
 (export-always 'element-in-view-port-p)
 (defpsmacro element-in-view-port-p (element)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -729,12 +729,15 @@ See `gtk-browser's `modifier-translator' slot."
     (when (nyxt::prompt-buffer-p buffer)
       (update-prompt buffer))
     (if key-string
-        (progn
+        (flet ((key ()
+                 (keymaps:make-key :code keycode
+                                   :value key-string
+                                   :modifiers modifiers
+                                   :status :pressed)))
           (alex:appendf (key-stack sender)
-                        (list (keymaps:make-key :code keycode
-                                                :value key-string
-                                                :modifiers modifiers
-                                                :status :pressed)))
+                        (list (key)))
+          (run-thread "on-signal-key-press"
+            (on-signal-key-press buffer (key)))
           (funcall (input-dispatcher sender) event
                    buffer
                    sender printable-value))


### PR DESCRIPTION
# Description

This is a catch-all fix to VI insert mode not being enabled in some input field cases, like using Tab to focus it or invoking a non-hint command. `on-signal-key-press` (now a generic function in buffer.lisp) should be reliable (though possibly a bit wasteful) enough for that.

@fictitiousexistence, @r3k2, can you check?

# Discussion

Going through all the modes of all the buffers on every keypress feels like a lot of CPU cycles wasted, doesn't it? CC @Ambrevar, @aadcg

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
