### PR TITLE
hint mode and search buffer mode must not share the same stylesheet

### DIFF
--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -158,7 +158,8 @@ For instance, to include images:
     (ps:chain element (remove-attribute "nyxt-hintable"))))
 
 (defun add-hints (&key selector (buffer (current-buffer)))
-  (add-stylesheet (style (find-submode 'hint-mode))
+  (add-stylesheet "nyxt-hint-stylesheet"
+                  (style (find-submode 'hint-mode))
                   buffer)
   (set-hintable-attribute selector)
   (update-document-model :buffer buffer)

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -490,8 +490,9 @@ For shorter search patterns, `initial-delay' applies.")
         (maybe-remove-search-marks (buffer match))
         match)))
    (prompter:constructor
-    (lambda (source) (add-stylesheet (style (find-submode 'search-buffer-mode))
-                                (buffer source))))
+    (lambda (source) (add-stylesheet "nyxt-search-stylesheet"
+                                     (style (find-submode 'search-buffer-mode))
+                                     (buffer source))))
    (prompter:destructor
     (lambda (prompter source)
       (declare (ignore source))

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -119,12 +119,14 @@ If `setf'-d to a list of two values -- set Y to `first' and X to `second' elemen
     (ps:chain result (slice 0 (ps:lisp limit)))))
 
 (export-always 'add-stylesheet)
-(defun add-stylesheet (style &optional (buffer (current-buffer)))
+(defun add-stylesheet (stylesheet-name style &optional (buffer (current-buffer)))
   (ps-eval :async t :buffer buffer
-    (unless (nyxt/ps:qs document "#nyxt-stylesheet")
+    (unless (nyxt/ps:qs document (ps:lisp
+                                  (concatenate
+                                   'string '(#\#) stylesheet-name)))
       (ps:try
        (ps:let ((style-element (ps:chain document (create-element "style"))))
-         (setf (ps:@ style-element id) "nyxt-stylesheet")
+         (setf (ps:@ style-element id) (ps:lisp stylesheet-name))
          (ps:chain document head (append-child style-element))
          (setf (ps:chain style-element inner-text) (ps:lisp style)))
        (:catch (error))))))


### PR DESCRIPTION
Hi! When you search for something with `seach-buffer` and then navigate with `follow-hint`, you get hints not shown as expected (it works also the other way around). This is because `nyxt/mode/hint` and `nyxt/mode/search-buffer` share the same stylesheet. This patch just renames stylesheets, so they can be used simultaneously.

This is what it looks like before the fix:
![20230505_11h15m24s_grim](https://user-images.githubusercontent.com/812069/236409415-af8496d0-db10-4fa3-9709-7aa33aa46a02.png)
