### PR TITLE
Destroy hanged buffers properly

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -692,4 +692,5 @@ regular commands, such as "
    (:li "Fix the display of history suggestions when going forward in history.")
    (:li "Security: all the non-ASCII domain names are shown as IDN punycodes in addition
 to aesthetic display in status buffer.")
-   (:li "The canceled page requests are stored to history, making it more consistent.")))
+   (:li "The canceled page requests are stored to history, making it more consistent.")
+   (:li "Trying to delete a hanged buffer destroys it, instead of leaving it dangling forever.")))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1467,6 +1467,15 @@ the `active-buffer'."
       (echo "[~a] ~a: ~a" (webkit:webkit-web-view-uri web-view) title body)
       t)))
 
+(defun buffer-destroy (buffer)
+  (mapc (lambda (handler-id)
+          (gobject:g-signal-handler-disconnect (gtk-object buffer) handler-id))
+        (handler-ids buffer))
+  (nyxt/web-extensions::tabs-on-removed buffer)
+  (nyxt::buffer-hide buffer)
+  (gtk:gtk-widget-destroy (gtk-object buffer))
+  (setf (gtk-object buffer) nil))
+
 (define-ffi-method ffi-buffer-make ((buffer gtk-buffer))
   "Initialize BUFFER's GTK web view."
   (unless (gtk-object buffer) ; Buffer may already have a view, e.g. the prompt-buffer.
@@ -1555,13 +1564,8 @@ the `active-buffer'."
      (cffi:foreign-enum-value 'webkit:webkit-web-process-termination-reason reason))
     (buffer-delete buffer))
   (connect-signal buffer "close" nil (web-view)
-    (mapc (lambda (handler-id)
-            (gobject:g-signal-handler-disconnect web-view handler-id))
-          (handler-ids buffer))
-    (nyxt/web-extensions::tabs-on-removed buffer)
-    (nyxt::buffer-hide buffer)
-    (gtk:gtk-widget-destroy web-view)
-    (setf (gtk-object buffer) nil))
+    (declare (ignore web-view))
+    (buffer-destroy buffer))
   (connect-signal buffer "load-failed" nil (web-view load-event failing-url error)
     (declare (ignore load-event web-view))
     ;; TODO: WebKitGTK sometimes (when?) triggers "load-failed" when loading a
@@ -1686,12 +1690,12 @@ the `active-buffer'."
   buffer)
 
 (define-ffi-method ffi-buffer-delete ((buffer gtk-buffer))
-  ;; FIXME: Check is-web-process-responsive property, and simply close the
-  ;; buffer if unresponsive. Otherwise the whole browser is unable to delete any
-  ;; buffer after the hanged one.
-  (if (slot-value buffer 'gtk-object) ; Not all buffers have their own web view, e.g. prompt buffers.
-      (webkit:webkit-web-view-try-close (gtk-object buffer))
-      (nyxt::buffer-hide buffer)))
+  (cond
+   ((not (slot-value buffer 'gtk-object))
+    (nyxt::buffer-hide buffer))
+   ((webkit:webkit-web-view-is-web-process-responsive (gtk-object buffer))
+    (webkit:webkit-web-view-try-close (gtk-object buffer)))
+   (t (buffer-destroy buffer))))
 
 (define-ffi-method ffi-buffer-load ((buffer gtk-buffer) url)
   "Load URL in BUFFER.


### PR DESCRIPTION
# Description

It's often the case that some buffers (web-views) become unresponsive all of a sudden. Trying to kill those with `webkit:webkit-web-view-try-close` yields no result and makes Nyxt slightly less usable, with undeleted buffer still hanging around.

This patch checks whether the web view is responsive before trying to close it. If the view is responsive, do `...try-close` on it. If not, simply destroy it without mercy.

# Discussion

I'm waiting on Guix merging cl-webkit update and merging this. Not much discussion required for this PR, I believe.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
