### PR TITLE
Refactor `:nselect`, `:nbutton`, `:ninput` for debuggability and maintainability

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,29 +11,30 @@ Mention there any suspicious parts of the new code, or the ideas that you'd like
 # Checklist:
 Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.
 
-- [ ] I have pulled from master before submitting this PR
-- [ ] There are no merge conflicts.
+- [ ] Git hygiene:
+  - I have pulled from master before submitting this PR
+  - There are no merge conflicts.
 - [ ] I've added the new dependencies as:
-  - [ ] ASDF dependencies,
-  - [ ] Git submodules,
+  - ASDF dependencies,
+  - Git submodules,
     ```sh
 	cd /path/to/nyxt/checkout
     git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
     ```
-  - [ ] and Guix dependencies.
+  - and Guix dependencies.
 - [ ] My code follows the style guidelines for Common Lisp code. See:
   - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
   - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
 - [ ] I have performed a self-review of my own code.
 - [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
 - [ ] Documentation:
-  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
-  - [ ] I have updated the existing documentation to match my changes.
-  - [ ] I have commented my code in hard-to-understand areas.
-  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
-  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
-  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
+  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
+  - I have updated the existing documentation to match my changes.
+  - I have commented my code in hard-to-understand areas.
+  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
+  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
+  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
 - [ ] Compilation and tests:
-  - [ ] My changes generate no new warnings.
-  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
-  - [ ] I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
+  - My changes generate no new warnings.
+  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
+  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,13 +85,19 @@ jobs:
         rm -f nyxt
         make all LISP=ros LISP_FLAGS="${{ matrix.rosargs }} run -- --no-userinit --non-interactive"
 
+    # Load tests separately to not clutter the test output.
+    - name: Load tests
+      shell: bash
+      run: |
+        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)' -e  '(handler-bind ((error (lambda (a) (uiop:print-backtrace) (format *error-output* "~a~&" a) (uiop:quit 17)))) (asdf:load-system :nyxt/tests))'
+
     - name: Run tests
       shell: bash
       # Export CI to tell ASDF to quit on test errors.
       env:
        NASDF_TESTS_QUIT_ON_FAIL: yes
       run: |
-        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)' -e '(handler-bind ((error (lambda (a) (uiop:print-backtrace) (format *error-output* "~a~&" a) (uiop:quit 17)))) (asdf:load-system :nyxt/tests))' -e '(asdf:test-system :nyxt)'
+        ros ${{ matrix.rosargs }} -e '(asdf:load-system :nyxt/submodules)' -e '(asdf:test-system :nyxt)'
 
     - name: Validate make-instance symbols
       shell: bash

--- a/documents/README.org
+++ b/documents/README.org
@@ -507,8 +507,8 @@ obvious).
 
 Nyxt uses the following branches:
 
-- =master= for development;
-- =<feature-branches>= for very particular situations;
+- =master=  :: for development;
+- <feature-branches> :: for very particular situations;
 - =<2,3,...>-series= to backport commits corresponding to specific major
   versions.
 
@@ -525,7 +525,8 @@ The names of the branches really matter since the merge commit references them,
 so please take that into account!
 
 After the changed are merged, please do not forget to delete obsolete or
-dangling branches.
+dangling branches. If you merge the remote branch instead of the local one, then
+GitHub deletes the remote branch automatically.
 
 Note to core contributors: since you have commit access, you can push trivial
 changes directly to the target branch (skipping the review process).  The merge
@@ -560,6 +561,9 @@ We've also developed some of our own:
   systematic uses of Serapeum:
   - =sera:eval-always=;
   - =export-always=;
+  - =sera:and-let*=;
+  - =sera:lret=;
+  - =sera:single=
   - =->= (declaimed types).
 - Use =funcall*= to not error when function does not exist.
 - Prefer classes over structs.  Rationale:
@@ -600,23 +604,25 @@ When =slot-value= is the only parameter specified then:
   explicit call to =defgeneric=, not with just calls to =defmethod=.  This
   enables proper source location of the generic function (otherwise it cannot be
   found), plus it lets you write different documentation for the generic and the
-  the specialized methods.
-- We use the =%foo%= naming convention for special local variables, but this is
-  rare and ideally they should be avoided.
+  specialized methods.
+- We use the =%foo%= naming convention for special local variables. But special
+  variables are rare and ideally they should be avoided.
 - We suffix predicates with =-p=.  Unlike the usual convention, we always use a
-  =-= even for single words.
+  hyphen even for single word predicates.
 - Prefer the term =url= over =uri=.
-- URLs should be of type =quri:uri=.  If you need to manipulate a URL string,
-  call it =url-string=.
+- URLs should be of type =quri:uri=.  If you need to manipulate a URL string, call
+  it =url-string=. In case the value contains a URL, but is not =quri:url=, use
+  =url-designator= and its =url= method to normalize into =quri:uri=.
 - Paths should be of type =cl:pathname=.
   Use =uiop:native-namestring= to "send" to OS-facing functions,
   =uiop:ensure-pathname= to "receive" from OS-facing functions or to "trunamize".
 - Prefer =handler-bind= over =handler-case=: when running from the REPL, this
   triggers the debugger with a full stacktrace; when running the Nyxt binary,
   all conditions are caught anyway.
-- Do not handle the =T= condition, this may break everything.  Handle =error= or
-  exceptionally =condition= (for instance if you do not control the called code, and
-  some libraries subclass =condition= instead of =error=).
+- Do not handle the =T= condition, this may break everything.  Handle =error=,
+  =serious-condition=, or exceptionally =condition= (for instance if you do not
+  control the called code, and some libraries subclass =condition= instead of
+  =error=).
 - Dummy variables are called =_=.
 - Prefer American spelling.
 

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -717,8 +717,7 @@ like buttons.")
    (:li "The REPL features " (:nxref :class-name 'nyxt/repl-mode:shell-cell "shell cells")
         ", which pass commands to the underlying system shell.")
    (:li "The prompt buffer tab interface has been updated. Tabs are stably sorted and do
-not shuffle around. It is now possible to middle click to delete tabs by middle
-clicking."))
+not shuffle around. It is now possible to middle click to delete tabs."))
 
   (:h3 "Programming interface")
   (:ul

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -721,8 +721,8 @@ not shuffle around. It is now possible to middle click to delete tabs."))
 
   (:h3 "Programming interface")
   (:ul
-   (:li "Spinneret tags like " (:code ":nxref") " and " (:code ":ncode")
-        " are refactored for debuggability and obviousness.")
+   (:li "Spinneret tags like " (:code ":nxref") ", " (:code ":ncode") ", and "
+        (:code ":nbutton") " are refactored for debuggability and obviousness.")
    (:li "New " (:code "ntoc") " tag for Table of Contents generation.")
    (:li "The REPL is extensible via " (:nxref :class-name 'nyxt/repl-mode:cell "cell class")
         " and its methods.")))

--- a/source/debugger.lisp
+++ b/source/debugger.lisp
@@ -44,7 +44,7 @@ See `ndebug:condition-wrapper' for documentation."))
   (spinneret:with-html-string
     (dolist (restart (ndebug:restarts wrapper))
       (:nbutton :text (format nil "[~a] ~a" (dissect:name restart) (dissect:report restart))
-        (ndebug:invoke wrapper restart)))))
+        `(ndebug:invoke ,wrapper ,restart)))))
 
 (defun backtrace->html (wrapper)
   (spinneret:with-html-string

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -204,12 +204,12 @@ useful actions there, including the familiar " (:code "set-url") ", " (:code "hi
 ", and " (:code "history-forwards") ".")
     (:div (:nbutton :text "I want to know more, show me the manual!"
             :buffer panel
-            (manual))
+            '(manual))
           (:nbutton
             :buffer panel
             :class "accent"
             :text "Got it, close this panel"
-            (delete-panel-buffer :panels panel)))))
+            `(delete-panel-buffer :panels ,panel)))))
 
 (define-internal-page-command-global new ()
     (buffer "*New buffer*")
@@ -289,9 +289,9 @@ useful actions there, including the familiar " (:code "set-url") ", " (:code "hi
       (:h1 :class "accent" "Nyxt")
       (:i "The Internet on your terms.")
       (:div (:nbutton :text "Start searching!"
-              (set-url :prefill-current-url-p nil)))
+              '(set-url :prefill-current-url-p nil)))
       (:div (:nbutton :text "How do I..."
-              (intro))))
+              '(intro))))
      (:p :class "copyright"
          (format nil "Nyxt/~a ~a" (name *renderer*) +version+)
          (:br)
@@ -368,11 +368,11 @@ System information is also saved to clipboard."
          (:h1 :id "title" "Nyxt " (:span :id "subtitle" "browser ☺"))
          (:h3 (time:format-timestring nil (time:now) :format time:+rfc-1123-format+))
          (:nbutton :text "🗁 Restore Session"
-           (nyxt::restore-history-by-name))
+           '(nyxt::restore-history-by-name))
          (:a :class "button" :href (nyxt-url 'manual) "🕮 Manual")
          (:nbutton
            :text "≡ Execute Command"
-           (nyxt::execute-command))
+           '(nyxt::execute-command))
          (:a :class "button" :href "https://nyxt.atlas.engineer/download" "⇡ Update"))
         (:h3 (:b "Recent URLs"))
         (:ul (:raw (history-html-list :limit 50)))

--- a/source/mode/buffer-listing.lisp
+++ b/source/mode/buffer-listing.lisp
@@ -42,12 +42,12 @@ With LINEAR-VIEW-P, list buffers linearly instead."
                  (:p (:nbutton
                        :text "✕"
                        :title "Delete buffer"
-                       (nyxt::delete-buffer :buffers buffer)
-                       (reload-buffer listing-buffer))
+                       `(nyxt::delete-buffer :buffers ,buffer)
+                       `(reload-buffer ,listing-buffer))
                      (:nbutton
                        :text "→"
                        :title "Switch to buffer"
-                       (nyxt::switch-buffer :buffer buffer) )
+                       `(nyxt::switch-buffer :buffer ,buffer))
                      (:a :href (render-url (url buffer))
                          (if (uiop:emptyp (title buffer))
                              (render-url (url buffer))
@@ -69,10 +69,10 @@ With LINEAR-VIEW-P, list buffers linearly instead."
       (:h1 "Buffers")
       (:nbutton
         :text "Tree display"
-        (nyxt/buffer-listing-mode::list-buffers))
+        '(nyxt/buffer-listing-mode::list-buffers))
       (:nbutton
         :text "Linear display"
-        (nyxt/buffer-listing-mode::list-buffers :linear-view-p t))
+        '(nyxt/buffer-listing-mode::list-buffers :linear-view-p t))
       (:br)
       (:div
        (if cluster
@@ -99,7 +99,7 @@ With LINEAR-VIEW-P, list buffers linearly instead."
            (spinneret:with-html-string
              (:p (:nbutton :text (title buffer)
                    :buffer panel-buffer
-                   (nyxt::switch-buffer :buffer buffer))))))
+                   `(nyxt::switch-buffer :buffer ,buffer))))))
     (spinneret:with-html-string
       (:nstyle (lass:compile-and-write
                 '(.button
@@ -111,12 +111,12 @@ With LINEAR-VIEW-P, list buffers linearly instead."
        (:h1 "Buffers")
        (:nbutton :text "Update ↺"
          :buffer panel-buffer
-         (reload-buffer
-          (find
-           (render-url (url panel-buffer))
-           (nyxt::panel-buffers (current-window))
-           :test #'string=
-           :key (compose
-                 #'render-url #'url))))
+         `(reload-buffer
+           (find
+            (render-url (url ,panel-buffer))
+            (nyxt::panel-buffers (current-window))
+            :test #'string=
+            :key (compose
+                  #'render-url #'url))))
        (loop for buffer in (buffer-list)
              collect (:raw (buffer-markup buffer)))))))

--- a/source/mode/macro-edit.lisp
+++ b/source/mode/macro-edit.lisp
@@ -25,9 +25,9 @@
            collect (:tr (:td (:nbutton :class "button"
                                :text "✕"
                                :title "Remove from the macro"
-                               (nyxt/macro-edit-mode::remove-function
-                                (find-submode 'macro-edit-mode)
-                                index)))
+                               `(nyxt/macro-edit-mode::remove-function
+                                 (find-submode 'macro-edit-mode)
+                                 ,index)))
                         (:td
                          (:a.button
                           :title "Help"
@@ -51,7 +51,7 @@
     (:p "Commands")
     (:p (:nbutton
           :text "+ Add command"
-          (nyxt/macro-edit-mode::add-command)))
+          '(nyxt/macro-edit-mode::add-command)))
     (:div
      :id "commands"
      (:raw
@@ -61,10 +61,10 @@
     (:hr)
     (:nbutton
       :text "Save macro"
-      (nyxt/macro-edit-mode::save-macro))
+      '(nyxt/macro-edit-mode::save-macro))
     (:nbutton
       :text "Compile macro"
-      (nyxt/macro-edit-mode::evaluate-macro))))
+      '(nyxt/macro-edit-mode::evaluate-macro))))
 
 (defmethod add-function ((macro-editor macro-edit-mode) command)
   (alex:appendf (functions macro-editor)

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -114,10 +114,10 @@ meaningful values."))
     (spinneret:with-html-string
       (:ninput
         :autofocus (eq (current-cell (current-mode :repl)) cell)
-        :onfocus (focus-cell cell)
-        :onchange (setf (input cell)
-                        (ps-eval
-                          (ps:@ (nyxt/ps:active-element document) value)))
+        :onfocus `(focus-cell ,cell)
+        :onchange `(setf (input ,cell)
+                         (ps-eval
+                           (ps:@ (nyxt/ps:active-element document) value)))
         (input cell))))
   (:documentation "Generate HTML for the input area of the CELL.
 Generic function to specialize against new REPL cell types.

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -477,17 +477,17 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                              :text "↓"
                              :title "Next source"
                              :buffer prompt-buffer
-                             (funcall (sym:resolve-symbol :next-source :command)))
+                             '(funcall (sym:resolve-symbol :next-source :command)))
                            (:nbutton
                              :text "↑"
                              :title "Previous source"
                              :buffer prompt-buffer
-                             (funcall (sym:resolve-symbol :previous-source :command)))
+                             '(funcall (sym:resolve-symbol :previous-source :command)))
                            (:nbutton
                              :text "⚙"
                              :title "Toggle attributes display"
                              :buffer prompt-buffer
-                             (funcall (sym:resolve-symbol :toggle-attributes-display :command)))
+                             '(funcall (sym:resolve-symbol :toggle-attributes-display :command)))
                            (prompter:name source)
                            (if (prompter:hide-suggestion-count-p source)
                                ""
@@ -535,7 +535,7 @@ This does not redraw the whole prompt buffer, unlike `prompt-render'."
                              :text "×"
                              :title "Close prompt"
                              :buffer prompt-buffer
-                             (funcall (sym:resolve-symbol :quit-prompt-buffer :command)))))
+                             '(funcall (sym:resolve-symbol :quit-prompt-buffer :command)))))
                (:div :id "suggestions"
                      :style (if (invisible-input-p prompt-buffer)
                                 "visibility:hidden;"

--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -25,25 +25,6 @@
     (declare (ignorable keys))
     `(:script ,@attrs (:raw ,@body))))
 
-(serapeum:eval-always
-  (defun remove-smart-quoting (form)
-    "If the form is quoted or quasi-quoted, return the unquoted/evaluated variant.
-Otherwise, return the form as is."
-    (cond
-      ((and (listp form)
-            (eq 'quote (first form)))
-       (second form))
-      #+(or sbcl ecl)
-      ((and (listp form)
-            (eq #+sbcl 'sb-int:quasiquote
-                #+ecl 'si:quasiquote
-                ;; FIXME: CCL expands quasiquote to
-                ;; `list*' call.
-                ;; TODO: Other implementations?
-                (first form)))
-       (eval form))
-      (t form))))
-
 (serapeum:-> %nselect-onchange (string (nyxt:maybe nyxt:buffer) (nyxt:list-of list)) t)
 (defun %nselect-onchange (id buffer clauses)
   "Compiles the CLAUSES body into Parenscript code.

--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -44,53 +44,84 @@ Otherwise, return the form as is."
        (eval form))
       (t form))))
 
-(deftag :nselect (body attrs &rest keys &key (id (alexandria:required-argument 'id)) &allow-other-keys)
+(serapeum:-> %nselect-onchange (string (nyxt:maybe nyxt:buffer) (nyxt:list-of list)) t)
+(defun %nselect-onchange (id buffer clauses)
+  "Compiles the CLAUSES body into Parenscript code.
+Parenscript fetches values from <select> with ID and evaluates the respective
+forms in BUFFER."
+  (let ((buffer (or buffer (nyxt:current-buffer))))
+    (ps:ps*
+     (with-ps-gensyms (var inner-var)
+       `(nyxt/ps:lisp-eval
+         (:title ,(format nil "nselect ~a choice" id)
+                 ,@(when buffer
+                     `(:buffer ,buffer)))
+         (let ((,var (alexandria:ensure-list
+                      (nyxt:ps-eval
+                        (ps:chain *Array (from (ps:chain (nyxt/ps:qs document (+ "#" (ps:lisp ,id)))
+                                                         selected-options))
+                                  (map (lambda (e) (ps:@ e value))))))))
+           (dolist (,inner-var ,var)
+             (str:string-case ,inner-var
+               ,@(loop for (clause . forms) in clauses
+                       for value = (first (uiop:ensure-list clause))
+                       collect (cons (nyxt:prini-to-string value)
+                                     forms))))))))))
+
+(serapeum:-> %nselect-options ((nyxt:list-of list)) t)
+(defun %nselect-options (clauses)
+  "Produces a set of options for :nselect based on CLAUSES list."
+  (spinneret:with-html-string
+    (loop for (value display title) in (mapcar (alexandria:compose #'uiop:ensure-list #'first) clauses)
+          collect (:option
+                   :value (nyxt:prini-to-string value)
+                   (when title
+                     (list :title title))
+                   (string-capitalize (or display (nyxt:prini-to-string value)))))))
+
+(deftag :nselect (body attrs &rest keys &key default (id (alexandria:required-argument 'id)) buffer &allow-other-keys)
   "Generate <select> tag from the BODY resembling cond clauses.
 
-BODY forms can be of two kinds:
+BODY can be:
+- Multiple forms, each following/producing one of the formats:
+  - (VALUE . FORMS) -- creates <option value=\"value\">value</option> and runs
+    FORMS when it's selected.
+  - ((VALUE DISPLAY TITLE) . FORMS) -- creates an <option value=\"value\"
+    title=\"title\">display</option> and runs FORMS when it's selected. DISPLAY
+    and TITLE are optional literal strings.
+- A single form, expected to produce a list of forms like above.
 
-- (VALUE . FORMS) -- creates <option value=\"value\">value</option> and runs
-  FORMS when it's selected.
-
-- ((VALUE DISPLAY TITLE) . FORMS) -- creates an
-  <option value=\"value\" title=\"title\">display</option>
-  and runs FORMS when it's selected. DISPLAY and TITLE are optional literal
-  strings.
-
-In both cases, VALUE should be a literal (and printable) atom. For instance,
+In both cases, VALUEs should be literal (and printable) atoms. For instance,
 symbol, number, string, or keyword.
+
+BUFFER is a buffer to bind the actions of this tag to.
+
+DEFAULT is a string or a string-producing form that is used as the default
+option.
+
+In case some variable from the outer scope should be captured, injecting a
+closure into the clause would work best.
 
 Example:
 \(:nselect :id \"number-guessing\"
-  (1 (nyxt:echo \"Too low!\"))
-  (2 (nyxt:echo \"Correct!\"))
-  (3 (nyxt:echo \"Too high!\")))"
-  (with-gensyms (var)
-    (once-only (id)
+  :default \"Guess the number\"
+  '(1 (nyxt:echo \"Too low!\"))
+  (list 2 (nyxt:echo \"Correct!\"))
+  `(3 (funcall ,#'(lambda () (nyxt:echo \"Too high!\")))))"
+  (once-only (id)
+    (with-gensyms (body-var)
       (let ((keys keys))
         (declare (ignorable keys))
-        `(:select.button
-          ,@attrs
-          :id ,id
-          :onchange
-          (when (nyxt:current-buffer)
-            (ps:ps (nyxt/ps:lisp-eval
-                    (:title "nselect-choice")
-                    (let ((,var (nyxt:ps-eval (ps:chain (nyxt/ps:qs document (+ "#" (ps:lisp ,id))) value))))
-                      (str:string-case ,var
-                                       ,@(loop for (clause . forms) in (mapcar #'remove-smart-quoting body)
-                                               for value = (first (uiop:ensure-list clause))
-                                               collect (cons (nyxt:prini-to-string value)
-                                                             forms)))))))
-          ,@(loop for (clause) in (mapcar #'remove-smart-quoting body)
-                  for value = (first (uiop:ensure-list clause))
-                  for display = (second (uiop:ensure-list clause))
-                  for title = (third (uiop:ensure-list clause))
-                  collect `(:option
-                            :value ,(nyxt:prini-to-string value)
-                            ,@(when title
-                                (list :title title))
-                            ,(string-capitalize (or display (nyxt:prini-to-string value))))))))))
+        `(let ((,body-var ,(if (serapeum:single body)
+                               (first body)
+                               `(list ,@body))))
+           (:select.button
+            ,@attrs
+            :id ,id
+            :onchange (%nselect-onchange ,id ,buffer ,body-var)
+            ,@(when default
+                `((:option :selected t :disabled t ,default)))
+            (:raw (%nselect-options ,body-var))))))))
 
 (defun %nxref-doc (type symbol &optional (class-name (when (eq type :slot)
                                                        (alexandria:required-argument 'class-name))))
@@ -372,50 +403,47 @@ Most *-P arguments mandate whether to add the buttons for:
       (let* ((keys keys)
              (*print-escape* nil)
              (id (nyxt:prini-to-string (gensym)))
-             (select-options
-               (append
-                (when copy-p
-                  `(((copy "Copy" "Copy the code to clipboard.")
-                     (funcall (read-from-string "nyxt:ffi-buffer-copy")
-                              (nyxt:current-buffer) ,plaintext))))
-                (when config-p
-                  `(((config
-                      "Add to auto-config"
-                      (format nil "Append this code to the auto-configuration file (~a)."
-                              (nfiles:expand nyxt::*auto-config-file*)))
-                     (alexandria:write-string-into-file
-                      ,plaintext (nfiles:expand nyxt::*auto-config-file*)
-                      :if-exists :append
-                      :if-does-not-exist :create))))
-                (when repl-p
-                  `(((repl
-                      "Try in REPL"
-                      "Open this code in Nyxt REPL to experiment with it.")
-                     (nyxt:buffer-load-internal-page-focus
-                      (read-from-string "nyxt/repl-mode:repl")
-                      :form ,plaintext))))
-                (when (and file editor-p)
-                  `(((editor
-                      "Open in built-in editor"
-                      "Open the file this code comes from in Nyxt built-in editor-mode.")
-                     (funcall (read-from-string "nyxt/editor-mode:edit-file")
-                              ,file-var))))
-                (when (and file external-editor-p)
-                  `(((external-editor
-                      "Open in external editor"
-                      "Open the file this code comes from in external editor.")
-                     (uiop:launch-program
-                      (append (funcall (read-from-string "nyxt:external-editor-program")
-                                       (symbol-value (read-from-string "nyxt:*browser*")))
-                              (list (uiop:native-namestring ,file-var)))))))))
              (select-code
                `(:nselect
                   :id ,id
+                  :default "Act on code"
                   :style (unless ,inline-var
                            "position: absolute; top: 0; right: 0; margin: 0; padding: 2PX")
-                  ,@select-options)))
+                  ,@(when copy-p
+                      `(`((copy "Copy" "Copy the code to clipboard.")
+                          (funcall (read-from-string "nyxt:ffi-buffer-copy")
+                                   (nyxt:current-buffer) ,,plaintext))))
+                  ,@(when config-p
+                      `(`((config
+                           "Add to auto-config"
+                           (format nil "Append this code to the auto-configuration file (~a)."
+                                   (nfiles:expand nyxt::*auto-config-file*)))
+                          (alexandria:write-string-into-file
+                           ,,plaintext (nfiles:expand nyxt::*auto-config-file*)
+                           :if-exists :append
+                           :if-does-not-exist :create))))
+                  ,@(when repl-p
+                      `(`((repl
+                           "Try in REPL"
+                           "Open this code in Nyxt REPL to experiment with it.")
+                          (nyxt:buffer-load-internal-page-focus
+                           (read-from-string "nyxt/repl-mode:repl")
+                           :form ,,plaintext))))
+                  ,@(when (and file editor-p)
+                      `(`((editor
+                           "Open in built-in editor"
+                           "Open the file this code comes from in Nyxt built-in editor-mode.")
+                          (funcall (read-from-string "nyxt/editor-mode:edit-file")
+                                   ,,file-var))))
+                  ,@(when (and file external-editor-p)
+                      `(`((external-editor
+                           "Open in external editor"
+                           "Open the file this code comes from in external editor.")
+                          (uiop:launch-program
+                           (append (funcall (read-from-string "nyxt:external-editor-program")
+                                            (symbol-value (read-from-string "nyxt:*browser*")))
+                                   (list (uiop:native-namestring ,,file-var))))))))))
         (declare (ignorable keys))
-
         `(let* ((,body-var (list ,@body))
                 (,first (first ,body-var))
                 (,inline-var ,(if inline-provided-p

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -35,7 +35,7 @@ This leverages `mode-status' which can be specialized for individual modes."
               :buffer status
               :text "✚"
               :title (str:concat "Enabled modes: " (modes-string buffer))
-              (nyxt:toggle-modes))
+              '(nyxt:toggle-modes))
             (loop for mode in sorted-modes
                   collect
                   (let ((mode mode))
@@ -46,7 +46,7 @@ This leverages `mode-status' which can be specialized for individual modes."
                             :buffer status
                             :text formatted-mode
                             :title (format nil "Describe ~a" mode)
-                            (describe-class :class (name mode)))))))))
+                            `(describe-class :class (quote ,(name mode))))))))))
         "")))
 
 (defun modes-string (buffer)
@@ -63,27 +63,27 @@ This leverages `mode-status' which can be specialized for individual modes."
       :buffer status
       :text "←"
       :title "Backwards"
-      (nyxt/history-mode:history-backwards))
+      '(nyxt/history-mode:history-backwards))
     (:nbutton
       :buffer status
       :text "↺"
       :title "Reload"
-      (nyxt:reload-current-buffer))
+      '(nyxt:reload-current-buffer))
     (:nbutton
       :buffer status
       :text "→"
       :title "Forwards"
-      (nyxt/history-mode:history-forwards) )
+      '(nyxt/history-mode:history-forwards))
     (:nbutton
       :buffer status
       :text "≡"
       :title "Execute"
-      (nyxt:execute-command))
+      '(nyxt:execute-command))
     (:nbutton
       :buffer status
       :text "★"
       :title "Bookmark this page"
-      (funcall (read-from-string "nyxt/bookmark-mode:bookmark-current-url")))))
+      '(funcall (read-from-string "nyxt/bookmark-mode:bookmark-current-url")))))
 
 (export-always 'format-status-load-status)
 (defmethod format-status-load-status ((status status-buffer))
@@ -124,7 +124,7 @@ the URL.)"
         :buffer status
         :text content
         :title content
-        (nyxt:set-url)))))
+        '(nyxt:set-url)))))
 
 (export-always 'format-status-tabs)
 (defmethod format-status-tabs ((status status-buffer))


### PR DESCRIPTION
# Description

This continues the work of #2826 in making our tags more maintainable and splitting those into small runtime helpers (with the end goal of making them so self-sufficient that they can be moved to a separate library). This time, it's the refactoring of the interactive tags: our beloved `:nbutton` and less used `:nselect` and `:ninput`. Because of their interactive code-executing character, this PR is slightly more opinionated and needs more review.

# Discussion

You can see that all the uses of `:nbutton`, `:nselect`, and `:ninput` require quoted forms for execution. This is a significant change, so at least note that the syntax has changed. The syntax has changed for more transparency and less macro-wizardry, but it still has a certain learning curve (see the respective documentation and type declarations for reference on which values are accepted). In particular, closing over values requires either unquoting or inline closure creation. Examples:

mode/buffer-listing.lisp:
``` lisp
(:nbutton
 :text "Update ↺"
 :buffer panel-buffer
 `(reload-buffer
   (find
    ;; NOTE: unquoted:
    (render-url (url ,panel-buffer))
    (nyxt::panel-buffers (current-window))
    :test #'string=
    :key (compose
          #'render-url #'url))))
```

mode/repl.lisp:
``` lisp
(:nbutton
 :text "Edit Nyxt function"
 :title "Edit the source of one of Nyxt commands in REPL."
 ;; NOTE: Using closure here to capture repl-mode, because it's
 ;; mentioned in too much places. See `:nbutton' documentation.
 `(funcall
   ,#'(lambda ()
        (let ((functions (prompt :prompt "Function to edit"
                                 :sources (make-instance
                                           'nyxt::function-source
                                           :actions-on-return #'identity))))
          (setf (evaluations repl-mode)
                (append
                 (evaluations repl-mode)
                 (mapcar (lambda (sym)
                           (make-instance 'evaluation
                                          :input (function-lambda-string
                                                  (symbol-function sym))))
                         functions)))
          (reload-buffer (buffer repl-mode))))))
```

Does this look alright to you? @jmercouris, @aadcg?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [X] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
