### PR TITLE
NTOC tag

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -724,5 +724,6 @@ clicking."))
   (:ul
    (:li "Spinneret tags like " (:code ":nxref") " and " (:code ":ncode")
         " are refactored for debuggability and obviousness.")
+   (:li "New " (:code :ntoc) " tag for Table of Contents generation.")
    (:li "The REPL is extensible via " (:nxref :class-name 'nyxt/repl-mode:cell "cell class")
         " and its methods.")))

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -5,13 +5,13 @@
 
 (export-always 'manual-content)
 (defun manual-content ()
-  (str:concat
-   (spinneret:with-html-string
-     (:h1 "Nyxt manual")
-     (:p "This manual first includes the tutorial, then covers the configuration
-of Nyxt."))
-   (tutorial-content)
-   (manual-sections)))
+  (spinneret:with-html-string
+    (:h1 "Nyxt manual")
+    (:p "This manual first includes the tutorial, then covers the configuration
+of Nyxt.")
+    (:ntoc
+      (:raw (tutorial-content))
+      (:raw (manual-sections)))))
 
 (defun manual-sections ()
   (spinneret:with-html-string
@@ -251,8 +251,8 @@ the buffers. If you create a new buffer (via " (:nxref :command 'nyxt/hint-mode:
 from the branch of the previous buffer.")
         (:p "History can be navigated with the arrow keys in the status buffer, or with
 commands like " (:nxref :command 'nyxt/history-mode:history-backwards) " and "
-            (:nxref :command 'nyxt/history-mode:history-forwards)
-            " (which the arrows are bound to).")
+(:nxref :command 'nyxt/history-mode:history-forwards)
+" (which the arrows are bound to).")
         (:p "If the beyond-buffer-boundaries behavior sounds like too much to you, or you
 prefer the behavior of Nyxt 2, where the history was still a tree, but was not
 spilling across the buffers, then configure "


### PR DESCRIPTION
# Description

This adds a table of contents tag that uses its own body to generate the TOC.

Based on the interactive tags branch, for no particular reason.

I'll merge it after the interactive tags are merged.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] I have pulled from master before submitting this PR
- [X] There are no merge conflicts.
- [X] I've added the new dependencies as:
  - [X] ASDF dependencies,
  - [X] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [X] and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - [X] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [X] I have updated the existing documentation to match my changes.
  - [X] I have commented my code in hard-to-understand areas.
  - [x] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [X] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [X] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - [X] My changes generate no new warnings.
  - [X] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [X] New and existing unit tests pass locally with my changes.
