### PR TITLE
Add toggle prompt buffer focus command

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1350,6 +1350,17 @@ second latest buffer first."
                              :constructor (sera:filter (match-domain domain)
                                                        (sort-by-time (buffer-list)))))))
 
+(define-command toggle-prompt-buffer-focus ()
+  "Toggle the focus between the current buffer and the current prompt buffer."
+  (let ((prompt-buffer (current-prompt-buffer)))
+    (if (prompt-buffer-p (focused-buffer))
+        (progn (set-current-buffer (current-buffer))
+               (ps-eval :buffer prompt-buffer
+                 (setf (ps:@ (nyxt/ps:qs document "*") style opacity) "0.5")))
+        (progn (ffi-focus-prompt-buffer (current-window) prompt-buffer)
+               (ps-eval :buffer prompt-buffer
+                 (setf (ps:@ (nyxt/ps:qs document "*") style opacity) "1"))))))
+
 (defun switch-buffer-or-query-domain (domain)
   "Switch to a buffer if it exists for a given DOMAIN, otherwise query
   the user."

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -694,3 +694,8 @@ regular commands, such as "
 to aesthetic display in status buffer.")
    (:li "The canceled page requests are stored to history, making it more consistent.")
    (:li "Trying to delete a hanged buffer destroys it, instead of leaving it dangling forever.")))
+
+(define-version "3-pre-release-4"
+  (:h3 "Bindings")
+  (:ul
+   (:li "Add " (:nxref :command 'nyxt:toggle-prompt-buffer-focus) ".")))

--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -80,6 +80,9 @@ The specialized method may call `call-next-method' to return a sensible fallback
   (:documentation "Set the BUFFER's widget to display in WINDOW.
 If FOCUS is non-nil, "))
 
+(define-ffi-generic ffi-focus-prompt-buffer (window prompt-buffer)
+  (:documentation "Focus PROMPT-BUFFER in WINDOW."))
+
 (define-ffi-generic ffi-window-add-panel-buffer (window buffer side)
   (:documentation "Make widget for panel BUFFER and add it to the WINDOW widget.
 SIDE is one of `:left' or `:right'."))

--- a/source/mode/base.lisp
+++ b/source/mode/base.lisp
@@ -21,6 +21,7 @@ This mode is a good candidate to be passed to `make-buffer'."
        "C-tab" 'switch-buffer-next
        "C-T" 'reopen-buffer
        "C-t" 'make-buffer-focus
+       "M-o" 'toggle-prompt-buffer-focus
        "f1 r" 'manual
        "f1 t" 'tutorial
        "f1 b" 'describe-bindings
@@ -63,6 +64,7 @@ This mode is a good candidate to be passed to `make-buffer'."
        "C-x C-left" 'switch-buffer-previous
        "C-x right" 'switch-buffer-next
        "C-x C-right" 'switch-buffer-next
+       "C-x o" 'toggle-prompt-buffer-focus
        "C-x b" 'switch-buffer
        "C-x k" 'delete-buffer
        "C-x C-k" 'delete-current-buffer

--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -32,6 +32,7 @@ listed and chosen from with the command `set-action-on-return' (bound to
        "end" 'last-suggestion
        "pagehome" 'first-suggestion
        "pageend" 'last-suggestion
+       "M-o" 'toggle-prompt-buffer-focus
        "escape" 'quit-prompt-buffer
        "M-a" 'mark-all
        "M-u" 'unmark-all
@@ -69,6 +70,7 @@ listed and chosen from with the command `set-action-on-return' (bound to
        "C-n" 'next-suggestion
        "M-<" 'first-suggestion
        "M->" 'last-suggestion
+       "C-x o" 'toggle-prompt-buffer-focus
        "M-v" 'previous-page
        "C-v" 'next-page
        "M-p" 'previous-source

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1213,6 +1213,12 @@ the `active-buffer'."
       (gtk:gtk-widget-grab-focus (gtk-object (nyxt::active-buffer (window buffer))))
       (gtk:gtk-widget-grab-focus (prompt-buffer-view (window buffer)))))
 
+(define-ffi-method ffi-focus-prompt-buffer ((window gtk-window)
+                                            (prompt-buffer prompt-buffer))
+  "Focus PROMPT-BUFFER in WINDOW."
+  (gtk:gtk-widget-grab-focus (prompt-buffer-view (window prompt-buffer)))
+  prompt-buffer)
+
 (define-ffi-method ffi-height ((buffer status-buffer))
   (nth-value 1 (gtk:gtk-widget-size-request (status-container (window buffer)))))
 (define-ffi-method (setf ffi-height) (height (buffer status-buffer))


### PR DESCRIPTION
# Description

Add command that toggles the focus between the prompt buffer and the buffer behind it.

Developed in the context of PR #2772.

Fixes #1203

# Discussion

Please let me know if it looks sane, since I'm not an expert in how we handle ffi methods.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [x] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
