### PR TITLE
start: Restart with --failsafe instead of --no-config.

### DIFF
--- a/source/start.lisp
+++ b/source/start.lisp
@@ -639,12 +639,12 @@ Finally, run the browser, load URL-STRINGS if any, then run
                                (nyxt::error-in-new-window "Initialization error" ,(princ-to-string condition) ,backtrace))))
                  :name 'error-reporter))))))
     (let* ((new-command-line (append (uiop:raw-command-line-arguments)
-                                     `("--no-config"
+                                     `("--failsafe"
                                        "--eval"
                                        ,(set-error-message condition backtrace)))))
       (log:warn "Restarting with ~s."
                 (append (uiop:raw-command-line-arguments)
-                        '("--no-config")))
+                        '("--failsafe")))
       (uiop:launch-program new-command-line)
       (quit 1))))
 


### PR DESCRIPTION
# Description

Fixes #2778.

# Discussion

@franburstall Can you confirm it works as expected on your end?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
