### PR TITLE
Force request inspection for link clicks.

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -726,6 +726,8 @@ color-picker support as an example application for this feature.")
 
 (define-version "3.X.Y"
   (:ul
+   (:li "Clicked links are now fully inspectable and all the functionality of
+Nyxt works properly with these.")
    (:li "The " (:code "external-editor-program") " slot no longer signals when the program is a string containing spaces.")
    (:li "The " (:code "external-editor-program") " returns the slot value directly rather than returning a string value in a list.")
    (:li "Remove restrictions on zoom level in the form of "

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -106,7 +106,13 @@ See https://developer.gnome.org/gobject/stable/gobject-Signals.html#signal-memor
                              :documentation "Internal hack, do not use me!
 WebKitGTK may trigger 'load-failed' when loading a page from the WebKit-history
 cache.  Upstream bug?  We use this slot to know when to ignore these load
-failures."))
+failures.")
+   (currently-loading-url
+    nil
+    :documentation "The URL that the buffer loads right now.
+If the URL in `on-signal-notify-uri' is not the same as this URL, reload the
+buffer to force all the `on-signal-decide-policy' etc. request inspection
+things."))
   (:export-class-name-p t)
   (:export-accessor-names-p t))
 
@@ -1100,6 +1106,10 @@ See `finalize-buffer'."
            (url (if (url-empty-p url)
                     (url buffer)
                     url)))
+      (setf (currently-loading-url buffer)
+            (if (eq load-event :webkit-load-finished)
+                nil
+                url))
       (cond ((eq load-event :webkit-load-started)
              (setf (nyxt::status buffer) :loading)
              (nyxt/web-extensions::tabs-on-updated buffer '(("status" . "loading")))
@@ -1554,6 +1564,24 @@ the `active-buffer'."
     (declare (ignore param-spec))
     (nyxt/web-extensions::tabs-on-updated
      buffer `(("url" . ,(webkit:webkit-web-view-uri web-view))))
+    ;; This is to force clicked links to be loaded again, this time through all
+    ;; the handlers we have. Otherwise clicked links might:
+    ;; - Open the otherwise blocked/redirected pages.
+    ;; - Avoid toggling auto-rules.
+    ;; - Confuse URL hook handlers (be it core handlers or user ones) in general.
+    (let ((url (ensure-url (webkit:webkit-web-view-uri web-view))))
+      (unless (or (url-empty-p url)
+                  ;; Reload.
+                  (and (not (url-empty-p (url buffer)))
+                       (quri:uri= url (url buffer)))
+                  ;; We ignore hooks when loading WebKit history, but that
+                  ;; doesn't need reloading, so we ignore history case here.
+                  (loading-webkit-history-p buffer)
+                  (and (not (url-empty-p (currently-loading-url buffer)))
+                       (quri:uri= url (currently-loading-url buffer))))
+        (log:debug "URL ~a is neither current URL (~a) nor the last committed URL (~a). Might be a clicked link. Reloading."
+                   url (url buffer) (currently-loading-url buffer))
+        (buffer-load url :buffer buffer)))
     (on-signal-notify-uri buffer nil))
   (connect-signal buffer "notify::title" nil (web-view param-spec)
     (declare (ignore  param-spec))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1571,9 +1571,8 @@ the `active-buffer'."
     ;; - Confuse URL hook handlers (be it core handlers or user ones) in general.
     (let ((url (ensure-url (webkit:webkit-web-view-uri web-view))))
       (unless (or (url-empty-p url)
-                  ;; Reload.
-                  (and (not (url-empty-p (url buffer)))
-                       (quri:uri= url (url buffer)))
+                  (url-empty-p (url buffer)) ; Ignore just-created buffers.
+                  (quri:uri= url (url buffer)) ; Ignore reloads.
                   ;; We ignore hooks when loading WebKit history, but that
                   ;; doesn't need reloading, so we ignore history case here.
                   (loading-webkit-history-p buffer)


### PR DESCRIPTION
# Description

So the problem is: how do we detect clicked links? By detecting whether it's certainly not a clicked one! I've stumbled at this (possibly incomplete) list of conditions for _certainly-not-a-clicked-URL_ toplevel requests:
- The URL is the same as last commited one (newly added `currently-loading-url`).
- The URL is the same as buffer URL (reload, basically).
- If the new URL is empty (borked up signal, certainly not a conforming link click that WebKit manages).
- Or if we load WebKit history (loading history ignores signals and hooks too, but we have much more control over it, so nothing to worry about).

If request fits none of these categories, then it's most likely a clicked link one.

@Ambrevar, @aadcg, @jmercouris, please review and test on as much websites as you can, because there's too much variables for me to get everything right from the first shot.

Fixes #2634

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [X] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
