### PR TITLE
Fix compilation error reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,14 +67,15 @@ jobs:
     - name: Fetch Common Lisp third-party dependencies
       shell: bash
       run: |
-        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)'
+        ros ${{ matrix.rosargs }}  -e '(handler-bind ((error (lambda (a) (uiop:print-backtrace) (format *error-output* "Error: ~a~&" a) (uiop:quit 17)))) (asdf:load-system :nyxt/submodules))'
         mkdir -p ~/.config/common-lisp/source-registry.conf.d/
         echo "(:tree \"$PWD/_build/submodules\")" > ~/.config/common-lisp/source-registry.conf.d/asdf.conf
 
     - name: Load Nyxt
       shell: bash
       run: |
-        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)' -e '(handler-case (asdf:load-system :nyxt/${{matrix.renderer}}-application) (error (a) (format t "caught error ~s~%~a~%" a a) (uiop:quit 17)))'
+        # TODO: Can we make CCL backtraces more readable?  With trivial-backtrace maybe?
+        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)' -e '(handler-bind ((error (lambda (a) (uiop:print-condition-backtrace a) (format *error-output* "Error: ~a~&" a) (uiop:quit 17)))) (asdf:load-system :nyxt/${{matrix.renderer}}-application))'
 
     - name: Build Nyxt executable
       shell: bash
@@ -90,14 +91,14 @@ jobs:
       env:
        NASDF_TESTS_QUIT_ON_FAIL: yes
       run: |
-        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)' -e '(handler-case (asdf:load-system :nyxt/tests) (error (a) (format t "caught error ~s~%~a~%" a a) (uiop:quit 17)))' -e '(asdf:test-system :nyxt)'
+        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)' -e '(handler-bind ((error (lambda (a) (uiop:print-backtrace) (format *error-output* "~a~&" a) (uiop:quit 17)))) (asdf:load-system :nyxt/tests))' -e '(asdf:test-system :nyxt)'
 
     - name: Validate make-instance symbols
       shell: bash
       run: |
-        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)'  -e '(asdf:load-system :nyxt)' -e '(push :nyxt-debug-make-instance *features*)' -e '(handler-case (asdf:load-system :nyxt :force t) (error (a) (format t "caught error ~s~%~a~%" a a) (uiop:quit 17)))'
+        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)'  -e '(asdf:load-system :nyxt)' -e '(push :nyxt-debug-make-instance *features*)' -e '(handler-bind ((error (lambda (a) (uiop:print-backtrace) (format *error-output* "~a~&" a) (uiop:quit 17)))) (asdf:load-system :nyxt :force t))'
 
     - name: Keymap type checking
       shell: bash
       run: |
-        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)'  -e '(asdf:load-system :nyxt)' -e '(push :nyxt-debug-keymap *features*)' -e '(handler-case (asdf:load-system :nyxt :force t) (error (a) (format t "caught error ~s~%~a~%" a a) (uiop:quit 17)))'
+        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)'  -e '(asdf:load-system :nyxt)' -e '(push :nyxt-debug-keymap *features*)' -e '(handler-bind ((error (lambda (a) (uiop:print-backtrace) (format *error-output* "~a~&" a) (uiop:quit 17)))) (asdf:load-system :nyxt :force t))'

--- a/libraries/nasdf/log.lisp
+++ b/libraries/nasdf/log.lisp
@@ -9,7 +9,7 @@
 (defvar *log-prefix* "; ")
 
 (defun logger (control-string &rest format-arguments)
-  "Like `format' but assumes `*error-output*' as a stream."
+  "Like `format' but assumes `*error-output*' as a stream and ensures fresh lines."
   (let ((*standard-output* *error-output*))
     (fresh-line )
     (princ *log-prefix*)

--- a/libraries/nasdf/nasdf.asd
+++ b/libraries/nasdf/nasdf.asd
@@ -2,7 +2,7 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (defsystem "nasdf"
-  :version "0.0.0"
+  :version "0.1.1"
   :author "Atlas Engineer LLC"
   :homepage "https://github.com/atlas-engineer/ntemplate"
   :description "ASDF helpers for system setup, testing and installation."

--- a/libraries/nasdf/nasdf.lisp
+++ b/libraries/nasdf/nasdf.lisp
@@ -11,6 +11,7 @@
 (defun env-true-p (env-variable)
   (let ((value (uiop:getenv env-variable)))
     (or (string-equal "true" value)
+        (string-equal "yes" value)
         (string-equal "on" value)
         (string-equal "1" value))))
 

--- a/libraries/nasdf/readme.org
+++ b/libraries/nasdf/readme.org
@@ -44,3 +44,10 @@ mean; for instance both =on= and =true= are valid values to enable the feature.
 ** History
 
 NASDF was originally developed for [[https://nyxt.atlas.engineer][Nyxt]].
+
+** Change log
+
+*** 0.1.1
+
+- Fix compilation-tests.
+- Fix =env-true-p= to accept =yes= as =T=.

--- a/libraries/nasdf/tests.lisp
+++ b/libraries/nasdf/tests.lisp
@@ -27,6 +27,30 @@ If the NASDF_TESTS_NO_NETWORK environment variable is set, tests with the `:onli
   `((asdf:load-op "lisp-unit2")
     ,@(call-next-method)))
 
+(defmethod asdf:perform :around ((op asdf:test-op) (c nasdf-test-system))
+  (let ((*debugger-hook* (if (env-true-p "NASDF_TESTS_QUIT_ON_FAIL")
+                             nil        ; We are non-interactive.
+                             *debugger-hook*)))
+    (handler-bind ((error (lambda (c)
+                            (logger "Errors:~&~a" c)
+                            (when (env-true-p "NASDF_TESTS_QUIT_ON_FAIL")
+                              ;; Arbitrary but hopefully recognizable exit code.
+                              (quit 18)))))
+      (call-next-method))))
+
+;; TODO: Can we avoid duplicating this `test-op' / `load-op' setup?
+(defmethod asdf:perform :around ((op asdf:load-op) (c nasdf-test-system))
+  (logger "NASDF_TESTS_QUIT_ON_FAIL=~a~&" (getenv "NASDF_TESTS_QUIT_ON_FAIL"))
+  (let ((*debugger-hook* (if (env-true-p "NASDF_TESTS_QUIT_ON_FAIL")
+                             nil        ; We are non-interactive.
+                             *debugger-hook*)))
+    (handler-bind ((error (lambda (c)
+                            (logger "Errors:~&~a" c)
+                            (when (env-true-p "NASDF_TESTS_QUIT_ON_FAIL")
+                              ;; Arbitrary but hopefully recognizable exit code.
+                              (quit 18)))))
+      (call-next-method))))
+
 (defmethod asdf:perform ((op asdf:test-op) (c nasdf-test-system))
   (destructuring-bind (&key package tags exclude-tags &allow-other-keys)
       (targets c)
@@ -36,22 +60,19 @@ If the NASDF_TESTS_NO_NETWORK environment variable is set, tests with the `:onli
       (let ((missing-packages (remove-if  #'find-package (uiop:ensure-list package))))
         (when missing-packages
           (logger "Undefined test packages: ~s" missing-packages)))
-      (let ((*debugger-hook* (if (env-true-p "NASDF_TESTS_QUIT_ON_FAIL")
-                                 nil    ; We are non-interactive.
-                                 *debugger-hook*)))
-        (let ((test-results
-                (uiop:symbol-call :lisp-unit2 :run-tests
-                                  :package package
-                                  :tags tags
-                                  :exclude-tags exclude-tags
-                                  :run-contexts (find-symbol "WITH-SUMMARY-CONTEXT" :lisp-unit2))))
-          (when (and
-                 (or
-                  (uiop:symbol-call :lisp-unit2 :failed test-results)
-                  (uiop:symbol-call :lisp-unit2 :errors test-results))
-                 (getenv "NASDF_TESTS_QUIT_ON_FAIL"))
-            ;; Arbitrary but hopefully recognizable exit code.
-            (quit 18)))))))
+      (let ((test-results
+              (uiop:symbol-call :lisp-unit2 :run-tests
+                                :package package
+                                :tags tags
+                                :exclude-tags exclude-tags
+                                :run-contexts (find-symbol "WITH-SUMMARY-CONTEXT" :lisp-unit2))))
+        (when (and
+               (or
+                (uiop:symbol-call :lisp-unit2 :failed test-results)
+                (uiop:symbol-call :lisp-unit2 :errors test-results))
+               ;; TODO: Always raise error or not?
+               (getenv "NASDF_TESTS_QUIT_ON_FAIL"))
+          (error "Tests failed."))))))
 
 (export-always 'print-benchmark)
 (defun print-benchmark (benchmark-results)

--- a/libraries/nasdf/tests.lisp
+++ b/libraries/nasdf/tests.lisp
@@ -116,5 +116,5 @@ If the NASDF_TESTS_NO_NETWORK environment variable is set, tests with the `:onli
                             (unless (or (redefinition-p c)
                                         #+ccl
                                         (osicat-warning-p c))
-                              (error c) ))))
+                              (cerror "Continue" "Compilation warning: ~a" c)))))
     (funcall thunk)))

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -462,7 +462,7 @@ The ARGS are used as a keyword arglist for the function bound to the defined URL
   `(fetch (ps:lisp (str:concat
                     (lisp-url :id ,id :buffer ,buffer :title ,title)
                     (quri:url-encode-params
-                     (list ,@(loop for (name value . rest) on args by #'cddr
+                     (list ,@(loop for (name value) on args by #'cddr
                                    collect `(cons (symbol->param-name ,name)
                                                   (value->param-value ,value))))
                      :space-to-plus t)))


### PR DESCRIPTION
# Description

Since the switch to NASDF, compilation error would not be reported as shown by https://github.com/atlas-engineer/nyxt/actions/runs/4073163720/jobs/7016756278

This was because we would forward a condition of type `warning` and the CI would only catch `errors`.

This also fixes a compilation bug in `nyxt/ps::lisp-call`.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [ ] I have pulled from master before submitting this PR
- [ ] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [ ] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
