### PR TITLE
Alternative style for <pre> code listings.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -129,8 +129,8 @@ See also the `profile' slot in the `browser' class.")
             `(pre
               :overflow "auto"
               :color ,theme:on-background
-              :background-color ,theme:secondary
-              :border-radius "2px"
+              :background-color ,theme:background
+              :border "2px" solid ,theme:primary
               :padding "5px")
             `("table, th, td"
               :border-color ,theme:secondary

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -711,4 +711,6 @@ like buttons.")
   (:ul
    (:li "Trying to delete a hanged buffer destroys it, instead of leaving it dangling forever.")))
 
-(define-version "3-pre-release-5")
+(define-version "3-pre-release-5"
+  (:ul
+   (:li "Code listings on manual and help system are more readable.")))


### PR DESCRIPTION
# Description

@jmercouris expressed the worry that code listings on Nyxt pages are not intelligible enough. This PR tries to address this problem by turning all code blocks in Nyxt into bordered boxes with regular background and text colors. It's clear, it's contrasting, it's simple. See the attached screenshot for how it looks now:

![pre-restyle](https://user-images.githubusercontent.com/57838654/223720397-08e283b0-2665-4cbd-9d51-a85b76c4958c.png)

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.