### PR TITLE
GTK: Properly disable storage of data-manager files in nosave-profile.

### DIFF
--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -289,8 +289,9 @@ the renderer thread, use `defmethod' instead."
   (:accessor-name-transformer (class*:make-name-transformer name)))
 
 (defmethod files:resolve :around ((profile nosave-profile) (file data-manager-file))
-  "We shouldn't store any `data-manager' data for `nosave-profile'."
-  #p"")
+  "We shouldn't store any `data-manager' data for `nosave-profile'.
+WebKit should be given a null value and not an empty string in this case."
+  nil)
 
 (define-class data-manager-data-directory (files:data-file data-manager-file)
   ()


### PR DESCRIPTION
# Description

Recipe:

- `(nyxt:start :failsafe t)`
- Notice that extra directories are created the current directory:
  - `WebKitCache`
  - `CacheStorage`
  - `localstorage` (sometimes)

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
