### PR TITLE
Status buffer restyle

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -769,7 +769,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :overflow "hidden"
               :white-space "nowrap"
               :z-index "3"
-              :flex-basis "8em")
+              :flex-basis "104px")
             `("#url"
               :background-color ,theme:primary
               :color ,theme:on-primary
@@ -782,7 +782,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :z-index "2"
               :flex-grow "3"
               :flex-shrink "2"
-              :flex-basis "10em")
+              :flex-basis "144px")
             `("#tabs"
               :background-color ,theme:secondary
               :color ,theme:on-secondary
@@ -795,7 +795,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :z-index "1"
               :flex-grow "10"
               :flex-shrink "4"
-              :flex-basis "10em")
+              :flex-basis "144px")
             `("#tabs::-webkit-scrollbar"
               :display "none")
             `(.tab

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -805,7 +805,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :padding-left "5px"
               :padding-right "5px")
             `(".tab:hover"
-              :opacity 0.8)
+              :opacity 0.6)
             `("#modes"
               :background-color ,theme:primary
               :color ,theme:on-primary
@@ -830,7 +830,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :background-color ,theme:accent
               :color ,theme:on-accent)
             `((:and .button :hover)
-              :opacity 0.8)
+              :opacity 0.6)
             `((:and .button (:or :visited :active))
               :color ,theme:background)
             `(.plain

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -764,13 +764,12 @@ store them somewhere and `ffi-buffer-delete' them once done."))
             `("#controls"
               :background-color ,theme:secondary
               :color ,theme:on-secondary
-              ;; :font-size "16px"
               :font-weight "700"
               :padding-left "5px"
               :overflow "hidden"
               :white-space "nowrap"
               :z-index "3"
-              :flex-basis "7em")
+              :flex-basis "8em")
             `("#url"
               :background-color ,theme:primary
               :color ,theme:on-primary
@@ -815,10 +814,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :padding-right "5px"
               :overflow-x "scroll"
               :white-space "nowrap"
-              :z-index "2"
-              :flex-grow "2"
-              :flex-shrink "1"
-              :flex-basis "10em")
+              :z-index "2")
             `("#modes::-webkit-scrollbar"
               :display "none")
             `(button

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -834,8 +834,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
             `((:and .button (:or :visited :active))
               :color ,theme:background)
             `(.plain
-              :padding-left "4px"
-              :padding-right "4px"
+              :padding-left "6px"
+              :padding-right "6px"
               :color ,theme:on-background
               :background-color ,theme:background))))
   (:export-class-name-p t)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -802,8 +802,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :color ,theme:background
               :white-space "nowrap"
               :text-decoration "none"
-              :padding-left "5px"
-              :padding-right "5px")
+              :padding-left "8px"
+              :padding-right "8px")
             `(".tab:hover"
               :opacity 0.6)
             `("#modes"
@@ -834,6 +834,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
             `((:and .button (:or :visited :active))
               :color ,theme:background)
             `(.plain
+              :padding-left "4px"
+              :padding-right "4px"
               :color ,theme:on-background
               :background-color ,theme:background))))
   (:export-class-name-p t)

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -61,7 +61,7 @@ This leverages `mode-status' which can be specialized for individual modes."
     ;; https://support.mozilla.org/en-US/kb/mouse-shortcuts-perform-common-tasks
     (:nbutton
       :buffer status
-      :text "◄"
+      :text "←"
       :title "Backwards"
       (nyxt/history-mode:history-backwards))
     (:nbutton
@@ -71,7 +71,7 @@ This leverages `mode-status' which can be specialized for individual modes."
       (nyxt:reload-current-buffer))
     (:nbutton
       :buffer status
-      :text "►"
+      :text "→"
       :title "Forwards"
       (nyxt/history-mode:history-forwards) )
     (:nbutton

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -97,9 +97,11 @@ This leverages `mode-status' which can be specialized for individual modes."
 (defmethod format-status-url ((status status-buffer))
   (let* ((buffer (current-buffer (window status)))
          (content (uiop:strcat
+                   (quri:uri-scheme (url buffer))
+                   " ‐ "
                    (quri:uri-domain (url buffer))
                    (when (title buffer)
-                     (str:concat " — " (title buffer)))
+                     (str:concat " ‐ " (title buffer)))
                    (when (find (url buffer) (remove buffer (buffer-list))
                                :test #'url-equal :key #'url)
                      (format nil " (buffer ~a)" (id buffer))))))

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -96,17 +96,13 @@ This leverages `mode-status' which can be specialized for individual modes."
 (export-always 'format-status-url)
 (defmethod format-status-url ((status status-buffer))
   (let* ((buffer (current-buffer (window status)))
-         (content (multiple-value-bind (aesthetic safe)
-                      (render-url (url buffer))
-                    (uiop:strcat
-                     (if safe
-                         (format nil "~a (~a)" safe aesthetic)
-                         aesthetic)
-                     (when (title buffer)
-                       (str:concat " — " (title buffer)))
-                     (when (find (url buffer) (remove buffer (buffer-list))
-                                 :test #'url-equal :key #'url)
-                       (format nil " (buffer ~a)" (id buffer)))))))
+         (content (uiop:strcat
+                   (quri:uri-domain (url buffer))
+                   (when (title buffer)
+                     (str:concat " — " (title buffer)))
+                   (when (find (url buffer) (remove buffer (buffer-list))
+                               :test #'url-equal :key #'url)
+                     (format nil " (buffer ~a)" (id buffer))))))
     (spinneret:with-html-string
       (:nbutton
         :buffer status


### PR DESCRIPTION
# Description

This includes many minor fixes, for more information, please see the commit log.

Short summary: made modes area expand as needed instead of taking up a lot of space. Tweaked appearance of tabs. Increased contrast on mouseover. Use just domain in the status area, the full URL is 99% of the time cut off and therefore unreadable. Switch triangle shapes for forward/backward to arrows.

Before:
![Screenshot_20230209_154901](https://user-images.githubusercontent.com/1691662/217947041-31ac7d4e-920f-4d46-b5c4-f3160ade1e65.png)


After:
![Screenshot_20230209_154755](https://user-images.githubusercontent.com/1691662/217946819-6d801e55-9f3a-4a9e-898c-0fd0d95bb2d8.png)
