### PR TITLE
Prompt ux

### DIFF
--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -91,13 +91,13 @@ See `nyxt::attribute-widths'.")
           :padding-right "7px")
         `("#prompt-modes"
           :background-color ,theme:primary
-          :width "5px"
+          :min-width "5px"
           :line-height "26px"
           :padding-left "3px"
           :padding-right "3px")
         `("#close-button"
+          :padding-right "3px"
           :line-height "24px"
-          :padding-right "5px"
           :font-weight "bold"
           :font-size "20px")
         `(".arrow-left"
@@ -117,7 +117,6 @@ See `nyxt::attribute-widths'.")
           :opacity 0.6)
         `((:and .button (:or :visited :active))
           :color ,theme:background)
-
         `("#input"
           :background-color ,theme:background
           :color ,theme:on-background
@@ -141,7 +140,7 @@ See `nyxt::attribute-widths'.")
           :overflow-y "hidden"
           :overflow-x "hidden"
           :height "100%"
-          :width "100%")
+          :margin-right "3px")
         `(".source-content"
           :background-color ,theme:background
           :color ,theme:on-background

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -75,6 +75,9 @@ See `nyxt::attribute-widths'.")
           :margin "0"
           :padding "0")
         `("#prompt-area"
+          :border-top "2px solid"
+          :border-bottom "2px solid"
+          :border-color ,theme:primary
           :background-color ,theme:primary
           :color ,theme:on-primary
           :display "grid"
@@ -130,6 +133,9 @@ See `nyxt::attribute-widths'.")
         `((:and .button (:or :visited :active))
           :color ,theme:background)
         `("#input"
+          :height "28px"
+          :margin-top "0"
+          :margin-bottom "0"
           :padding-left "16px !important"
           :background-color ,theme:background
           :color ,theme:on-background

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -69,7 +69,7 @@ See `nyxt::attribute-widths'.")
           :font-size "14px"
           :line-height "18px")
         `(body
-          :border-right "3px solid"
+          :border-right "2px solid"
           :border-color ,theme:primary
           :overflow "hidden"
           :margin "0"
@@ -81,12 +81,17 @@ See `nyxt::attribute-widths'.")
           :grid-template-columns "auto auto 1fr auto auto"
           :width "100%")
         `("#prompt"
+          :background-color ,theme:primary
           :padding-left "10px"
           :line-height "28px")
         `("#prompt-input"
           :margin-right "-10px"
           :line-height "28px")
         `("#prompt-extra"
+          :z-index "1"
+          :min-width "12px"
+          :padding-right "14px !important"
+          :background-color ,theme:primary
           :line-height "28px"
           :padding-right "7px")
         `("#prompt-modes"
@@ -125,6 +130,7 @@ See `nyxt::attribute-widths'.")
         `((:and .button (:or :visited :active))
           :color ,theme:background)
         `("#input"
+          :padding-left "16px !important"
           :background-color ,theme:background
           :color ,theme:on-background
           :opacity 0.9
@@ -495,7 +501,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
               (:body
                (:div :id "prompt-area"
                      (:div :id "prompt" (:mayberaw (prompter:prompt prompt-buffer)))
-                     (:div :id "prompt-extra" "[?/?]")
+                     (:div :id "prompt-extra" :class "arrow-right" "[?/?]")
                      (:div :id "prompt-input"
                            (:input :type (if (invisible-input-p prompt-buffer)
                                              "password"

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -78,7 +78,7 @@ See `nyxt::attribute-widths'.")
           :background-color ,theme:primary
           :color ,theme:on-primary
           :display "grid"
-          :grid-template-columns "auto auto 1fr auto"
+          :grid-template-columns "auto auto 1fr auto auto"
           :width "100%")
         `("#prompt"
           :padding-left "10px"
@@ -90,6 +90,26 @@ See `nyxt::attribute-widths'.")
           :line-height "26px"
           :padding-left "3px"
           :padding-right "3px")
+        `("#close-button"
+          :line-height "24px"
+          :padding-right "5px"
+          :font-size "24px")
+        `(button
+          :background "transparent"
+          :color "inherit"
+          :text-decoration "none"
+          :border "none"
+          :padding 0
+          :font "inherit"
+          :outline "inherit")
+        `(.button.accent
+          :background-color ,theme:accent
+          :color ,theme:on-accent)
+        `((:and .button :hover)
+          :opacity 0.6)
+        `((:and .button (:or :visited :active))
+          :color ,theme:background)
+
         `("#input"
           :background-color ,theme:background
           :color ,theme:on-background
@@ -467,7 +487,13 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                              "text")
                                    :id "input"
                                    :value (prompter:input prompt-buffer)))
-                     (:div :id "prompt-modes" ""))
+                     (:div :id "prompt-modes" "")
+                     (:div :id "close-button"
+                           (:nbutton
+                             :text "×"
+                             :title "Close prompt"
+                             :buffer prompt-buffer
+                             (nyxt/prompt-buffer-mode:: quit-prompt-buffer))))
                (:div :id "suggestions"
                      :style (if (invisible-input-p prompt-buffer)
                                 "visibility:hidden;"

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -69,6 +69,8 @@ See `nyxt::attribute-widths'.")
           :font-size "14px"
           :line-height "18px")
         `(body
+          :border-right "3px solid"
+          :border-color ,theme:primary
           :overflow "hidden"
           :margin "0"
           :padding "0")

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -501,7 +501,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                              :text "×"
                              :title "Close prompt"
                              :buffer prompt-buffer
-                             (nyxt/prompt-buffer-mode:: quit-prompt-buffer))))
+                             (funcall (sym:resolve-symbol :quit-prompt-buffer :command)))))
                (:div :id "suggestions"
                      :style (if (invisible-input-p prompt-buffer)
                                 "visibility:hidden;"

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -83,17 +83,25 @@ See `nyxt::attribute-widths'.")
         `("#prompt"
           :padding-left "10px"
           :line-height "26px")
+        `("#prompt-input"
+          :margin-right "-10px"
+          :line-height "26px")
         `("#prompt-extra"
           :line-height "26px"
           :padding-right "7px")
         `("#prompt-modes"
+          :background-color ,theme:primary
+          :width "5px"
           :line-height "26px"
           :padding-left "3px"
           :padding-right "3px")
         `("#close-button"
           :line-height "24px"
           :padding-right "5px"
-          :font-size "24px")
+          :font-weight "bold"
+          :font-size "20px")
+        `(".arrow-left"
+          :clip-path "polygon(10px 0, 100% 0, 100% 100%, 10px 100%, 0% 50%)")
         `(button
           :background "transparent"
           :color "inherit"
@@ -482,12 +490,13 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                (:div :id "prompt-area"
                      (:div :id "prompt" (:mayberaw (prompter:prompt prompt-buffer)))
                      (:div :id "prompt-extra" "[?/?]")
-                     (:div (:input :type (if (invisible-input-p prompt-buffer)
+                     (:div :id "prompt-input"
+                           (:input :type (if (invisible-input-p prompt-buffer)
                                              "password"
                                              "text")
                                    :id "input"
                                    :value (prompter:input prompt-buffer)))
-                     (:div :id "prompt-modes" "")
+                     (:div :id "prompt-modes" :class "arrow-left" "")
                      (:div :id "close-button"
                            (:nbutton
                              :text "×"

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -82,26 +82,33 @@ See `nyxt::attribute-widths'.")
           :width "100%")
         `("#prompt"
           :padding-left "10px"
-          :line-height "26px")
+          :line-height "28px")
         `("#prompt-input"
           :margin-right "-10px"
-          :line-height "26px")
+          :line-height "28px")
         `("#prompt-extra"
-          :line-height "26px"
+          :line-height "28px"
           :padding-right "7px")
         `("#prompt-modes"
-          :background-color ,theme:primary
-          :min-width "5px"
-          :line-height "26px"
+          :background-color ,theme:secondary
+          :padding-left "10px !important"
+          :padding-right "14px !important"
+          :line-height "28px"
           :padding-left "3px"
           :padding-right "3px")
         `("#close-button"
-          :padding-right "3px"
+          :text-align "right"
+          :background-color ,theme:primary
+          :min-width "24px"
           :line-height "24px"
           :font-weight "bold"
           :font-size "20px")
+        `(".arrow-right"
+          :clip-path "polygon(0 0, calc(100% - 10px) 0, 100% 50%, calc(100% - 10px) 100%, 0 100%)"
+          :margin-right "-10px")
         `(".arrow-left"
-          :clip-path "polygon(10px 0, 100% 0, 100% 100%, 10px 100%, 0% 50%)")
+          :clip-path "polygon(10px 0, 100% 0, 100% 100%, 10px 100%, 0% 50%)"
+          :margin-left "-10px")
         `(button
           :background "transparent"
           :color "inherit"
@@ -496,7 +503,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                    :id "input"
                                    :value (prompter:input prompt-buffer)))
                      (:div :id "prompt-modes" :class "arrow-left" "")
-                     (:div :id "close-button"
+                     (:div :id "close-button" :class "arrow-left"
                            (:nbutton
                              :text "×"
                              :title "Close prompt"


### PR DESCRIPTION
# Description

Prompt buffer usability fixes :-)

Fixes # (issue)
https://github.com/atlas-engineer/nyxt/issues/2687

# Discussion
I was not able to achieve the chamfer/triangle on the bottom right. It would involve many changes to the prompt buffer to get the CSS to work, and even them, I'm not even sure it *would* work.

I will leave that for a subsequent PR. Something is better than nothing, and I believe this to be a strong improvement.

![Screenshot_20230306_004823](https://user-images.githubusercontent.com/1691662/223038819-f6679307-6019-4818-a17c-2b496290920b.png)

