### PR TITLE
libraries/web-extensions/Makefile: Fix binding against the right library

### DIFF
--- a/libraries/web-extensions/Makefile
+++ b/libraries/web-extensions/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # REVIEW: Is there a better way to find the .pc file regardless of the version suffix?
-PKG_MODULES := glib-2.0 gobject-2.0 $(shell pkg-config --list-all | awk '/^webkit2gtk-web-extension/ {print $$1}')
+PKG_MODULES := glib-2.0 gobject-2.0 $(shell pkg-config --list-all | awk '/^webkit2gtk-web-extension-4.1/ {print $$1}')
 
 # See https://stackoverflow.com/questions/5618615/check-if-a-program-exists-from-a-makefile.
 CC := $(shell command -v $(CC) 2> /dev/null || echo gcc)


### PR DESCRIPTION
# Description


Currently we only support WebKitGTK 4.1, not 5.0.  So if both are installed, we need to ensure we don't accidentally drag both as dependencies.

Fixes #2147

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - [x] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [x] I have updated the existing documentation to match my changes.
  - [x] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [x] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [x] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - [ ] My changes generate no new warnings.
  - [ ] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [ ] New and existing unit tests pass locally with my changes.
