### PR TITLE
Better spinneret tags handling

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -713,4 +713,9 @@ like buttons.")
 
 (define-version "3-pre-release-5"
   (:ul
-   (:li "Code listings on manual and help system are more readable.")))
+   (:li "Code listings on manual and help system are more readable."))
+
+  (:h3 "Programming interface")
+  (:ul
+   (:li "Spinneret tags like " (:code ":nxref") " and " (:code ":ncode")
+        " are refactored for debuggability and obviousness.")))

--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -431,9 +431,7 @@ For generic functions, describe all the methods."
                                     (not-error-p (null (getf definition :error)))
                                     (file (first (rest (getf definition :location)))))
                      (:h2 (format nil "Source (~a)" file))
-                     (:ncode
-                       :file file
-                       :literal-p t
+                     (:ncode :file file
                        (multiple-value-bind (listing form)
                            (function-lambda-string (symbol-function input))
                          (or form listing))))
@@ -473,7 +471,8 @@ For generic functions, describe all the methods."
                     (multiple-value-bind (source form file)
                         (source-for-thing method)
                       (:h2 (format nil "Source (~a)" file))
-                      (:ncode :file file :literal-p t (or form source)))))))
+                      (:ncode :file file
+                        (or form source)))))))
           (spinneret:with-html-string
             (:nstyle (style buffer))
             (:h1 (format nil "~s" input) ; Use FORMAT to keep package prefix.
@@ -552,12 +551,8 @@ A command is a special kind of function that can be called with
                       (prini-to-string (getf props :type)))
                   (prini-to-string (getf props :type)))))
        (when (getf props :initform)
-         (let* ((initform-string (prini-to-string (getf props :initform)))
-                (multiline-form? (search +newline+ initform-string)))
-           (:dt "Default value")
-           (:dd (if multiline-form?
-                    (:ncode :literal-p t initform-string)
-                    (:ncode :literal-p t :inline-p t initform-string)))))
+         (:dt "Default value")
+         (:dd (:ncode (prini-to-string (getf props :initform)))))
        (when (getf props :documentation)
          (:dt "Documentation")
          (:dd (:pre (:code (:raw (resolve-backtick-quote-links
@@ -600,8 +595,7 @@ A command is a special kind of function that can be called with
           (multiple-value-bind (source s-expr file)
               (source-for-thing (find-class class))
             (declare (ignore source))
-            (:ncode :file file :literal-p t
-              s-expr))
+            (:ncode :file file s-expr))
           (:h2 "Describe")
           (:pre (:code (with-output-to-string (s) (describe class s))))))
       (spinneret:with-html-string

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -834,18 +834,16 @@ mode's configuration file:")
           "#!/bin/sh
 #|
 exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
-|#
-
-;; Disable session restoration to speed up startup and get more reproducible behavior.
-\(define-configuration browser
-  ((restore-session-on-startup-p nil)))
-
-;; Load the URL of Nyxt repository by default in all new buffers.
-;; Alternatively, call `buffer-load' in `after-startup-hook'.
-\(define-configuration browser
-  ((default-new-buffer-url (quri:uri \"https://github.com/atlas-engineer/nyxt\"))))
-
-\(hooks:on (after-startup-hook *browser*) (browser)
+|#"
+          '(define-configuration browser
+            "Disable session restoration to speed up startup and get more reproducible
+behavior."
+            ((restore-session-on-startup-p nil)))
+          '(define-configuration browser
+            "Load the URL of Nyxt repository by default in all new buffers.
+Alternatively, call `buffer-load' in `after-startup-hook'."
+            ((default-new-buffer-url (quri:uri "https://github.com/atlas-engineer/nyxt"))))
+          "\(hooks:on (after-startup-hook *browser*) (browser)
   ;; Once the page's done loading, do your thing.
   (hooks:once-on (buffer-loaded-hook (current-buffer)) (buffer)
     ;; It's sometimes necessary to sleep, as `buffer-loaded-hook' fires when the

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -54,7 +54,7 @@ similar programming language.")
                           "Create configuration file")))))
         (:p "Example:")
         (:ncode
-          (define-configuration web-buffer
+          '(define-configuration web-buffer
             ((default-modes (pushnew 'nyxt/no-script-mode:no-script-mode %slot-value%)))))
         (:p "The above turns on the 'no-script-mode' (disables JavaScript) by default for
 every buffer.")
@@ -107,11 +107,11 @@ add the following to your configuration:")
         (:ul
          (:li "vi bindings:"
               (:ncode
-                (define-configuration buffer
+                '(define-configuration buffer
                   ((default-modes (pushnew 'nyxt/vi-mode:vi-normal-mode %slot-value%))))))
          (:li "Emacs bindings:"
               (:ncode
-                (define-configuration buffer
+                '(define-configuration buffer
                   ((default-modes (pushnew 'nyxt/emacs-mode:emacs-mode %slot-value%)))))))
         (:p "You can create new scheme names with " (:nxref :function 'nkeymaps:make-keyscheme)
             ".  Also see the "
@@ -121,21 +121,21 @@ add the following to your configuration:")
             (:nxref :slot 'keyscheme-map :class-name 'mode) " with "
             (:nxref :function 'keymaps:define-keyscheme-map) ". For example:")
         (:ncode
-          (define-configuration base-mode
-            "Note the :import part of the define-keyscheme-map.
+          '(define-configuration base-mode
+            "Note the :import part of the `define-keyscheme-map'.
 It re-uses the other keymap (in this case, the one that was slot value before
 the configuration) and merely adds/modifies it."
             ((keyscheme-map
               (define-keyscheme-map
-                  "my-base" (list :import %slot-value%)
-                keyscheme:vi-normal
-                (list "g b" (lambda-command switch-buffer* ()
-                              (switch-buffer :current-is-last-p t))))))))
+               "my-base" (list :import %slot-value%)
+               keyscheme:vi-normal
+               (list "g b" (lambda-command switch-buffer* ()
+                             (switch-buffer :current-is-last-p t))))))))
         (:p "The " (:nxref :slot 'override-map :class-name 'input-buffer) " is a keymap that has priority over
 all other keymaps.  By default, it has few bindings like the one
 for " (:nxref :command 'execute-command) ".  You can use it to set keys globally:")
         (:ncode
-          (define-configuration input-buffer
+          '(define-configuration input-buffer
             ((override-map (let ((map (make-keymap "override-map")))
                              (define-key map
                                "M-x" 'execute-command
@@ -164,19 +164,19 @@ Note that this kind of global keymaps also have priority over regular character
 insertion, so you should probably not bind anything without modifiers in such a
 keymap.")
         (:ncode
-          (defvar *my-keymap* (make-keymap "my-map"))
-          (define-key *my-keymap*
+          '(defvar *my-keymap* (make-keymap "my-map"))
+          '(define-key *my-keymap*
             "C-f" 'nyxt/history-mode:history-forwards
             "C-b" 'nyxt/history-mode:history-backwards)
 
-          (define-mode my-mode ()
+          '(define-mode my-mode ()
             "Dummy mode for the custom key bindings in `*my-keymap*'."
             ((keyscheme-map (keymaps:make-keyscheme-map
                              nyxt/keyscheme:cua *my-keymap*
                              nyxt/keyscheme:emacs *my-keymap*
                              nyxt/keyscheme:vi-normal *my-keymap*))))
 
-          (define-configuration web-buffer
+          '(define-configuration web-buffer
             "Enable this mode by default."
             ((default-modes (pushnew 'my-mode %slot-value%)))))
         (:p "Bindings are subject to various translations as per "
@@ -218,31 +218,31 @@ corresponding section.")
 order to make python3 the default, the above code can be slightly modified as
 follows.")
         (:ncode
-          (defvar *my-search-engines*
+          '(defvar *my-search-engines*
             (list
              '("google" "https://google.com/search?q=~a" "https://google.com")
              '("doi" "https://dx.doi.org/~a" "https://dx.doi.org/")
              '("python3" "https://docs.python.org/3/search.html?q=~a" "https://docs.python.org/3"))
             "List of search engines.")
 
-          (define-configuration context-buffer
+          '(define-configuration context-buffer
             "Go through the search engines above and `make-search-engine' out of them."
             ((search-engines (append %slot-default%
-                                     (mapcar (lambda (engine) (apply 'make-search-engine engine))
-                                             *my-search-engines*))))))
+                              (mapcar (lambda (engine) (apply 'make-search-engine engine))
+                               *my-search-engines*))))))
         (:p "If you don't want to use " (:nxref :function 'make-search-engine)
             " and want to try building the engines yourself, you can always make new "
             (:nxref :class-name 'search-engine) " and add it to "
             (:nxref :class-name 'context-buffer :slot 'search-engines) " list:")
         (:ncode
-          (define-configuration context-buffer
+          '(define-configuration context-buffer
             "Add a single search engine manually."
             ((search-engines (pushnew (make-instance 'search-engine
-                                                     :name "Reddit"
-                                                     :shortcut "r"
-                                                     :search-url "https://reddit.com/search/?q=~a"
-                                                     :fallback-url "https://reddit.com")
-                                      %slot-value%))))))
+                                       :name "Reddit"
+                                       :shortcut "r"
+                                       :search-url "https://reddit.com/search/?q=~a"
+                                       :fallback-url "https://reddit.com")
+                              %slot-value%))))))
 
       (:nsection :title "History"
         (:p "Nyxt history model is a tree whose nodes are URLs. It branches out through all
@@ -353,7 +353,7 @@ Lisp function, except the form is " (:code "define-command") " instead of "
         the context of a mode, use " (:code "define-command-global") ".")
         (:p "Example:")
         (:ncode
-          (define-command-global my-bookmark-url ()
+          '(define-command-global my-bookmark-url ()
             "Query which URL to bookmark."
             (let ((url (prompt
                         :prompt "Bookmark URL"
@@ -364,8 +364,7 @@ to write custom prompt buffers.")
         (:p "You can also create your own context menu entries binding those to Lisp commands, using "
             (:nxref :function 'ffi-add-context-menu-command) " function. You can bind the "
             (:code "bookmark-url") " like this:")
-        (:ncode
-          (ffi-add-context-menu-command 'my-bookmark-url "Bookmark URL"))
+        (:ncode '(ffi-add-context-menu-command 'my-bookmark-url "Bookmark URL"))
         (:p "Currently, context menu commands don't have access to the renderer objects (and
 shouldn't hope to). Commands you bind to context menu actions should deduce most
 of the information from their surroundings, using JavaScript and Lisp functions
@@ -375,10 +374,10 @@ Nyxt provides. For example, one can use the "
         (:p "With this, one can improve the bookmarking using "
             (:nxref :slot 'url-at-point :class-name 'buffer) ":")
         (:ncode
-          (ffi-add-context-menu-command
-           (lambda ()
-             (nyxt/bookmark-mode:bookmark-add (url-at-point (current-buffer))))
-           "Bookmark Link")))
+          '(ffi-add-context-menu-command
+            (lambda ()
+              (nyxt/bookmark-mode:bookmark-add (url-at-point (current-buffer))))
+            "Bookmark Link")))
 
       (:nsection :title "Custom URL schemes"
         (:p "If there's a scheme that Nyxt doesn't support, but you want it to, you can
@@ -480,7 +479,7 @@ still define it as:")
               "Hello there!"))
           (:p " and use as:")
           (:ncode
-            (buffer-load-internal-page-focus 'not-a-command))
+            '(buffer-load-internal-page-focus 'not-a-command))
           (:p "See the slots and documentation of " (:nxref :class-name 'internal-page)
               " to understand what you can pass to "
               (:nxref :macro 'define-internal-page) ".")))
@@ -547,7 +546,7 @@ you can safely set new inputs and select the necessary suggestions."))
         (:p "For instance, if you want to force 'old.reddit.com' over 'www.reddit.com', you
 can set a hook like the following in your configuration file:")
         (:ncode
-          (defun old-reddit-handler (request-data)
+          '(defun old-reddit-handler (request-data)
             (let ((url (url request-data)))
               (setf (url request-data)
                     (if (search "reddit.com" (quri:uri-host url))
@@ -557,18 +556,18 @@ can set a hook like the following in your configuration file:")
                           url)
                         url)))
             request-data)
-          (define-configuration web-buffer
+          '(define-configuration web-buffer
             ((request-resource-hook
               (hooks:add-hook %slot-default% 'old-reddit-handler)))))
         (:p "(See " (:nxref :function 'url-dispatching-handler)
             " for a simpler way to achieve the same result.)")
         (:p "Or, if you want to set multiple handlers at once,")
         (:ncode
-          (define-configuration web-buffer
+          '(define-configuration web-buffer
             ((request-resource-hook
               (reduce #'hooks:add-hook
-                      '(old-reddit-handler auto-proxy-handler)
-                      :initial-value %slot-default%)))))
+               '(old-reddit-handler auto-proxy-handler)
+               :initial-value %slot-default%)))))
         (:p "Some hooks like the above example expect a return value, so it's
 important to make sure we return " (:nxref :class-name 'request-data) " here.  See the
 documentation of the respective hooks for more details."))
@@ -600,17 +599,17 @@ say to develop Nyxt or extensions.")
         (:p "Example to create a development profile that stores all data in "
             (:code "/tmp/nyxt") " and stores bookmark in an encrypted file:")
         (:ncode
-          (define-class dev-profile (nyxt-profile)
+          '(define-class dev-profile (nyxt-profile)
             ((files:name :initform "nyxt-dev"))
             (:documentation "Development profile."))
-          (defmethod files:resolve ((profile dev-profile) (path nyxt-file))
+          '(defmethod files:resolve ((profile dev-profile) (path nyxt-file))
             "Expand all data paths inside a temporary directory."
             (serapeum:path-join (files:expand (make-instance 'nyxt-temporary-directory))
-                                (uiop:relativize-pathname-directory (call-next-method))))
-          (defmethod files:resolve ((profile dev-profile) (file history-file))
+             (uiop:relativize-pathname-directory (call-next-method))))
+          '(defmethod files:resolve ((profile dev-profile) (file history-file))
             "Persist history to default location."
             (files:resolve (global-profile) file))
-          (define-configuration web-buffer
+          '(define-configuration web-buffer
             "Make new profile the default."
             ((profile (make-instance (or (find-profile-class (getf *options* :profile)) 'dev-profile))))))
         (:p "Then you can start a separate instance of Nyxt using this profile
@@ -642,16 +641,16 @@ snippet to your config:")
           (:ncode
             ;; FIXME: Why does `define-configuration' not work for password
             ;; interfaces? Something's fishy with user classes...
-            (defmethod initialize-instance :after ((interface password:keepassxc-interface) &key &allow-other-keys)
+            '(defmethod initialize-instance :after ((interface password:keepassxc-interface) &key &allow-other-keys)
               "It's obviously not recommended to set master password here,
 as your config is likely unencrypted and can reveal your password to someone
 peeking at the screen."
               (setf (password:password-file interface) "/path/to/your/passwords.kdbx"
-                    (password:key-file interface) "/path/to/your/keyfile"
-                    (password:yubikey-slot interface) "1:1111"))
-            (define-configuration nyxt/password-mode:password-mode
+               (password:key-file interface) "/path/to/your/keyfile"
+               (password:yubikey-slot interface) "1:1111"))
+            '(define-configuration nyxt/password-mode:password-mode
               ((nyxt/password-mode:password-interface (make-instance 'password:keepassxc-interface))))
-            (define-configuration buffer
+            '(define-configuration buffer
               ((default-modes (append (list 'nyxt/password-mode:password-mode) %slot-value%)))))))
 
       (:nsection :title "Appearance"
@@ -661,18 +660,18 @@ facilities provided by " (:nxref :package :theme) " and "
 ". For example, to set a theme to a midnight-like one, you can add this snippet
 to your configuration file:")
         (:ncode
-          (define-configuration browser
+          '(define-configuration browser
             ((theme (make-instance 'theme:theme
-                                   :dark-p t
-                                   :background-color "black"
-                                   :on-background-color "#808080"
-                                   :accent-color "#37a8e4"
-                                   :on-accent-color "black"
-                                   :primary-color "gray"
-                                   :on-primary-color "white"
-                                   :secondary-color "darkgray"
-                                   :on-secondary-color "black")
-                    :doc "You can omit the colors you like in default theme, and they will stay as they were."))))
+                     :dark-p t
+                     :background-color "black"
+                     :on-background-color "#808080"
+                     :accent-color "#37a8e4"
+                     :on-accent-color "black"
+                     :primary-color "gray"
+                     :on-primary-color "white"
+                     :secondary-color "darkgray"
+                     :on-secondary-color "black")
+              :doc "You can omit the colors you like in default theme, and they will stay as they were."))))
         (:p "This, on the next restart of Nyxt, will repaint all the interface elements into
 a dark-ish theme.")
         (:p "As an alternative to the all-encompassing themes, you can alter the style of
@@ -680,7 +679,7 @@ every individual class controlling Nyxt interface elements. All such classes hav
             (:nxref :function 'nyxt:style)
             " slot that you can configure with your own CSS like this:")
         (:ncode
-          (define-configuration nyxt/style-mode:dark-mode
+          '(define-configuration nyxt/style-mode:dark-mode
             ((style
               (theme:themed-css (theme *browser*)
                 `(*
@@ -718,31 +717,36 @@ variables like " (:code "theme:on-primary") ".)")
       (:nsection :title "Scripting"
         (:p "You can evaluate code from the command line with "
             (:code "--eval") " and " (:code "--load") ".  From a shell:")
-        (:pre (:code "$ nyxt --no-config --eval '+version+' \
-  --load my-lib.lisp --eval '(format t \"Hello ~a!~&\" (my-lib:my-world))'"))
+        (:ncode :repl-p nil :config-p nil
+          "$ nyxt --no-config --eval '+version+' \
+  --load my-lib.lisp --eval '(format t \"Hello ~a!~&\" (my-lib:my-world))'")
         (:p "You can evaluate multiple --eval and --load in a row, they are
 executed in the order they appear.")
         (:p "You can also evaluate a Lisp file from the Nyxt interface with
 the " (:nxref :command 'load-file) " command.  For
 convenience, " (:nxref :command 'load-config-file) " (re)loads your initialization file.")
         (:p "You can even make scripts.  Here is an example foo.lisp:")
-        (:pre (:code "#!/bin/sh
+        (:ncode
+          :repl-p nil
+          :config-p nil
+          "#!/bin/sh
 #|
 exec nyxt --script \"$0\"
 |#
 
 ;; Your code follows:
-\(format t \"~a~&\" +version+)"))
+\(format t \"~a~&\" +version+)")
         (:p "--eval and --load can be commanded to operate over an
 existing instance instead of a separate instance that exits immediately.")
         (:p "The" (:nxref :slot 'remote-execution-p :class-name 'browser)
             " of the remote instance must be non-nil:")
         (:ncode
-          (define-configuration browser
+          '(define-configuration browser
             ((remote-execution-p t))))
         (:p "To let know a private instance of Nyxt to load a foo.lisp script and run its"
             (:code "foo") "function:")
-        (:pre (:code "nyxt --profile nosave --remote --load foo.lisp --eval '(foo)' --quit"))
+        (:ncode :repl-p nil :config-p nil
+          "nyxt --profile nosave --remote --load foo.lisp --eval '(foo)' --quit")
         (:p "Note that " (:code "--quit")
             "at the end of each Nyxt CLI call here. If you don't provide " (:code "--quit")
             " when dealing with a remote instance, it will go into a REPL mode, allowing an
@@ -761,15 +765,15 @@ small configuration snippet (note that you'd need to have "
             (:nxref :class-name 'nyxt/user-script-mode:user-script-mode)
             " in your " (:nxref :function 'default-modes "buffer default-modes") " ):")
         (:ncode
-          (define-configuration web-buffer
+          '(define-configuration web-buffer
             "Enable user-script-mode, if you didn't already."
             ((default-modes (pushnew 'nyxt/user-script-mode:user-script-mode %slot-value%))))
 
-          (define-configuration nyxt/user-script-mode:user-script-mode
+          '(define-configuration nyxt/user-script-mode:user-script-mode
             ((nyxt/user-script-mode:user-scripts
               (list
                (make-instance 'nyxt/user-script-mode:user-script
-                              :code "// ==UserScript==
+                :code "// ==UserScript==
                               // @name          No navbars!
                               // @description	A simple script to remove navbars
                               // @run-at        document-end
@@ -818,14 +822,16 @@ automations and web page analysis.")
         (:p "To enable headless mode, simply start Nyxt with the "
             (:code "--headless")
             " CLI flag and provide a script file to serve as the configuration file:")
-        (:pre (:code "nyxt --headless --config /path/to/your/headless-config.lisp"))
+        (:ncode :repl-p nil :config-p nil
+          "nyxt --headless --config /path/to/your/headless-config.lisp")
         (:p "Note that you pass it a " (:i "configuration file")
             "—headless mode is only different from the regular Nyxt functions in that it has
 no GUI, and is all the same otherwise, contrary to all the seeming similarities
 to the " (:code "--script") " flag usage.")
         (:p "The example below showcases frequent idioms that are found in the
 mode's configuration file:")
-        (:pre (:code "#!/bin/sh
+        (:ncode :repl-p nil :config-p nil
+          "#!/bin/sh
 #|
 exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
 |#
@@ -860,7 +866,7 @@ exec nyxt --headless --no-auto-config --profile nosave --config \"$0\"
     (echo \"Clicked the star.\")
     ;; It's good tone to `nyxt:quit' after you're done, but if you use nyxt
     ;; --no-socket, you don't have to. Just be ready for some RAM eating :)
-    (nyxt:quit)))"))
+    (nyxt:quit)))")
         (:p "The contents of headless-config.lisp feature configuration forms that
 make Nyxt perform some actions to the opened pages and/or on certain
 hooks. Things you'd most probably want to put there are: ")
@@ -930,7 +936,7 @@ class instantiation, you'll have to specialize the
 lower-level " (:nxref :function 'customize-instance)
 " generic function.  Example:")
         (:ncode
-          (defmethod customize-instance ((buffer buffer) &key)
+          '(defmethod customize-instance ((buffer buffer) &key)
             (echo "Buffer ~a created." buffer)))
         (:p "All classes with metaclass " (:nxref :class-name 'user-class) " call "
             (:nxref :function 'customize-instance) " on instantiation,
@@ -990,9 +996,10 @@ GStreamer plugins as mentioned in the 'Playing videos' section."))
         (:nsection :title "Input method support (CJK, etc.)"
           (:p "Depending on your setup, you might have to set some environment variables
 or run some commands before starting Nyxt, for instance")
-          (:pre (:code "GTK_IM_MODULE=xim
+          (:ncode :repl-p nil :config-p nil
+            "GTK_IM_MODULE=xim
 XMODIFIERS=@im=ibus
-ibus --daemonize --replace --xim"))
+ibus --daemonize --replace --xim")
           (:p "You can persist this change by saving the commands in
 your " (:code ".xprofile") " or similar."))
 
@@ -1005,10 +1012,11 @@ following environment variable before starting Nyxt:")
 nyxt
 "))
           (:p "If that doesn't look satisfactory, try exporting the following environment variables before starting Nyxt:")
-          (:pre (:code "export GDK_SCALE=2
+          (:ncode :repl-p nil :config-p nil
+            "export GDK_SCALE=2
 export GDK_DPI_SCALE=0.5
 nyxt
-")))
+"))
 
         (:nsection :title "StumpWM mouse scroll"
           (:p "If the mouse scroll does not work for you, see the "
@@ -1022,4 +1030,4 @@ nyxt
     can try to disable compositing. To disable compositing from your
     initialization file, you can do the following: ")
           (:ncode
-            (setf (uiop:getenv "WEBKIT_DISABLE_COMPOSITING_MODE") "1")))))))
+            '(setf (uiop:getenv "WEBKIT_DISABLE_COMPOSITING_MODE") "1")))))))

--- a/source/tutorial.lisp
+++ b/source/tutorial.lisp
@@ -337,7 +337,7 @@ overriding any mode keybinding. If you want to toggle mark with C-space,
 you'll need to set your own override-map such that C-space is not bound.
 An example:")
         (:ncode
-          (define-configuration input-buffer
+          '(define-configuration input-buffer
             ((override-map (let ((map (make-keymap "override-map")))
                              (define-key map
                                "M-x" 'execute-command)))))))


### PR DESCRIPTION
# Description

This polishes and simplifies our Spinneret tags, essentially offloading compile-time computation into runtime, where they are much easier to catch. This also introduces lots of helpers for `:nselect`, `:nxref`, `:ncode`, with stack traces getting much clearer too.

~As a downside, `remove-smart-quoting` is not used in `:ncode` and `:nselect` anymore, making those more explicit (you need to quote all code snippets), but essentially more usable and runtime-friendly. `:nbutton` and `:ninput` stilly rely on `remove-smart-quoting`, but I'm thinking on ways to remove it altogether, as a confusing and ad-hoc solution to a nonexistent problem.~ It will be removed in the next PR about tags, but for now it's still there.

# Discussion

Should there macros be tested? I'm anxious to say no, because different implementation produce different macro outputs even in `macroexpand-1`, but maybe some terribly generalized pattern matching could work for tag macroexpansion testing?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
