### PR TITLE
libraries/class-star: Infer type from parent slot if any.

### DIFF
--- a/libraries/class-star/class-star.lisp
+++ b/libraries/class-star/class-star.lisp
@@ -159,7 +159,8 @@ The predicate returns non-nil when the argument is of the `name' class.")
 (defun inherited-slot-type (slot-name superclasses)
   (let ((parent (find slot-name superclasses
                       :test (lambda (slot class)
-                              (find slot (mopu:slot-names class))))))
+                              ;; REVIEW: We ignore unfinalized classes, is it wise?
+                              (find slot (ignore-errors (mopu:slot-names class)))))))
     (when parent
       (values
        (getf (mopu:slot-properties parent slot-name)

--- a/libraries/class-star/tests/tests.lisp
+++ b/libraries/class-star/tests/tests.lisp
@@ -97,3 +97,27 @@
              (getf (mopu:slot-properties 'foo-type-infer 'fun) :type))
   (assert-eq nil
              (getf (mopu:slot-properties 'foo-type-infer 'composite) :type)))
+
+(define-test inherited-type-inference ()
+  (class-star:define-class parent ()
+    ((name "foo")
+     (age nil
+          :type (or null number))))
+  (class-star:define-class child (parent)
+    ((name nil
+           :type (or null string))
+     (age 17)))
+  (let ((p (make-instance 'parent))
+        (c (make-instance 'child)))
+    ;; Perform some  assignments: CCL can catch type errors here.
+    (setf (slot-value p 'age) 18)
+    (setf (slot-value c 'name) "bar")
+    (setf (slot-value c 'age) nil)
+    (assert-eq 'string
+               (getf (mopu:slot-properties 'parent 'name) :type))
+    (assert-equal '(or null number)
+                  (getf (mopu:slot-properties 'parent 'age) :type))
+    (assert-equal '(or null string)
+                  (getf (mopu:slot-properties 'child 'name) :type))
+    (assert-equal '(or null number)
+                  (getf (mopu:slot-properties 'child 'age) :type))))

--- a/source/mode/watch.lisp
+++ b/source/mode/watch.lisp
@@ -37,8 +37,7 @@
    (nyxt/repeat-mode:repeat-interval 300.0)
    (nyxt/repeat-mode:repeat-action
     #'(lambda (mode)
-        (reload-buffer (buffer mode)))
-    :type (maybe (function (nyxt/repeat-mode:repeat-mode))))))
+        (reload-buffer (buffer mode))))))
 
 (define-command-global watch-buffer (&optional (buffer (current-buffer)))
   "Reload BUFFER at a prompted interval."


### PR DESCRIPTION
# Description

This changes class-star to infer type from inherited slot, if any.

Fixes #2715 and supersedes #2716.

# Discussion

This may not do the right thing if the parent class is not finalized.  For now I opted to just ignore unfinalized classes.

Any idea if we can do better about this? @aadcg @aartaka 

# To do:

- [x] Merge #2765 first.
- [x] Protect against unfinalized classes.  Problem can be seen when loading `prompter`.
- [ ] Ensure bug from #2715 is fixed.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
