### PR TITLE
user-interface.lisp: Fix user interface.

### DIFF
--- a/source/user-interface.lisp
+++ b/source/user-interface.lisp
@@ -10,7 +10,7 @@
    (user-interface:buffer paragraph)
    (ps:ps
      (setf (ps:chain document
-                     (query-selector (ps:lisp (user-interface:id paragraph)))
+                     (get-element-by-id (ps:lisp (user-interface:id paragraph)))
                      text-content)
            (ps:lisp (user-interface:text paragraph))))))
 
@@ -19,7 +19,7 @@
    (user-interface:buffer progress-bar)
    (ps:ps
      (setf (ps:chain document
-                     (query-selector (ps:lisp (user-interface:id progress-bar)))
+                     (get-element-by-id (ps:lisp (user-interface:id progress-bar)))
                      style
                      width)
            (ps:lisp (format nil "~,1f%" (user-interface:percentage progress-bar)))))))
@@ -29,10 +29,10 @@
    (user-interface:buffer button)
    (ps:ps
      (setf (ps:chain document
-                     (query-selector (ps:lisp (user-interface:id button)))
+                     (get-element-by-id (ps:lisp (user-interface:id button)))
                      text-content)
            (ps:lisp (user-interface:text button)))
      (setf (ps:chain document
-                     (query-selector (ps:lisp (user-interface:id button)))
+                     (get-element-by-id (ps:lisp (user-interface:id button)))
                      onclick)
            (ps:lisp (user-interface:action button))))))


### PR DESCRIPTION
Hi! Can you please check if download-mode works correctly in the most recent nyxt and, if not, apply this PR? User interface's `update` method was broken between nyxt 3-pre-release-1 and 3-pre-release-2 and I think the breakage should still be present in master. I cannot install the most recent nyxt myself because I have an old version of WebKit which is incompatible with cl-webkit2. Here is a commit message with clarification:

In 5a5f0cb a correct call to document.getElementById() was (accidentally?) replaced with document.querySelector(). Consequences of that are some broken modes, e.g. download-mode shows many JS errors and progress bars do not work anymore. This commit fixes these errors.
