### PR TITLE
Extend nyxt guix

### DIFF
--- a/build-scripts/nyxt-guix.el
+++ b/build-scripts/nyxt-guix.el
@@ -16,6 +16,9 @@
 
 (require 'cl-lib)
 
+(defvar nyxt-guix-profile-directory "~/.guix-temp-profiles/nyxt"
+  "Default directory where to dump auto-generated Guix profiles for Nyxt development.")
+
 (defun nyxt--pure-env (&rest preserve-vars)
   "Return a pure `env' command as a list of string."
   (append '("env" "-i")
@@ -49,9 +52,6 @@
       (concat
        (or (getenv "XDG_CACHE_HOME") "~/.cache")
        "/lisp-repl-core-directory")))
-
-(defvar nyxt-guix-profile-directory "~/.guix-temp-profiles/nyxt"
-  "Default directory where to dump auto-generated Guix profiles for Nyxt development.")
 
 (cl-defun nyxt-guix-lazy-shell-command (root &key
                                              ;; expression

--- a/build-scripts/nyxt-guix.el
+++ b/build-scripts/nyxt-guix.el
@@ -17,10 +17,10 @@
 (require 'cl-lib)
 
 (defvar nyxt-guix-profile-directory "~/.guix-temp-profiles/nyxt"
-  "Default directory where to dump auto-generated Guix profiles for Nyxt development.")
+  "Directory where auto-generated Guix profiles are stored.")
 
 (defun nyxt--pure-env (&rest preserve-vars)
-  "Return a pure `env' command as a list of string."
+  "Return a pure `env' command as a list of strings."
   (append '("env" "-i")
           (mapcar (lambda (var) (concat var "=" (getenv var)))
                   (append
@@ -122,20 +122,24 @@ already exists and CONTAINER is nil, after sourcing \"etc/profile\"."
                                       preserve
                                       no-grafts
                                       (ad-hoc '("guix" "gnupg")))
-  "Run a CL-IMPLEMENTATION executable image with all dependencies of CL-SYSTEM
+  "Run a CL-IMPLEMENTATION executable image with dependencies of CL-SYSTEM
 pre-loaded.
 
-The image is generated as needed and cached as IMAGE-PATH.
-It's generated if it does not exist, if FORCE is non-nil, or if the \"nyxt.scm\"
-file in NYXT-CHECKOUT is more recent.
+Note that all dependencies of CL-SYSTEM are pre-loaded, whereas
+CL-SYSTEM itself isn't.  This is useful to work on CL-SYSTEM.
+
+The image is generated as needed and cached as IMAGE-PATH.  It's
+generated when one of the following holds: FORCE is non-nil, the
+image does not exist, the Guix profile does not exit, or the
+\"nyxt.scm\" file in NYXT-CHECKOUT is more recent.
 
 When CONTAINER is non-nil, generate the image in a Guix container.
-When no-grafts is non-nil, disable Guix grafting when generating the image.
+When NO-GRAFTS is non-nil, disable Guix grafting when generating the image.
 
 PRESERVE is a list of environmental variable to preserve when running the image.
 
-This function is a suitable candidate as a SLIME or SLY Lisp
-implementation.  Example:
+This function is a suitable candidate as a SLIME or SLY Lisp implementation.
+Example:
 
  (setq sly-lisp-implementations
   `((nyxt-ccl-tests (lambda () (nyxt-make-guix-cl-for-nyxt

--- a/build-scripts/nyxt-guix.el
+++ b/build-scripts/nyxt-guix.el
@@ -54,18 +54,18 @@
   "Default directory where to dump auto-generated Guix profiles for Nyxt development.")
 
 (cl-defun nyxt-guix-lazy-shell-command (root &key
-                                                   ;; expression
-                                                   load
-                                                   ;; manifest
-                                                   ad-hoc
-                                                   preserve
-                                                   container
-                                                   network
-                                                   share
-                                                   expose
-                                                   no-grafts
-                                                   extra-args
-                                                   command-args)
+                                             ;; expression
+                                             load
+                                             ;; manifest
+                                             ad-hoc
+                                             preserve
+                                             container
+                                             network
+                                             share
+                                             expose
+                                             no-grafts
+                                             extra-args
+                                             command-args)
   "Return the command to load a Guix shell, persisted at ROOT.
 If the ROOT shell already exists, don't regenerate it.
 

--- a/build-scripts/nyxt.scm
+++ b/build-scripts/nyxt.scm
@@ -129,6 +129,8 @@
    (native-inputs
     (list cl-lisp-unit2
           sbcl
+          ;; Useful for testing, unneeded for the upstream Guix package
+          ccl
           ;; Only for development, unneeded for the upstream Guix package:
           cl-trivial-benchmark))
    (inputs


### PR DESCRIPTION
# Description

The goal is to extend `nyxt-guix.el` so that it's easier to run tests locally, generating images with personalized CL implementations (constrained by those supported by `lisp-repl-core-dumper`) and personalized system dependencies pre-loaded.

Example of a possible configuration of `{sly,slime}-lisp-implementation`.

```lisp
(setq sly-lisp-implementations
      '((nyxt-sbcl
         (lambda () (nyxt-make-guix-cl-for-nyxt
                "~/common-lisp/nyxt"
                ;; :force t
                :preserve '("VAR")
                :no-grafts t
                :ad-hoc '("emacs" "xdg-utils"))))
        (nyxt-sbcl-test
         (lambda () (nyxt-make-guix-cl-for-nyxt
                "~/common-lisp/nyxt"
                ;; :force t
                :cl-system-dependencies "nyxt/tests"
                :preserve '("VAR")
                :no-grafts t
                :ad-hoc '("emacs" "xdg-utils"))))
        (nyxt-ccl-test
         (lambda () (nyxt-make-guix-cl-for-nyxt
                "~/common-lisp/nyxt"
                ;; :force t
                :cl-implementation "ccl"
                :cl-system-dependencies "nyxt/tests"
                :preserve '("VAR")
                :no-grafts t
                :ad-hoc '("emacs" "xdg-utils"))))))
```

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [ ] I have pulled from master before submitting this PR
- [ ] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [ ] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
