### PR TITLE
Don't use deprecated webkit env variable.

### DIFF
--- a/libraries/web-extensions/README.org
+++ b/libraries/web-extensions/README.org
@@ -16,7 +16,6 @@ variables:
 
 #+begin_src sh
 export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-export WEBKIT_FORCE_SANDBOX=1
 #+end_src
 
 This is obviously disabling a critical security measure, so only do this in a

--- a/source/renderer/gi-gtk.lisp
+++ b/source/renderer/gi-gtk.lisp
@@ -43,7 +43,6 @@ For now it is also partly based on `nyxt/renderer/gtk'."))
 interface. On Darwin, we must run the GTK thread on the main thread."
   (declare (ignore urls startup-timestamp))
   (log:debug "Initializing GI-GTK Interface")
-  (setf (uiop:getenv "WEBKIT_FORCE_SANDBOX") "0")
   (if nyxt/renderer/gtk::gtk-running-p
       (nyxt/renderer/gtk::within-gtk-thread
         (call-next-method))


### PR DESCRIPTION
See https://bugs.webkit.org/show_bug.cgi?id=250232 and https://github.com/WebKit/WebKit/pull/8591.


# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
