### PR TITLE
Discard overlapped elements in `hint-mode`

### DIFF
--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -159,7 +159,8 @@ For instance, to include images:
         (in-view-port-p (ps:lisp (compute-hints-in-view-port-p (find-submode 'hint-mode)))))
     (ps:dolist (element elements)
       (if in-view-port-p
-          (when (nyxt/ps:element-in-view-port-p element)
+          (when (and (nyxt/ps:element-in-view-port-p element)
+                     (not (nyxt/ps:element-overlapped-p element)))
             (ps:chain element (set-attribute "nyxt-hintable" "")))
           (ps:chain element (set-attribute "nyxt-hintable" ""))))))
 

--- a/source/parenscript-macro.lisp
+++ b/source/parenscript-macro.lisp
@@ -151,3 +151,21 @@
               (not (= (chain computed-style "visibility") "hidden"))
               (not (= (chain computed-style "display") "none")))
          t nil)))
+
+(export-always 'element-overlapped-p)
+(defpsmacro element-overlapped-p (element)
+  "Whether ELEMENT is overlapped by another element."
+  `(let* ((rect (chain ,element (get-bounding-client-rect)))
+          (computed-style (chain window (get-computed-style ,element)))
+          (coord-truncation-offset 2)
+          (radius (serapeum:parse-float (chain computed-style border-top-left-radius)))
+          (rounded-border-offset (ceiling (* radius (- 1 (sin (/ pi 4))))))
+          (offset (max coord-truncation-offset rounded-border-offset))
+          (el (chain document (element-from-point (+ (chain rect left) offset)
+                                                  (+ (chain rect top) offset)))))
+     (if (or (>= offset (chain rect width))
+             (>= offset (chain rect height)))
+         t
+         (progn (loop while (and el (/= el element))
+                      do (setf el (chain el parent-node)))
+                (null el)))))


### PR DESCRIPTION
-------

# Description

I have added a function to verify whether an element is overlapped when calling the `follow-hint` command. This function is used to discard the overlapped elements when the user has set the `compute-hints-in-view-port-p` to `t`.

Fixes #2506

# Discussion

The new added function `element-overlapped-p` is inspired by [the algorithm](https://github.com/lusakasa/saka-key/blob/master/src/modes/hints/client/findHints.js#L114) from `saka-key` project. I have noticed a side effect to this algorithm which is that it automatically discards elements that aren't in the view port, this part is already implemented in the function `element-in-view-port-p` which makes the process redundant since both functions are called when checking for hints. After investigating the issue I found out that the javascript function [`elementFromPoint`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint) returns `null` when the element is outside the view port, which according to the algorithm acts as if the two elements are not related thus one is overlapping the other.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - [ ] ASDF dependencies,
  - [ ] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [ ] and Guix dependencies.
- [ ] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.