### PR TITLE
Change UI of tree style hinting by dimming characters matched by user input

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -738,7 +738,8 @@ not shuffle around. It is now possible to middle click to delete tabs.")
         " and "
         (:nxref :slot 'nyxt/hint-mode:auto-follow-hints-p
           :class-name 'nyxt/hint-mode:hint-mode)
-        "are enabled."))
+        "are enabled.")
+   (:li "Tree style hinting now highlights hints by dimming the matched characters."))
   (:h3 "Bug fixes")
   (:ul
    (:li "Switching focus away from Nyxt doesn't make it unfullscreen anymore.")))

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -37,6 +37,10 @@ user input.")
       `(".nyxt-hint.nyxt-select-hint"
         :background-color ,theme:accent
         :color ,theme:on-accent)
+      `(".nyxt-hint.nyxt-match-hint"
+        :padding "0px"
+        :border-style "none"
+        :opacity "0.5")
       `(".nyxt-element-hint"
         :background-color ,theme:accent))
     :documentation "The style of the hint overlays.")

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -257,7 +257,8 @@ Consult https://developer.mozilla.org/en-US/docs/Web/CSS/visibility."
               do (if (str:starts-with-p input
                                         (prompter:attributes-default suggestion)
                                         :ignore-case t)
-                     (set-hint-visibility (prompter:value suggestion) "visible")
+                     (progn (dim-hint-prefix (prompter:value suggestion) (length input))
+                            (set-hint-visibility (prompter:value suggestion) "visible"))
                      (set-hint-visibility (prompter:value suggestion) "hidden"))))
       suggestions))
    (prompter:filter

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -232,6 +232,19 @@ Consult https://developer.mozilla.org/en-US/docs/Web/CSS/visibility."
                                                        (identifier hint))))))
     (when element (setf (ps:@ element style "visibility") (ps:lisp state)))))
 
+(define-parenscript-async dim-hint-prefix (hint prefix-length)
+  "Dim the first PREFIX-LENGTH characters of HINT element."
+  (let ((element (nyxt/ps:qs document (ps:lisp (format nil "#nyxt-hint-~a"
+                                                       (identifier hint))))))
+    (when element
+      (let ((span-element (ps:chain document (create-element "span"))))
+        (setf (ps:@ span-element class-name) "nyxt-hint nyxt-match-hint")
+        (setf (ps:@ span-element text-content)
+              (ps:lisp (subseq (identifier hint) 0 prefix-length)))
+        (setf (ps:chain element inner-h-t-m-l)
+              (+ (ps:@ span-element outer-h-t-m-l)
+                 (ps:lisp (subseq (identifier hint) prefix-length))))))))
+
 (define-class hint-source (prompter:source)
   ((prompter:name "Hints")
    (prompter:actions-on-current-suggestion-enabled-p t)


### PR DESCRIPTION
# Description

Adds a new theme subclass that decreases the opacity of matched user input characters so that the remaining hint characters are highlighted. This is executed in the `filter-preprocessor` of `hint-source` class right before the hint is set to visible.

# Discussion

The new theme subclass overrides the padding and border-style of the parent class so that the hint elements remain the exact same in terms of styling with just the character opacity changing, this could've been avoided if I used a new class instead of a subclass, but in that case I would have to set the font and other styling parameters to match `nyxt-hint` class. So in both cases there is some kind of redundancy, I'm not sure if there's a better way.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainers to do so.
- [X] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.