### PR TITLE
Refactor tabs UI

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -792,26 +792,38 @@ store them somewhere and `ffi-buffer-delete' them once done."))
             `("#tabs"
               :background-color ,theme:secondary
               :color ,theme:on-secondary
+              :line-height "22px"
               :min-width "100px"
               :white-space "nowrap"
               :overflow-x "scroll"
               :text-align "left"
-              :padding-left "15px"
-              :padding-right "10px"
+              :padding-left "20px"
+              :padding-right "20px"
               :z-index "1"
               :flex-grow "10"
               :flex-shrink "4"
               :flex-basis "144px")
             `("#tabs::-webkit-scrollbar"
               :display "none")
-            `(.tab
-              :color ,theme:background
-              :white-space "nowrap"
-              :text-decoration "none"
-              :padding-left "8px"
-              :padding-right "8px")
+            `(".tab"
+              :background-color ,theme:background-alternate
+              :color ,theme:on-background-alternate
+              :opacity 0.6
+              :display "inline-block"
+              :margin-top "1px"
+              :padding-left "18px"
+              :padding-right "18px"
+              :margin-right "-8px"
+              :margin-left "-9px"
+              :text-decoration "transparent"
+              :border "transparent"
+              :border-radius "1px"
+              :font "inherit"
+              :outline "inherit"
+              :clip-path "polygon(20px 0%, 100% 0%, calc(100% - 20px) 100%, 0% 100%)")
             `(".tab:hover"
-              :opacity 0.6)
+              :opacity 0.8
+              :cursor "pointer")
             `("#modes"
               :background-color ,theme:primary
               :color ,theme:on-primary
@@ -839,10 +851,9 @@ store them somewhere and `ffi-buffer-delete' them once done."))
               :opacity 0.6)
             `((:and .button (:or :visited :active))
               :color ,theme:background)
-            `(.plain
-              :padding-left "6px"
-              :padding-right "6px"
+            `(.selected-tab
               :color ,theme:on-background
+              :opacity "1.0 !important"
               :background-color ,theme:background))))
   (:export-class-name-p t)
   (:export-accessor-names-p t)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -806,8 +806,8 @@ store them somewhere and `ffi-buffer-delete' them once done."))
             `("#tabs::-webkit-scrollbar"
               :display "none")
             `(".tab"
-              :background-color ,theme:background-alternate
-              :color ,theme:on-background-alternate
+              :background-color ,theme:background
+              :color ,theme:on-background
               :opacity 0.6
               :display "inline-block"
               :margin-top "1px"

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1202,12 +1202,12 @@ This is a low-level function.  See `buffer-delete' for the high-level version."
   (when *browser*
     (setf (gethash id (slot-value *browser* 'buffers)) buffer)
     ;; Force setf call so that slot is seen as changed, e.g. by status buffer watcher.
-    (setf (slot-value *browser* 'buffers) (slot-value *browser* 'buffers))))
+    (setf (buffers *browser*) (buffers *browser*))))
 
 (defun buffers-delete (id)
   (remhash id (slot-value *browser* 'buffers))
   ;; Force setf call so that slot is seen as changed, e.g. by status buffer watcher.
-  (setf (slot-value *browser* 'buffers) (slot-value *browser* 'buffers)))
+  (setf (buffers *browser*) (buffers *browser*)))
 
 (export-always 'window-list)
 (defun window-list ()

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -733,6 +733,9 @@ store them somewhere and `ffi-buffer-delete' them once done."))
    (glyph-mode-presentation-p
     nil
     :documentation "Display the modes as a list of glyphs.")
+   (display-tabs-by-last-access-p
+    nil
+    :documentation "Whether tabs are dynamically ordered by last access time.")
    (style (theme:themed-css (theme *browser*)
             `(body
               :line-height "20px"

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -155,11 +155,16 @@ the URL.)"
                               (nyxt/ps:lisp-eval
                                (:title "delete-tab-group"
                                 :buffer status)
-                               (if-confirm ((format nil "Delete all buffers with domain: ~a?" tab-display-text))
-                                   (mapcar #'nyxt::buffer-delete
-                                           (if (internal-url-p url)
-                                               internal-buffers
-                                               (sera:filter (match-domain domain) (buffer-list))))))
+                               (let ((buffers-to-delete
+                                       (if (internal-url-p url)
+                                           internal-buffers
+                                           (sera:filter (match-domain domain) (buffer-list)))))
+                                 (prompt
+                                  :prompt "Delete buffer(s)"
+                                  :sources (make-instance 'buffer-source
+                                                          :constructor buffers-to-delete
+                                                          :marks buffers-to-delete
+                                                          :actions-on-return (list (lambda-mapped-command buffer-delete))))))
                               (nyxt/ps:lisp-eval
                                (:title "select-tab-group"
                                 :buffer status)

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -128,54 +128,48 @@ the URL.)"
 
 (export-always 'format-status-tabs)
 (defmethod format-status-tabs ((status status-buffer))
-  (flet ((domains (buffers)
-           (remove-duplicates
-            (sera:filter-map #'quri:uri-domain
-                             (remove-if #'internal-url-p
-                                        (mapcar #'url (sort-by-time buffers))))
-            :test #'equal)))
+  (let* ((buffers (if (display-tabs-by-last-access-p status)
+                      (sort-by-time (buffer-list))
+                      (reverse (buffer-list))))
+         (domain-deduplicated-urls (remove-duplicates
+                                    (mapcar #'url buffers)
+                                    :test #'string=
+                                    :key #'quri:uri-domain)))
     (spinneret:with-html-string
-      (alex:when-let ((internal-buffers (remove-if-not #'internal-url-p (sort-by-time (buffer-list)) :key #'url)))
-        (:span
-         :class (if (internal-url-p (url (current-buffer)))
-                    "plain tab"
-                    "tab")
-         :onclick (ps:ps
-                    (if (or (= (ps:chain window event which) 2)
-                            (= (ps:chain window event which) 4))
-                        (nyxt/ps:lisp-eval
-                         (:title "delete-tab-group"
-                          :buffer status)
-                         (if-confirm ((format nil "Delete all internal buffers?"))
-                                     (nyxt:delete-buffer :buffers internal-buffers)))
-                        (nyxt/ps:lisp-eval
-                         (:title "select-tab-group"
-                          :buffer status)
-                         (prompt
-                          :prompt "Switch to buffer with internal page"
-                          :sources (make-instance 'buffer-source
-                                                  :constructor internal-buffers)))))
-         (if (sera:single internal-buffers)
-             (prini-to-string (parse-nyxt-url (url (first internal-buffers))))
-             "internal")))
-      (loop for domain in (domains (buffer-list))
-            collect (:span
-                     :class (if (equal (quri:uri-domain (url (current-buffer))) domain)
-                                "plain tab"
-                                "tab")
-                     :onclick (ps:ps
-                                (if (or (= (ps:chain window event which) 2)
-                                        (= (ps:chain window event which) 4))
-                                    (nyxt/ps:lisp-eval
-                                     (:title "delete-tab-group"
-                                      :buffer status)
-                                     (if-confirm ((format nil "Delete all buffers with domain: ~a?" domain))
-                                                 (nyxt:delete-buffer :buffers (sera:filter (match-domain domain) (buffer-list)))))
-                                    (nyxt/ps:lisp-eval
-                                     (:title "select-tab-group"
-                                      :buffer status)
-                                     (nyxt::switch-buffer-or-query-domain domain))))
-                     domain)))))
+      (loop for url in domain-deduplicated-urls
+            collect
+            (let* ((internal-buffers (remove-if-not #'internal-url-p (buffer-list) :key #'url))
+                   (domain (quri:uri-domain url))
+                   (tab-display-text (if (internal-url-p url)
+                                         "internal"
+                                         domain))
+                   (url url))
+              (:span
+               :class (if (string= (quri:uri-domain (url (current-buffer (window status))))
+                                   (quri:uri-domain url))
+                          "selected-tab tab"
+                          "tab")
+               :onclick (ps:ps
+                          (if (or (= (ps:chain window event which) 2)
+                                  (= (ps:chain window event which) 4))
+                              (nyxt/ps:lisp-eval
+                               (:title "delete-tab-group"
+                                :buffer status)
+                               (if-confirm ((format nil "Delete all buffers with domain: ~a?" tab-display-text))
+                                   (mapcar #'nyxt::buffer-delete
+                                           (if (internal-url-p url)
+                                               internal-buffers
+                                               (sera:filter (match-domain domain) (buffer-list))))))
+                              (nyxt/ps:lisp-eval
+                               (:title "select-tab-group"
+                                :buffer status)
+                               (if (internal-url-p url)
+                                   (prompt
+                                    :prompt "Switch to buffer with internal page"
+                                    :sources (make-instance 'buffer-source
+                                                            :constructor internal-buffers))
+                                   (nyxt::switch-buffer-or-query-domain domain)))))
+               tab-display-text))))))
 
 (export-always 'format-status)
 (defmethod format-status ((status status-buffer))

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -266,4 +266,8 @@ See also `define-setf-handler'."
     (lambda (buffer)
       (when (window status-buffer)
         (when (eq buffer (active-buffer (window status-buffer)))
-          (print-status (window status-buffer)))))))
+          (print-status (window status-buffer))))))
+  (define-setf-handler browser buffers status-buffer
+    (lambda (browser)
+      (declare (ignore browser))
+      (mapc #'print-status (window-list)))))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -76,8 +76,9 @@ the generic functions on `status-buffer'.  Finally set the `window'
         :background-color ,theme:primary
         :color ,theme:on-primary)
       `(body
-        :background-color ,theme:background-alternate
-        :color ,theme:on-background-alternate
+        :background-color ,theme:background
+        :color ,theme:on-background
+        :opacity 0.9
         :font-size "12px"
         :padding 0
         :padding-left "4px"


### PR DESCRIPTION
# Description

A follow up to #2843, featuring a sensible branch name and rebased on top of the new theme changes.

# Discussion

There may be some minor topics left to discussion that were started in #2843.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] I have pulled from master before submitting this PR
- [x] There are no merge conflicts.
- [x] I've added the new dependencies as:
  - [x] ASDF dependencies,
  - [x] Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - [x] and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - [ ] All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - [ ] I have updated the existing documentation to match my changes.
  - [ ] I have commented my code in hard-to-understand areas.
  - [ ] I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - [ ] I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - [ ] (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - [x] New and existing unit tests pass locally with my changes.
