### PR TITLE
prompt-buffer: Accept lambdas in set-action-on-return.

### DIFF
--- a/libraries/prompter/prompter.lisp
+++ b/libraries/prompter/prompter.lisp
@@ -171,6 +171,8 @@ computation is not finished.")))
 (defmethod run-action-on-current-suggestion ((prompter prompter))
   (sera:and-let* ((source (current-source prompter))
                   (_ (actions-on-current-suggestion-enabled-p source))
+                  (not (eq #'identity (alex:ensure-function
+                                       (default-action-on-current-suggestion source))))
                   (action (default-action-on-current-suggestion source))
                   (suggestion (%current-suggestion prompter)))
     (let ((delay (actions-on-current-suggestion-delay source)))

--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -352,10 +352,12 @@ current unmarked suggestion."
    'prompter:suggestion
    :value action
    ;; TODO: Include bindings in attributes.
-   :attributes `(("Name" ,(symbol-name (typecase action
-                                         (command (name action))
-                                         (function (slynk-backend:function-name action))
-                                         (t action))))
+   :attributes `(("Name" ,(or (ignore-errors
+                               (symbol-name (typecase action
+                                              (command (name action))
+                                              (function (slynk-backend:function-name action))
+                                              (t action))))
+                              "Lambda"))
                  ("Documentation" ,(or (first (sera:lines
                                                (typecase action
                                                  (command (documentation action t))

--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -336,8 +336,11 @@ current unmarked suggestion."
     (funcall* command)))
 
 (defun prompt-buffer-actions-on-return (&optional (window (current-window)))
-  (sera:and-let* ((first-prompt-buffer (first (nyxt::active-prompt-buffers window))))
-    (prompter:actions-on-return first-prompt-buffer)))
+  (or (sera:and-let* ((first-prompt-buffer (first (nyxt::active-prompt-buffers window))))
+        (prompter:actions-on-return first-prompt-buffer))
+      (progn
+        (echo-warning "No actions to choose from.")
+        (error 'prompt-buffer-canceled))))
 
 (defun prompt-buffer-actions-on-current-suggestion (&optional (window (current-window)))
   (sera:and-let* ((first-prompt-buffer (first (nyxt::active-prompt-buffers window))))


### PR DESCRIPTION
# Description

This is an alternative proposal to #2801.

Fixes #2794.

# Discussion

I might not have understood the problem that @aadcg wants to tackle in #2794.  In any case, this PR fixes `set-action-on-return` on the following prompt:

```lisp
(prompt :prompt "Test"
        :sources (make-instance 'prompter:source
                                :name "Test"
                                :constructor (list "Hello")
                                :actions-on-return
                                (list
                                 ;; Defining it with a lambda results in
                                 ;; a error when issuing command
                                 ;; set-action-on-return.
                                 (lambda (suggestion-list)
                                   "Greet world."
                                   (echo (str:concat (first suggestion-list)
                                                     " World!")))
                                 #'identity)))
```

- [ ] This pull request also skips the prompt buffer of set-action-on-return when there is no action.  But I don't think that relevant since `identity` is a valid action now.
- [ ] Commit https://github.com/atlas-engineer/nyxt/pull/2814/commits/9ed6ea850623818b7134b98703f407364fc4b0f6 has the benefit of being more general: if the source is empty, don't display the prompt buffer.  But that's probably too shortsighted: when combining multiple sources, this empty source would prevent the use of the rest.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
