### PR TITLE
Prompt buffer buttons

### DIFF
--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -165,6 +165,9 @@ See `nyxt::attribute-widths'.")
            :white-space "nowrap"
            :height "20px"
            :overflow "auto")
+          ("tr:hover"
+           :cursor "pointer"
+           :font-weight "bold")
           (th
            :background-color ,theme:primary
            :color ,theme:on-primary
@@ -430,7 +433,6 @@ an integer."))
                                             (- suggestion-index cursor-index))
                                            (prompter:run-action-on-return
                                             (current-prompt-buffer))))
-
                           (loop for (nil attribute attribute-display)
                                 in (prompter:active-attributes suggestion :source source)
                                 collect (:td :title attribute

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -420,43 +420,28 @@ an integer."))
                 for suggestion-index from (max 0 (- cursor-index (/ max-suggestion-count 2)))
                 for suggestion in (nthcdr suggestion-index (prompter:suggestions source))
                 collect
-                (let ((suggestion-index suggestion-index)
-                      (cursor-index cursor-index))
-                  (:tr :id (when (equal (list suggestion source)
-                                        (multiple-value-list (prompter:%current-suggestion prompt-buffer)))
-                             "selection")
-                       :class (when (prompter:marked-p source (prompter:value suggestion))
-                                "marked")
-                       :onmousedown (when (mouse-support-p prompt-buffer)
-                                      (ps:ps
-                                       (lambda (event)
-                                         (nyxt/ps:lisp-eval
-                                          (:title "choose-this-suggestion"
-                                                  :buffer prompt-buffer)
-                                          (prompter::set-current-suggestion
-                                           (current-prompt-buffer)
-                                           (- suggestion-index cursor-index)))
-                                         (cond
-                                           ;; Ctrl-click to mark a single suggestion.
-                                           ;; TODO: Shift-click to mark a region.
-                                           ((or (ps:@ event meta-key)
-                                                (ps:@ event ctrl-key))
-                                            (nyxt/ps:lisp-eval
-                                             (:title "mark-this-suggestion"
-                                                     :buffer prompt-buffer)
-                                             (funcall (read-from-string "nyxt/prompt-buffer-mode:toggle-mark")
-                                                      prompt-buffer)))
-                                           (t (nyxt/ps:lisp-eval
-                                               (:title "return-this-suggestion"
-                                                       :buffer prompt-buffer)
-                                               (prompter:run-action-on-return
-                                                (nyxt::current-prompt-buffer))))))))
-                       (loop for (nil attribute attribute-display)
-                               in (prompter:active-attributes suggestion :source source)
-                             collect (:td :title attribute
-                                          (if attribute-display
-                                              (:raw attribute-display)
-                                              attribute))))))))))
+                   (let ((suggestion-index suggestion-index)
+                         (cursor-index cursor-index))
+                     (:tr :id (when (equal (list suggestion source)
+                                           (multiple-value-list (prompter:%current-suggestion prompt-buffer)))
+                                "selection")
+                          :class (when (prompter:marked-p source (prompter:value suggestion))
+                                   "marked")
+                          :onclick (ps:ps (nyxt/ps:lisp-eval
+                                           (:title "choose-this-suggestion"
+                                            :buffer prompt-buffer)
+                                           (prompter::set-current-suggestion
+                                            (current-prompt-buffer)
+                                            (- suggestion-index cursor-index))
+                                           (prompter:run-action-on-return
+                                            (current-prompt-buffer))))
+
+                          (loop for (nil attribute attribute-display)
+                                in (prompter:active-attributes suggestion :source source)
+                                collect (:td :title attribute
+                                             (if attribute-display
+                                                 (:raw attribute-display)
+                                                 attribute))))))))))
 
 (export 'prompt-render-suggestions)
 (defmethod prompt-render-suggestions ((prompt-buffer prompt-buffer))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -49,6 +49,11 @@ some point.")
      (hide-single-source-header-p
       nil
       :documentation "Hide source header when there is only one.")
+     (mouse-support-p
+      t
+      :type boolean
+      :documentation "Whether to allow mouse events to set and return the
+current suggestion in the prompt buffer.")
      (dynamic-attribute-width-p
       nil
       :type boolean
@@ -424,21 +429,23 @@ an integer."))
                                 "selection")
                           :class (when (prompter:marked-p source (prompter:value suggestion))
                                    "marked")
-                          :onmousemove (ps:ps (nyxt/ps:lisp-eval
-                                               (:title "select-this-suggestion"
-                                                :buffer prompt-buffer)
-                                               (prompter::set-current-suggestion
-                                                (current-prompt-buffer)
-                                                (- suggestion-index cursor-index))
-                                               (prompt-render-suggestions prompt-buffer)))
-                          :onclick (ps:ps (nyxt/ps:lisp-eval
-                                           (:title "choose-this-suggestion"
-                                            :buffer prompt-buffer)
-                                           (prompter::set-current-suggestion
-                                            (current-prompt-buffer)
-                                            (- suggestion-index cursor-index))
-                                           (prompter:run-action-on-return
-                                            (current-prompt-buffer))))
+                          :onmousemove (when (mouse-support-p prompt-buffer)
+                                         (ps:ps (nyxt/ps:lisp-eval
+                                                 (:title "select-this-suggestion"
+                                                  :buffer prompt-buffer)
+                                                 (prompter::set-current-suggestion
+                                                  (current-prompt-buffer)
+                                                  (- suggestion-index cursor-index))
+                                                 (prompt-render-suggestions prompt-buffer))))
+                          :onclick (when (mouse-support-p prompt-buffer)
+                                     (ps:ps (nyxt/ps:lisp-eval
+                                             (:title "choose-this-suggestion"
+                                              :buffer prompt-buffer)
+                                             (prompter::set-current-suggestion
+                                              (current-prompt-buffer)
+                                              (- suggestion-index cursor-index))
+                                             (prompter:run-action-on-return
+                                              (current-prompt-buffer)))))
                           (loop for (nil attribute attribute-display)
                                 in (prompter:active-attributes suggestion :source source)
                                 collect (:td :title attribute

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -166,8 +166,7 @@ See `nyxt::attribute-widths'.")
            :height "20px"
            :overflow "auto")
           ("tr:hover"
-           :cursor "pointer"
-           :font-weight "bold")
+           :cursor "pointer")
           (th
            :background-color ,theme:primary
            :color ,theme:on-primary
@@ -425,6 +424,13 @@ an integer."))
                                 "selection")
                           :class (when (prompter:marked-p source (prompter:value suggestion))
                                    "marked")
+                          :onmousemove (ps:ps (nyxt/ps:lisp-eval
+                                               (:title "select-this-suggestion"
+                                                :buffer prompt-buffer)
+                                               (prompter::set-current-suggestion
+                                                (current-prompt-buffer)
+                                                (- suggestion-index cursor-index))
+                                               (prompt-render-suggestions prompt-buffer)))
                           :onclick (ps:ps (nyxt/ps:lisp-eval
                                            (:title "choose-this-suggestion"
                                             :buffer prompt-buffer)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -474,6 +474,16 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                       "display:none;"
                                       "display:revert")
                            (:nbutton
+                             :text "↓"
+                             :title "Next source"
+                             :buffer prompt-buffer
+                             (funcall (sym:resolve-symbol :next-source :command)))
+                           (:nbutton
+                             :text "↑"
+                             :title "Previous source"
+                             :buffer prompt-buffer
+                             (funcall (sym:resolve-symbol :previous-source :command)))
+                           (:nbutton
                              :text "⚙"
                              :title "Toggle columns"
                              :buffer prompt-buffer

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -49,11 +49,6 @@ some point.")
      (hide-single-source-header-p
       nil
       :documentation "Hide source header when there is only one.")
-     (mouse-support-p
-      t
-      :type boolean
-      :documentation "Whether to allow mouse events to set and return the
-current suggestion in the prompt buffer.")
      (dynamic-attribute-width-p
       nil
       :type boolean

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -480,7 +480,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                              (funcall (sym:resolve-symbol :previous-source :command)))
                            (:nbutton
                              :text "⚙"
-                             :title "Toggle columns"
+                             :title "Toggle attributes display"
                              :buffer prompt-buffer
                              (funcall (sym:resolve-symbol :toggle-attributes-display :command)))
                            (prompter:name source)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -473,6 +473,11 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                                            (sera:single sources))
                                       "display:none;"
                                       "display:revert")
+                           (:nbutton
+                             :text "⚙"
+                             :title "Toggle columns"
+                             :buffer prompt-buffer
+                             (funcall (sym:resolve-symbol :toggle-attributes-display :command)))
                            (prompter:name source)
                            (if (prompter:hide-suggestion-count-p source)
                                ""


### PR DESCRIPTION
# Description

This includes prompt level buttons to iterate through the sources and set the the visible attributes/columns.

I would like to change the spacing between the buttons, but I cannot use a `:nbutton` to do this I have to use a `:a` with the `:class` button instead. For some reason WebKit makes it impossible to move the buttons closer to each other. In any case, this completes the objectives of Thomas.

![Screenshot_20230308_181759](https://user-images.githubusercontent.com/1691662/223882545-b8522937-ac0c-4aec-99e9-6c5b4b3e996e.png)
![Screenshot_20230308_181816](https://user-images.githubusercontent.com/1691662/223882548-45923eb4-7de7-402a-99f1-b73549c6acb8.png)
