### PR TITLE
Update NASDF to 0.1.4.

### DIFF
--- a/libraries/nasdf/compilation-tests.lisp
+++ b/libraries/nasdf/compilation-tests.lisp
@@ -10,21 +10,63 @@
     :initarg :packages
     :reader packages
     :documentation "Packages to check for unbound exports.
-Sub-packages are included in the check."))
+Sub-packages are included in the check.")
+   (unbound-symbols-to-ignore
+    :initform '()
+    :initarg :unbound-symbols-to-ignore
+    :reader unbound-symbols-to-ignore
+    :documentation "Symbols to ignore when checking for unbound exports.")
+   (undocumented-symbols-to-ignore
+    :initform '()
+    :initarg :undocumented-symbols-to-ignore
+    :reader undocumented-symbols-to-ignore
+    :documentation "Symbols to ignore when checking for documentation.
+Likely, slot names (these don't have native `documentation' support."))
   (:documentation "Specialized systems for compilation tests."))
 (import 'nasdf-compilation-test-system :asdf-user)
+
+(defun valid-type-p (type-specifier)
+  "Check the TYPE-SPECIFIER for being a valid type.
+The logic is:
+- If the type is documented as a type, then a type it is.
+- Otherwise, if `typep' exits normally (with whatever return value)
+  when checking arbitrary value against this specifier, then
+  TYPE-SPECIFIER is valid.
+- And if there's an error about argument types, then TYPE-SPECIFIER is
+  the type requiring arguments. Which means: type exists, even if
+  requiring arguments.
+- If there's any other error raised by `typep', then TYPE-SPECIFIER is
+  likely not a type."
+  (or (documentation type-specifier 'type)
+      (handler-case
+          (progn
+            (typep t type-specifier)
+            t)
+        #+sbcl
+        (sb-kernel::arg-count-error ()
+          t)
+        #+ccl
+        (ccl::simple-program-error ()
+          (search "can't be destructured against the lambda list" (format nil "~a" e)))
+        #+ecl
+        (simple-error (e)
+          (or (search "Too few arguments" (format nil "~a" e))
+              (not (search "not a valid type specifier" (format nil "~a" e)))))
+        #+clisp
+        (simple-error (e)
+          (or (search "may not be called with 0 arguments" (format nil "~a" e))
+              (not (search "invalid type specification" (format nil "~a" e)))))
+        (error () nil))))
 
 (defun list-unbound-exports (package)
   (let ((result '()))
     (do-external-symbols (s (find-package package) result)
-      (when (and (not (fboundp s))
-                 (not (boundp s))
-                 (not (find-class s nil))
-                 ;; TODO: How can we portably check if symbol refers to a type?
-                 #+sbcl
-                 (not (sb-ext:defined-type-name-p s))
-                 (or (not (find-package :parenscript))
-                     (not (gethash s (symbol-value (find-symbol "*MACRO-TOPLEVEL*" :parenscript))))))
+      (unless (or (fboundp s)
+                  (boundp s)
+                  (find-class s nil)
+                  (valid-type-p s)
+                  (and (find-package :parenscript)
+                       (gethash s (symbol-value (find-symbol "*MACRO-TOPLEVEL*" :parenscript)))))
         (push s result)))))
 
 (defun subpackage-p (subpackage package)
@@ -37,24 +79,90 @@ A sub-package has a name that starts with that of PACKAGE followed by a '/' sepa
 (defun list-subpackages (package)
   (remove-if (lambda (pkg) (not (subpackage-p pkg package))) (list-all-packages)))
 
-(defun unbound-exports (package)
-  "Report unbound exported symbols for PACKAGE and all its subpackages."
-  ;; TODO: Only SBCL is supported for now.
-  #-sbcl
-  nil
-  #+sbcl
-  (let* ((package (find-package package))
-         (report (delete nil
-                         (mapcar (lambda (package)
-                                   (let ((exports (list-unbound-exports package)))
-                                     (when exports
-                                       (list package exports))))
-                                 (cons (find-package package) (list-subpackages package))))))
-    (when report
-      (error "~a~&Found unbound exported symbols in ~a package~:p."
-             report (length report)))))
+(defun list-undocumented-exports (package)
+  (let ((result '())
+        (classes (loop for s being the external-symbol in package
+                       when (find-class s nil)
+                         collect s)))
+    (flet ((accessor-p (symbol)
+             "Check whether the SYMBOL is a slot accessor.
+This is necessary because accessors rarely have documentation and thus
+have to be excluded from the undocumented symbols list.
+Uses the built-in MOP abilities of every Lisp."
+             (and (fboundp symbol)
+                  (typep (symbol-function symbol) 'generic-function)
+                  (some (lambda (class)
+                          (ignore-errors
+                           (typep (find-method (symbol-function symbol) '() (list (find-class class)) nil)
+                                  '(or standard-accessor-method standard-reader-method standard-writer-method))))
+                        classes))))
+      (do-external-symbols (s (find-package package) result)
+        (unless (or (some (lambda (doctype) (documentation s doctype))
+                          '(variable function compiler-macro setf method-combination type structure))
+                    (accessor-p s)
+                    ;; Parenscript macros don't have documentation.
+                    (and (find-package :parenscript)
+                         (gethash s (symbol-value (find-symbol "*MACRO-TOPLEVEL*" :parenscript)))))
+          (push s result))))))
+
+(flet ((list-offending-packages (package export-lister testing-for)
+         (let* ((package (find-package package)))
+           (delete nil
+                   (mapcar (lambda (package)
+                             (logger ";;; Testing ~a for ~a" package testing-for)
+                             (let ((exports (funcall export-lister package)))
+                               (when exports
+                                 (list package exports))))
+                           (cons (find-package package) (list-subpackages package)))))))
+  (defun unbound-exports (package symbols-to-ignore)
+    "Report unbound exported symbols for PACKAGE and all its subpackages."
+    ;; NOTE: these implementations throw errors on atypical type specifier, enabling `valid-type-p'
+    #+(or sbcl ccl ecl clisp)
+    (let* ((report (list-offending-packages package #'list-unbound-exports "unbound exports"))
+           (report (delete
+                    nil
+                    (mapcar (lambda (rep)
+                              (destructuring-bind (package symbols)
+                                  rep
+                                (let ((really-undocumented-symbols
+                                        (remove-if (lambda (sym)
+                                                     (member (symbol-name sym) symbols-to-ignore
+                                                             :key #'symbol-name :test #'equal))
+                                                   symbols)))
+                                  (if really-undocumented-symbols
+                                      (list package really-undocumented-symbols)
+                                      nil))))
+                            report))))
+      (when report
+        (error "~a~&Found unbound exported symbols in ~a package~:p."
+               report (length report))))
+    #-(or sbcl ccl ecl clisp) nil)
+
+  (defun undocumented-exports (package symbols-to-ignore)
+    "Report undocumented exported symbols for PACKAGE and all its subpackages.
+SYMBOLS-TO-IGNORE are these that should not be tested for
+documentation (e.g. slot names)."
+    (let* ((report (list-offending-packages package #'list-undocumented-exports "undocumented exports"))
+           (report (delete
+                    nil
+                    (mapcar (lambda (rep)
+                              (destructuring-bind (package symbols)
+                                  rep
+                                (let ((really-undocumented-symbols
+                                        (remove-if (lambda (sym)
+                                                     (member (symbol-name sym) symbols-to-ignore
+                                                             :key #'symbol-name :test #'equal))
+                                                   symbols)))
+                                  (if really-undocumented-symbols
+                                      (list package really-undocumented-symbols)
+                                      nil))))
+                            report))))
+      (when report
+        (error "~a~&Found undocumented exported symbols in ~a package~:p."
+               report (length report))))))
 
 (defmethod asdf:perform ((op asdf:test-op) (c nasdf-compilation-test-system))
   (logger "------- STARTING Compilation Testing: ~a" (packages c))
-  (mapc #'unbound-exports (packages c))
+  (mapc #'(lambda (p) (unbound-exports p (unbound-symbols-to-ignore c))) (packages c))
+  (mapc #'(lambda (p) (undocumented-exports p (undocumented-symbols-to-ignore c))) (packages c))
   (logger "------- ENDING Compilation Testing: ~a" (packages c)))

--- a/libraries/nasdf/compilation-tests.lisp
+++ b/libraries/nasdf/compilation-tests.lisp
@@ -93,7 +93,7 @@ Uses the built-in MOP abilities of every Lisp."
                   (typep (symbol-function symbol) 'generic-function)
                   (some (lambda (class)
                           (ignore-errors
-                           (typep (find-method (symbol-function symbol) '() (list (find-class class)) nil)
+                           (typep (find-method (symbol-function symbol) '() (list (find-class class)))
                                   '(or standard-accessor-method standard-reader-method standard-writer-method))))
                         classes))))
       (do-external-symbols (s (find-package package) result)
@@ -134,7 +134,7 @@ Uses the built-in MOP abilities of every Lisp."
                                       nil))))
                             report))))
       (when report
-        (error "~a~&Found unbound exported symbols in ~a package~:p."
+        (error "~s~&Found unbound exported symbols in ~a package~:p."
                report (length report))))
     #-(or sbcl ccl ecl clisp) nil)
 
@@ -158,7 +158,7 @@ documentation (e.g. slot names)."
                                       nil))))
                             report))))
       (when report
-        (error "~a~&Found undocumented exported symbols in ~a package~:p."
+        (error "~s~&Found undocumented exported symbols in ~a package~:p."
                report (length report))))))
 
 (defmethod asdf:perform ((op asdf:test-op) (c nasdf-compilation-test-system))

--- a/libraries/nasdf/compilation-tests.lisp
+++ b/libraries/nasdf/compilation-tests.lisp
@@ -46,7 +46,7 @@ The logic is:
         (sb-kernel::arg-count-error ()
           t)
         #+ccl
-        (ccl::simple-program-error ()
+        (ccl::simple-program-error (e)
           (search "can't be destructured against the lambda list" (format nil "~a" e)))
         #+ecl
         (simple-error (e)

--- a/libraries/nasdf/nasdf.asd
+++ b/libraries/nasdf/nasdf.asd
@@ -2,7 +2,7 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (defsystem "nasdf"
-  :version "0.1.1"
+  :version "0.1.4"
   :author "Atlas Engineer LLC"
   :homepage "https://github.com/atlas-engineer/ntemplate"
   :description "ASDF helpers for system setup, testing and installation."

--- a/libraries/nasdf/package.lisp
+++ b/libraries/nasdf/package.lisp
@@ -33,6 +33,23 @@
                 #:perform
                 #:system-relative-pathname
                 #:system-source-directory)
+  (:import-from
+   #+abcl      #:mop
+   #+allegro   #:mop
+   #+clisp     #:clos
+   #+clozure   #:ccl
+   #+cmu       #:clos-mop
+   #+ecl       #:clos
+   #+clasp     #:clos
+   #+lispworks #:clos
+   #+mcl       #:ccl
+   #+sbcl      #:sb-mop
+   #+scl       #:clos
+   #+mezzano   #:mezzano.clos
+   #+sicl      #:sicl-clos
+   #:standard-accessor-method
+   #:standard-reader-method
+   #:standard-writer-method)
   (:documentation "ASDF helpers for system setup, testing and installation.
 
 To tell ASDF to fail loading a system on warnings, add this line to the system

--- a/libraries/nasdf/tests.lisp
+++ b/libraries/nasdf/tests.lisp
@@ -57,15 +57,17 @@ If the NASDF_TESTS_NO_NETWORK environment variable is set, tests with the `:onli
     (let ((exclude-tags (append (when (getenv "NASDF_TESTS_NO_NETWORK")
                                   '(:online))
                                 exclude-tags)))
-      (let ((missing-packages (remove-if  #'find-package (uiop:ensure-list package))))
+      (let ((missing-packages (remove-if #'find-package (uiop:ensure-list package))))
         (when missing-packages
           (logger "Undefined test packages: ~s" missing-packages)))
-      (let ((test-results
-              (uiop:symbol-call :lisp-unit2 :run-tests
-                                :package package
-                                :tags tags
-                                :exclude-tags exclude-tags
-                                :run-contexts (find-symbol "WITH-SUMMARY-CONTEXT" :lisp-unit2))))
+      ;; Binding `*package*' to test package makes for more reproducible tests.
+      (let* ((*package* (find-package package))
+             (test-results
+               (uiop:symbol-call :lisp-unit2 :run-tests
+                                 :package package
+                                 :tags tags
+                                 :exclude-tags exclude-tags
+                                 :run-contexts (find-symbol "WITH-SUMMARY-CONTEXT" :lisp-unit2))))
         (when (and
                (or
                 (uiop:symbol-call :lisp-unit2 :failed test-results)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -270,6 +270,7 @@ The renderer is configured from NYXT_RENDERER or `*nyxt-renderer*'."))
                  (:file "watch"))))
   :around-compile "NASDF:FAIL-ON-WARNINGS"
   :in-order-to ((test-op (test-op "nyxt/tests")
+                         (test-op "nyxt/tests/compilation")
                          ;; We test if manual dumping works, since it may catch
                          ;; some subtle mistakes:
                          (compile-op "nyxt/documentation")


### PR DESCRIPTION
# Description

This re-uses NASDF 0.1.4 updated in our N-libraries, in Nyxt. Which highlight a lot of improvement space :D In particular, lots of symbols are not documented:

<details>
<summary> Compilation tests emit (huge log): </summary>

```
; Errors:
((#<PACKAGE "NYXT">
  (MAKE-SEARCH-ENGINE HOOK-KEYMAPS-BUFFER FFI-WINDOW-DELETE PROFILE-NAME
                      COMMAND-P FFI-BUFFER-URL INACTIVE-MODE-SOURCE
                      FFI-BUFFER-ZOOM-LEVEL ON-SIGNAL-KEY-PRESS
                      FFI-KILL-BROWSER NYXT-DATA-DIRECTORY PS-LABELS
                      RENDERER-SCHEME FFI-BUFFER-AUTO-LOAD-IMAGE-ENABLED-P
                      FFI-INITIALIZE FFI-WINDOW-MESSAGE-BUFFER-HEIGHT
                      ON-SIGNAL-NOTIFY-TITLE ON-SIGNAL-LOAD-REDIRECTED
                      ON-SIGNAL-LOAD-STARTED ADD-MODES-TO-AUTO-RULES +VERSION+
                      FFI-BUFFER-PROXY FFI-WINDOW-UNMAXIMIZE
                      RENDERER-REQUEST-DATA NYXT-TEMPORARY-DIRECTORY GLYPH
                      FFI-WINDOW-SET-BUFFER BUFFER-P FINALIZE-BUFFER
                      FFI-WINDOW-ADD-PANEL-BUFFER FFI-WINDOW-MAXIMIZE
                      FFI-FOCUS-PROMPT-BUFFER ALIST-OF
                      FORMAT-STATUS-LOAD-STATUS FFI-TRACKING-PREVENTION
                      FFI-BUFFER-COOKIE-POLICY MAYBE* FFI-BUFFER-MAKE
                      NETWORK-BUFFER-P FFI-BUFFER-COPY HOST-ONLY-URL-P
                      KEYWORD-SOURCE FFI-BUFFER-MEDIA-ENABLED-P
                      FFI-BUFFER-TITLE FFI-BUFFER-GET-DOCUMENT
                      DOCUMENT-SCROLL-POSITION NOSAVE-BUFFER-P
                      BACKGROUND-BUFFER-P DISPATCH-INPUT-SKIP
                      FFI-BUFFER-LOAD-HTML FFI-WIDTH *OPEN-PROGRAM*
                      FFI-GENERATED-INPUT-EVENT-P ON-SIGNAL-LOAD-FINISHED
                      FFI-BUFFER-CUT STATUS-BUFFER-P INTERNAL-URL-P
                      DEFAULT-MODES ON-SIGNAL-LOAD-FAILED MODES
                      FFI-BUFFER-LOAD-ALTERNATE-HTML FORMAT-STATUS-BUTTONS
                      BUFFER-HISTORY FFI-GENERATE-INPUT-EVENT FORMAT-STATUS
                      CONTEXT-BUFFER-P ON-SIGNAL-NOTIFY-URI SEARCH-ENGINE
                      XDG-DOWNLOAD-DIR FFI-MUTED-P
                      FFI-WINDOW-DELETE-PANEL-BUFFER FFI-FOCUSED-P WINDOW-MAKE
                      FORMAT-STATUS-MODES EQUALS FFI-WINDOW-MAKE
                      USE-NYXT-PACKAGE-NICKNAMES FFI-BUFFER-EVALUATE-JAVASCRIPT
                      FORMAT-STATUS-TABS NYXT-SOURCE-REGISTRY FFI-HEIGHT
                      FFI-ADD-CONTEXT-MENU-COMMAND FFI-DISPLAY-URL
                      PROMPT-RENDER-SUGGESTIONS HOOK-RESOURCE
                      FFI-BUFFER-REMOVE-USER-STYLE PROMPT-BUFFER-CANCELED
                      ON-SIGNAL-BUTTON-PRESS ECHO-DISMISS MODE-CLASS
                      FFI-WINDOW-TO-FOREGROUND EXTERNAL-VISIBILITY-PACKAGES
                      HTML-STRING-P CONFIG-DIRECTORY-FILE
                      INTERNAL-VISIBILITY-PACKAGES RENDERER-BROWSER SLOT-FORM
                      DOCUMENT-GET-PARAGRAPH-CONTENTS FFI-PRINT-STATUS +ESCAPE+
                      WINDOW-LIST +NEWLINE+ FFI-INSPECTOR-SHOW REQUEST-DATA
                      EXTERNAL-EDITOR-PROGRAM ON-SIGNAL-LOAD-CANCELED
                      PROMPT-BUFFER-P FFI-WINDOW-UNFULLSCREEN
                      LIST-PROFILE-CLASSES MODABLE-BUFFER-P DOCUMENT-MODEL
                      FFI-WINDOW-TITLE KEYMAP BUFFER-MATCH-PREDICATE
                      PANEL-BUFFER-P FFI-BUFFER-ADD-USER-SCRIPT
                      FFI-BUFFER-ADD-USER-STYLE
                      FFI-BUFFER-SMOOTH-SCROLLING-ENABLED-P DISPATCH-COMMAND
                      INSPECTED-VALUE VALID-SCHEME-P FFI-PRINT-MESSAGE
                      EMPTY-PATH-URL-P CURRENT-SOURCE RENDERER-BUFFER
                      ON-SIGNAL-LOAD-COMMITTED FFI-BUFFER-REDO FFI-BUFFER-UNDO
                      DOCUMENT-BUFFER-P FFI-BUFFER-PASTE
                      FFI-PREFERRED-LANGUAGES BUFFER-SOURCE
                      FFI-BUFFER-REMOVE-USER-SCRIPT
                      INHERITED-VISIBILITY-PACKAGES FFI-BUFFER-USER-AGENT
                      FFI-WEB-EXTENSION-SEND-MESSAGE RENDERER-WINDOW
                      INPUT-BUFFER-P FFI-BUFFER-JAVASCRIPT-MARKUP-ENABLED-P
                      WEB-BUFFER-P FFI-BUFFER-LOAD MODE AUTO-RULE
                      FFI-WINDOW-FULLSCREEN FFI-BUFFER-DOWNLOAD COOKIE-POLICY
                      URL-SOURCES LOG-FILE NYXT-SOURCE-DIRECTORY MODE-SOURCE
                      INTRO FFI-BUFFER-DELETE FFI-BUFFER-SELECT-ALL
                      FFI-BUFFER-SOUND-ENABLED-P MODE-P MAYBE PACKAGES
                      FFI-BUFFER-EVALUATE-JAVASCRIPT-ASYNC EXTENSIONS-DIRECTORY
                      BASE-MODE-P GLOBAL-HISTORY-SOURCE FFI-WINDOW-ACTIVE
                      ACTIVE-MODE-SOURCE FORMAT-STATUS-URL
                      FFI-BUFFER-JAVASCRIPT-ENABLED-P
                      FFI-WITHIN-RENDERER-THREAD MANUAL-CONTENT
                      COMBINE-COMPOSED-HOOK-UNTIL-NIL PANEL-BUFFER CLASS-FORM
                      FFI-BUFFER-WEBGL-ENABLED-P))
 (#<PACKAGE "NYXT/USER-SCRIPT-MODE">
  (RENDERER-USER-SCRIPT USER-SCRIPT-MODE-P RENDERER-USER-STYLE))
 (#<PACKAGE "NYXT/RECORD-INPUT-FIELD-MODE">
  (INPUT-ENTRY RECORD-INPUT-FIELD-MODE-P))
 (#<PACKAGE "NYXT/REPEAT-MODE"> (REPEAT-MODE-P))
 (#<PACKAGE "NYXT/PASSTHROUGH-MODE"> (PASSTHROUGH-MODE-P))
 (#<PACKAGE "NYXT/STYLE-MODE"> (STYLE-MODE-P DARK-MODE-P))
 (#<PACKAGE "NYXT/KEYSCHEME">
  (VI-INSERT DEFAULT EMACS CUA NYXT-KEYMAP-VALUE VI-NORMAL))
 (#<PACKAGE "NYXT/NO-IMAGE-MODE"> (NO-IMAGE-MODE-P))
 (#<PACKAGE "NYXT/HISTORY-TREE-MODE"> (HISTORY-TREE-MODE-P))
 (#<PACKAGE "NYXT/BOOKMARK-MODE">
  (EQUALS BOOKMARK-MODE-P BOOKMARK-SOURCE BOOKMARK-ENTRY BOOKMARK-ADD))
 (#<PACKAGE "NYXT/HINT-MODE">
  (IDENTIFIER UNHIGHLIGHT-SELECTED-HINT HINT-MODE-P HIGHLIGHT-SELECTED-HINT))
 (#<PACKAGE "NYXT/SEARCH-BUFFER-MODE">
  (SEARCH-BUFFER-MODE-P SEARCH-BUFFER-SOURCE))
 (#<PACKAGE "NYXT/REDUCE-TRACKING-MODE"> (REDUCE-TRACKING-MODE-P))
 (#<PACKAGE "NYXT/TYPES"> (HTML-STRING-P COOKIE-POLICY MAYBE* ALIST-OF MAYBE))
 (#<PACKAGE "NYXT/SMALL-WEB-MODE"> (SMALL-WEB-MODE-P))
 (#<PACKAGE "NYXT/ANNOTATE-MODE">
  (ANNOTATE-MODE-P ANNOTATION SNIPPET-ANNOTATION URL-ANNOTATION))
 (#<PACKAGE "NYXT/BOOKMARK-FREQUENT-VISITS"> (BOOKMARK-FREQUENT-VISITS-MODE-P))
 (#<PACKAGE "NYXT/UTILITIES"> (+NEWLINE+ +ESCAPE+))
 (#<PACKAGE "NYXT/INPUT-EDIT-MODE">
  (WITH-TEXT-BUFFER INPUT-EDIT-MODE-P
    WITH-INPUT-AREA))
 (#<PACKAGE "NYXT/AUTOFILL-MODE">
  (MAKE-AUTOFILL AUTOFILL-P AUTOFILL-MODE-P AUTOFILL-SOURCE))
 (#<PACKAGE "NYXT/DOWNLOAD-MODE"> (DOWNLOAD-MODE-P RENDERER-DOWNLOAD))
 (#<PACKAGE "NYXT/DOCUMENT-MODE"> (GET-URL-SOURCE RING-SOURCE DOCUMENT-MODE-P))
 (#<PACKAGE "NYXT/KEYSCHEME-MODE"> (KEYSCHEME-MODE-P))
 (#<PACKAGE "NYXT/EXPEDITION-MODE"> (EXPEDITION-MODE-P))
 (#<PACKAGE "NYXT/TTS-MODE"> (TTS-MODE-P))
 (#<PACKAGE "NYXT/NO-PROCRASTINATE-MODE">
  (NO-PROCRASTINATE-ENTRY NO-PROCRASTINATE-MODE-P))
 (#<PACKAGE "NYXT/MIGRATION"> (FIND-SUGGESTIONS SUGGESTION-P TIP SUGGESTION))
 (#<PACKAGE "NYXT/BUFFER-LISTING-MODE"> (BUFFER-LISTING-MODE-P))
 (#<PACKAGE "NYXT/MESSAGE-MODE"> (MESSAGE-MODE-P))
 (#<PACKAGE "NYXT/WATCH-MODE"> (WATCH-MODE-P))
 (#<PACKAGE "NYXT/SPELL-CHECK-MODE"> (SPELL-CHECK-MODE-P))
 (#<PACKAGE "NYXT/HELP-MODE"> (HELP-MODE-P))
 (#<PACKAGE "NYXT/VISUAL-MODE"> (VISUAL-MODE-P))
 (#<PACKAGE "NYXT/READING-LINE-MODE"> (READING-LINE-MODE-P))
 (#<PACKAGE "NYXT/PASSWORD-MODE"> (PASSWORD-MODE-P))
 (#<PACKAGE "NYXT/MACRO-EDIT-MODE"> (MACRO-EDIT-MODE-P))
 (#<PACKAGE "NYXT/PREVIEW-MODE"> (PREVIEW-MODE-P))
 (#<PACKAGE "NYXT/LIST-HISTORY-MODE"> (LIST-HISTORY-MODE-P))
 (#<PACKAGE "NYXT/EMACS-MODE"> (EMACS-MODE-P))
 (#<PACKAGE "NYXT/FORCE-HTTPS-MODE"> (FORCE-HTTPS-MODE-P))
 (#<PACKAGE "NYXT/CRUISE-CONTROL-MODE"> (CRUISE-CONTROL-MODE-P))
 (#<PACKAGE "NYXT/HISTORY-MODE">
  (HISTORY-ALL-OWNER-NODES-SOURCE BLOCKED-P HISTORY-FORWARDS-SOURCE
   HISTORY-BACKWARDS-SOURCE HISTORY-MODE-P HISTORY-ALL-SOURCE
   ALL-HISTORY-FORWARDS-SOURCE))
 (#<PACKAGE "NYXT/REPL-MODE"> (REPL-MODE-P CANCEL-CELL))
 (#<PACKAGE "NYXT/FILE-MANAGER-MODE">
  (FILE-MANAGER-MODE-P RECURSIVE-DIRECTORY-ELEMENTS))
 (#<PACKAGE "NYXT/HINT-PROMPT-BUFFER-MODE"> (HINT-PROMPT-BUFFER-MODE-P))
 (#<PACKAGE "NYXT/DOM">
  (TRACK-ELEMENT-P RUBY-ELEMENT-P OPTGROUP-ELEMENT-P BLINK-ELEMENT-P
                   SOURCE-ELEMENT-P COL-ELEMENT-P EM-ELEMENT-P S-ELEMENT-P
                   CHECK-ELEMENT TD-ELEMENT-P NOSCRIPT-ELEMENT-P DATA-ELEMENT-P
                   TITLE-ELEMENT-P OUTPUT-ELEMENT-P Q-ELEMENT-P
                   MARQUEE-ELEMENT-P CHECKBOX-ELEMENT-P TEMPLATE-ELEMENT-P
                   CITE-ELEMENT-P ISINDEX-ELEMENT-P CAPTION-ELEMENT-P
                   CODE-ELEMENT-P DIV-ELEMENT-P PLAINTEXT-ELEMENT-P
                   TBODY-ELEMENT-P COLGROUP-ELEMENT-P DETAILS-ELEMENT-P
                   STYLE-ELEMENT-P B-ELEMENT-P LINK-ELEMENT-P PICTURE-ELEMENT-P
                   MAP-ELEMENT-P HGROUP-ELEMENT-P GET-UNIQUE-SELECTOR
                   H6-ELEMENT-P INS-ELEMENT-P PRE-ELEMENT-P H3-ELEMENT-P
                   BGSOUND-ELEMENT-P DFN-ELEMENT-P NEXTID-ELEMENT-P
                   IFRAME-ELEMENT-P SUP-ELEMENT-P STRUCTURE-ELEMENT-P
                   ABBR-ELEMENT-P NOBR-ELEMENT-P VIDEO-ELEMENT-P H2-ELEMENT-P
                   BASEFONT-ELEMENT-P FRAME-ELEMENT-P SPACER-ELEMENT-P
                   RTC-ELEMENT-P MAIN-ELEMENT-P STRIKE-ELEMENT-P VAR-ELEMENT-P
                   TR-ELEMENT-P ADDRESS-ELEMENT-P TABLE-ELEMENT-P U-ELEMENT-P
                   MARK-ELEMENT-P DIR-ELEMENT-P LEGEND-ELEMENT-P SAMP-ELEMENT-P
                   LISTING-ELEMENT-P DT-ELEMENT-P LIST-ELEMENT-P
                   OPTION-ELEMENT-P DIALOG-ELEMENT-P MULTICOL-ELEMENT-P
                   AUDIO-ELEMENT-P DEL-ELEMENT-P UL-ELEMENT-P H5-ELEMENT-P
                   EMBED-ELEMENT-P KBD-ELEMENT-P DD-ELEMENT-P BDI-ELEMENT-P
                   CLICK-ELEMENT FIELDSET-ELEMENT-P INPUT-ELEMENT-P
                   FIGCAPTION-ELEMENT-P SUB-ELEMENT-P SPAN-ELEMENT-P
                   FILE-CHOOSER-ELEMENT-P AREA-ELEMENT-P LABEL-ELEMENT-P
                   ARTICLE-ELEMENT-P FORM-ELEMENT-P FONT-ELEMENT-P
                   BODY-ELEMENT-P SLOT-ELEMENT-P OL-ELEMENT-P TH-ELEMENT-P
                   META-ELEMENT-P A-ELEMENT-P NOFRAMES-ELEMENT-P WBR-ELEMENT-P
                   TEXT-ELEMENT-P CENTER-ELEMENT-P SELECT-OPTION-ELEMENT
                   HOVER-ELEMENT ACRONYM-ELEMENT-P RT-ELEMENT-P THEAD-ELEMENT-P
                   SUMMARY-ELEMENT-P BDO-ELEMENT-P PARAM-ELEMENT-P H4-ELEMENT-P
                   BR-ELEMENT-P HEAD-ELEMENT-P SEMANTIC-ELEMENT-P
                   ASIDE-ELEMENT-P TT-ELEMENT-P HEADER-ELEMENT-P
                   APPLET-ELEMENT-P LI-ELEMENT-P NOEMBED-ELEMENT-P
                   SECTION-ELEMENT-P BASE-ELEMENT-P DATALIST-ELEMENT-P
                   FRAMESET-ELEMENT-P FIGURE-ELEMENT-P GET-NYXT-ID H-ELEMENT-P
                   METER-ELEMENT-P BLOCKQUOTE-ELEMENT-P FOCUS-SELECT-ELEMENT
                   P-ELEMENT-P BIG-ELEMENT-P NAV-ELEMENT-P STRONG-ELEMENT-P
                   OBJECT-ELEMENT-P PROGRESS-ELEMENT-P BUTTON-ELEMENT-P
                   SCROLL-TO-ELEMENT DL-ELEMENT-P I-ELEMENT-P CANVAS-ELEMENT-P
                   SET-CARET-ON-START TEXTAREA-ELEMENT-P XMP-ELEMENT-P
                   IMG-ELEMENT-P RADIO-ELEMENT-P TIME-ELEMENT-P HTML-ELEMENT-P
                   HR-ELEMENT-P SCRIPT-ELEMENT-P H1-ELEMENT-P SELECT-ELEMENT-P
                   TOGGLE-DETAILS-ELEMENT RP-ELEMENT-P RB-ELEMENT-P
                   TFOOT-ELEMENT-P FOOTER-ELEMENT-P SMALL-ELEMENT-P))
 (#<PACKAGE "NYXT/NO-WEBGL-MODE"> (NO-WEBGL-MODE-P))
 (#<PACKAGE "NYXT/BLOCKER-MODE"> (BLOCKER-MODE-P))
 (#<PACKAGE "NYXT/NO-SCRIPT-MODE"> (NO-SCRIPT-MODE-P))
 (#<PACKAGE "NYXT/EDITOR-MODE">
  (PLAINTEXT-EDITOR-MODE-P EDITOR-BUFFER-P EDITOR-MODE-P))
 (#<PACKAGE "NYXT/PROXY-MODE"> (PROXY-MODE-P))
 (#<PACKAGE "NYXT/PROMPT-BUFFER-MODE"> (PROMPT-BUFFER-MODE-P))
 (#<PACKAGE "NYXT/CERTIFICATE-EXCEPTION-MODE"> (CERTIFICATE-EXCEPTION-MODE-P))
 (#<PACKAGE "NYXT/REDUCE-BANDWIDTH-MODE"> (REDUCE-BANDWIDTH-MODE-P))
 (#<PACKAGE "NYXT/VI-MODE"> (VI-INSERT-MODE-P VI-NORMAL-MODE-P))
 (#<PACKAGE "NYXT/REMEMBRANCE-MODE">
  (REMEMBRANCE-MODE-P REMEMBRANCE-SOURCE REMEMBRANCE-EXACT-SOURCE))
 (#<PACKAGE "NYXT/BOOKMARKLETS-MODE"> (BOOKMARKLETS-MODE-P))
 (#<PACKAGE "NYXT/NO-SOUND-MODE"> (NO-SOUND-MODE-P))
 (#<PACKAGE "NYXT/PROCESS-MODE"> (PROCESS-MODE-P)))
Found undocumented exported symbols in 59 packages.
```
</details>

While some of these undocumented symbols are propagated from auto-generated code (like class predicates from NClasses), some of them are simply undocumented APIs we have. It's a high time we document all the public stuff we have in Nyxt. 

@aadcg, interested in digging into that? I'll fix the problems with auto-generated code, but you're in a better position to add the human-readable documentation :P

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.