### PR TITLE
Tab delete functionality

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -787,6 +787,7 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :flex-shrink "2"
               :flex-basis "144px")
             `("#tabs"
+              :line-height "24px"
               :background-color ,theme:secondary
               :color ,theme:on-secondary
               :min-width "100px"
@@ -801,14 +802,18 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :flex-basis "144px")
             `("#tabs::-webkit-scrollbar"
               :display "none")
-            `(.tab
-              :color ,theme:background
-              :white-space "nowrap"
-              :text-decoration "none"
-              :padding-left "8px"
-              :padding-right "8px")
+            `(".tab"
+              :margin-right "8px"
+              :background "transparent"
+              :color "inherit"
+              :text-decoration "transparent"
+              :border "transparent"
+              :border-radius "0.2em"
+              :padding 0
+              :font "inherit"
+              :outline "inherit")
             `(".tab:hover"
-              :opacity 0.6)
+              :cursor "pointer")
             `("#modes"
               :background-color ,theme:primary
               :color ,theme:on-primary


### PR DESCRIPTION
# Description

This allows the user to middle click to delete  a group of tabs. It additionally turns off temporal visualization for the tab area. The Tabs will no longer shuffle in the tab area when the user clicks on them.

# Question

Why does calling buffer-delete not invoke `print-status`? I thought it would have been hooked somewhere. I thought about appending to the setf handlers, but was unsure if I was just missing something silly.