### PR TITLE
Add and change prompt mouse/return actions for consistency and intuitiveness

### DIFF
--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -52,8 +52,10 @@ listed and chosen from with the command `set-action-on-return' (bound to
        "keypadenter" 'run-action-on-return
        "M-return" 'set-action-on-return
        "M-keypadenter" 'set-action-on-return
-       "C-return" 'run-action-on-current-suggestion
-       "C-keypadenter" 'run-action-on-current-suggestion
+       "C-return" 'toggle-mark-forwards
+       "C-keypadenter" 'toggle-mark-forwards
+       "s-return" 'toggle-mark-forwards
+       "s-keypadenter" 'toggle-mark-forwards
        "C-c C-j" 'set-action-on-current-suggestion
        "tab" 'insert-current-suggestion
        ; TODO: This is the Emacs Helm binding.  Better?

--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -56,6 +56,7 @@ listed and chosen from with the command `set-action-on-return' (bound to
        "C-keypadenter" 'toggle-mark-forwards
        "s-return" 'toggle-mark-forwards
        "s-keypadenter" 'toggle-mark-forwards
+       "C-j" 'run-action-on-current-suggestion
        "C-c C-j" 'set-action-on-current-suggestion
        "tab" 'insert-current-suggestion
        ; TODO: This is the Emacs Helm binding.  Better?

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -431,26 +431,39 @@ an integer."))
                                    "marked")
                           :onclick (when (mouse-support-p prompt-buffer)
                                      (ps:ps
-                                       (if (ps:chain window event ctrl-key)
-                                           (nyxt/ps:lisp-eval
-                                            (:title "mark-this-suggestion"
-                                             :buffer prompt-buffer)
-                                            (prompter::set-current-suggestion
-                                             prompt-buffer
-                                             (- suggestion-index cursor-index))
-                                            (prompter:toggle-mark prompt-buffer)
-                                            (prompter::set-current-suggestion
-                                             prompt-buffer
-                                             (- cursor-index suggestion-index))
-                                            (prompt-render-suggestions prompt-buffer))
-                                           (nyxt/ps:lisp-eval
-                                            (:title "return-this-suggestion"
-                                             :buffer prompt-buffer)
-                                            (prompter::set-current-suggestion
-                                             prompt-buffer
-                                             (- suggestion-index cursor-index))
-                                            (prompter:run-action-on-return
-                                             (nyxt::current-prompt-buffer))))))
+                                       (cond
+                                         ((or (ps:chain window event ctrl-key)
+                                              (ps:chain window event shift-key))
+                                          (nyxt/ps:lisp-eval
+                                           (:title "mark-this-suggestion"
+                                            :buffer prompt-buffer)
+                                           (prompter::set-current-suggestion
+                                            prompt-buffer
+                                            (- suggestion-index cursor-index))
+                                           (prompter:toggle-mark prompt-buffer)
+                                           (prompter::set-current-suggestion
+                                            prompt-buffer
+                                            (- cursor-index suggestion-index))
+                                           (prompt-render-suggestions prompt-buffer)))
+                                         ((ps:chain window event alt-key)
+                                          (nyxt/ps:lisp-eval
+                                           (:title "return-this-suggestion-with-another-action"
+                                            :buffer prompt-buffer)
+                                           (prompter::set-current-suggestion
+                                            prompt-buffer
+                                            (- suggestion-index cursor-index))
+                                           (uiop:symbol-call
+                                            :nyxt/prompt-buffer-mode :set-action-on-return
+                                            (nyxt::current-prompt-buffer))))
+                                         (t
+                                          (nyxt/ps:lisp-eval
+                                           (:title "return-this-suggestion"
+                                            :buffer prompt-buffer)
+                                           (prompter::set-current-suggestion
+                                            prompt-buffer
+                                            (- suggestion-index cursor-index))
+                                           (prompter:run-action-on-return
+                                            (nyxt::current-prompt-buffer)))))))
                           (loop for (nil attribute attribute-display)
                                 in (prompter:active-attributes suggestion :source source)
                                 collect (:td :title attribute

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -52,8 +52,12 @@ some point.")
      (mouse-support-p
       t
       :type boolean
-      :documentation "Whether to allow mouse events to set and return the
-current suggestion in the prompt buffer.")
+      :documentation "Whether to allow mouse events to act on prompt buffer suggestions.
+The following mouse keybindings are available:
+- button1: `run-action-on-return'
+- C-button1: `toggle-mark-forwards'
+- s-button1: `toggle-mark-forwards'
+- M-button1: `set-action-on-return'.")
      (dynamic-attribute-width-p
       nil
       :type boolean


### PR DESCRIPTION
# Description

This makes two changes:
- Adding more mouse actions, bridging the functionality mismatch between mouse use and keyboard use:
  - `C-button1` for marking.
  - `s-button1` for marking.
  - `M-button1` for return with another action (= `M-return`).
- Bringing the keyboard actions to consistency with these:
  - `C-return` for marking.
  - `s-return` for marking.

Fixes #2931
Also should resolve #2628 once we decide on what to do with the action on current suggestion.

# Discussion

@aadcg, we previously had this discussion about whether `run-action-on-current-suggestion` should be bound to `C-return`. Now that it stands for marking, it's resolved. But then, how does one run actions on current suggestion? Seems like it's not invokable with either mouse nor keyboard. Should it be `s-return`/`s-click`?

CC @lansingthomas 

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [X] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
