### PR TITLE
libraries/prompter/package: Initialize lparallel:*kernel*.

### DIFF
--- a/libraries/prompter/package.lisp
+++ b/libraries/prompter/package.lisp
@@ -7,6 +7,9 @@
   (:import-from :serapeum #:export-always))
 (in-package prompter)
 
+(unless lparallel:*kernel* (setf lparallel:*kernel*
+                                 (lparallel:make-kernel (or (serapeum:count-cpus) 1))))
+
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
   (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum))


### PR DESCRIPTION
# Description

Fixes the following issue:

```lisp
CL-USER> (asdf:load-system "nyxt/prompter")
PROMPTER> (make-instance 'prompter:source
                                :name "Test"
                                :constructor (list "Hello"))
WARNING:
   Error on separate prompter thread: Welcome to lparallel. To get started, you need to create some worker
threads. Choose the MAKE-KERNEL restart to create them now.

Worker threads are asleep when not in use. They are typically created
once per Lisp session.

Adding the following line to your startup code will prevent this
message from appearing in the future (N is the number of workers):

  (setf lparallel:*kernel* (lparallel:make-kernel N))
```




# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [x] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
