### PR TITLE
Names for search engines.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -419,6 +419,7 @@ down."))
     :documentation "Timestamp when the buffer was last switched to.")
    (search-engines
     (list (make-instance 'search-engine
+                         :name "Wikipedia"
                          :shortcut "wiki"
                          :search-url "https://en.wikipedia.org/w/index.php?search=~a"
                          :fallback-url (quri:uri "https://en.wikipedia.org/")
@@ -431,6 +432,7 @@ down."))
                                                (results (j:decode results)))
                                 (mapcar #'list (j:get 1 results) (j:get 3 results))))))
           (make-instance 'search-engine
+                         :name "DuckDuckGo"
                          :shortcut "ddg"
                          :search-url "https://duckduckgo.com/?q=~a"
                          :fallback-url (quri:uri "https://duckduckgo.com/")

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -238,6 +238,7 @@ follows.")
           (define-configuration context-buffer
             "Add a single search engine manually."
             ((search-engines (pushnew (make-instance 'search-engine
+                                                     :name "Reddit"
                                                      :shortcut "r"
                                                      :search-url "https://reddit.com/search/?q=~a"
                                                      :fallback-url "https://reddit.com")

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -4,7 +4,10 @@
 (in-package :nyxt)
 
 (define-class search-engine ()
-  ((shortcut (error "Slot `shortcut' must be set")
+  ((name nil
+         :type (maybe string)
+         :documentation "Human-readable name of the search engine, like \"Wikipedia\" or \"Searx\".")
+   (shortcut (error "Slot `shortcut' must be set")
              :type string
              :documentation "The word used to refer to the search engine, for
 instance from the `set-url' commands.")
@@ -80,7 +83,7 @@ Example (Tor-proxied completion function for Wikipedia):
 
 (defmethod prompter:object-attributes ((engine search-engine) (source prompter:source))
   (declare (ignore source))
-  `(("Shortcut" ,(shortcut engine))
+  `(("Name" ,(or (name engine) (shortcut engine)))
     ("Search URL" ,(search-url engine) nil 3)))
 
 (defun all-search-engines ()


### PR DESCRIPTION
# Description

This makes our search engines more readable in the prompt. Discussed on the call with @lansingthomas.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.