### PR TITLE
Document modes and subsystems

### DIFF
--- a/source/help.lisp
+++ b/source/help.lisp
@@ -30,6 +30,7 @@
                                     (type (getf (mopu:slot-properties (find-class class) slot)
                                                 :type)))
   "Set value of CLASS' SLOT in `*auto-config-file*'.
+Prompt for a new value and type-check it against the SLOT's TYPE, if any.
 CLASS is a class symbol."
   (sera:nlet lp ()
     (let ((input (read-from-string
@@ -47,11 +48,15 @@ CLASS is a class symbol."
 
 (define-internal-page-command-global common-settings ()
     (buffer "*Settings*" 'nyxt/mode/help:help-mode)
-  "Configure a set of frequently used settings."
+  "Display an interface to tweak frequently sought-after user options.
+The changes are saved to `*auto-config-file*', and persist from one Nyxt session
+to the next."
   (spinneret:with-html-string
     (:h1 "Common Settings")
-    (:p "Set the values for frequently configured settings. "
-        "Changes only apply to newly created buffers.")
+    (:p "Tweak frequently sought-after settings. The changes persist from one
+Nyxt session to the next.
+
+Note that some settings may require creating a new buffer to take effect.")
     (:h2 "Keybinding style")
     (:p (:button :class "button"
                  :onclick (ps:ps (nyxt/ps:lisp-eval
@@ -142,7 +147,7 @@ disabling compositing, you will need to restart Nyxt."))
           (:p "Edit user configuration and other files in external text editor.")))))
 
 (define-command print-bindings ()
-  "Print all known bindings for the current buffer."
+  "Display all known bindings for the current buffer."
   (nyxt::html-set-style (theme:themed-css (theme *browser*)
                           `(h3
                             :font-size "10px"
@@ -180,13 +185,14 @@ file, see the "
    buffer))
 
 (define-command nyxt-version ()
-  "Version number of this version of Nyxt.
-The version number is saved to clipboard."
+  "Display the version of Nyxt in the `message-buffer'.
+The value is saved to clipboard."
   (trivial-clipboard:text +version+)
   (echo "Version ~a" +version+))
 
 (define-panel-command intro ()
     (panel "*Introduction*" :left)
+  "Display a short introduction to Nyxt in a side panel."
   (spinneret:with-html-string
     (:h1 "Getting Started with Nyxt")
     (:p "If you want to start browsing right away, then you probably want to use "
@@ -214,7 +220,7 @@ useful actions there, including the familiar " (:code "set-url") ", " (:code "hi
 
 (define-internal-page-command-global new ()
     (buffer "*New buffer*")
-  "Open up a buffer with useful links suitable for `default-new-buffer-url'."
+  "Display a page suitable as `default-new-buffer-url'."
   (spinneret:with-html-string
    (:nstyle (theme:themed-css (theme *browser*)
                               `(body
@@ -301,14 +307,14 @@ useful actions there, including the familiar " (:code "set-url") ", " (:code "hi
 (sera:eval-always ; To satisfy `fboundp' of `manual' at compile-time (e.g. CCL).
   (define-internal-page-command-global manual ()
       (buffer "*Manual*" 'nyxt/mode/help:help-mode)
-    "Show the manual."
+    "Display Nyxt manual."
     (spinneret:with-html-string
       (:nstyle (lass:compile-and-write '(body :max-width "80ch")))
       (:raw (manual-content)))))
 
 (define-internal-page-command-global tutorial ()
     (buffer "*Tutorial*" 'nyxt/mode/help:help-mode)
-  "Show the tutorial."
+  "Display Nyxt tutorial."
   (spinneret:with-html-string
     (:nstyle (lass:compile-and-write '(body :max-width "80ch")))
     (:h1 "Nyxt tutorial")
@@ -319,8 +325,10 @@ the " (:code (:a.link :href (nyxt-url 'manual) "manual")) ".")
 
 (define-internal-page-command-global show-system-information ()
     (buffer "*System information*")
-  "Show buffer with Lisp version, Lisp features, OS kernel, etc.
-System information is also saved to clipboard."
+  "Display information about the currently running Nyxt system.
+
+It is of particular interest when reporting bugs.  The content is saved to
+clipboard."
   (let* ((*print-length* nil)
          (nyxt-information (system-information)))
     (prog1
@@ -333,7 +341,7 @@ System information is also saved to clipboard."
 
 (define-internal-page-command-global dashboard ()
     (buffer "*Dashboard*")
-  "Print a dashboard."
+  "Display a dashboard featuring bookmarks, recent URLs and other useful actions."
   (flet ((list-bookmarks (&key (limit 50) (separator " → "))
            (spinneret:with-html-string
              (let ((mode (make-instance 'nyxt/mode/bookmark:bookmark-mode)))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -10,12 +10,16 @@
 
 (export-always 'buffer-history)
 (defun buffer-history (&optional (buffer (current-buffer)))
+  "Get the history of BUFFER.
+Not modifiable."
   (files:content (history-file buffer)))
 
 (define-class history-entry ()          ; TODO: Export?
-  ((url (quri:uri "")
-        :accessor nil
-        :type (or quri:uri string))
+  ((url
+    (quri:uri "")
+    :writer t
+    :reader nil
+    :type (or quri:uri string))
    (title "")
    (last-access "" ; TODO: Remove with Nyxt 2.0?
                 :type (or string time:timestamp)
@@ -25,24 +29,23 @@ compatibility to import the old flat history.")
    ;; TODO: For now we never increment the explicit-visits count.  Maybe we
    ;; could use a new buffer slot to signal that the last load came from an
    ;; explicit request?
-   (explicit-visits 0
-                    :type integer
-                    :documentation "
-Number of times the URL was visited by a prompt buffer request.  This does not
+   (explicit-visits
+    0
+    :type integer
+    :documentation "Number of times the URL was visited by a prompt buffer request.  This does not
 include implicit visits.")
-   (implicit-visits 0
-                    :type integer
-                    :documentation "
-Number of times the URL was visited by following a link on a page.  This does
-not include explicit visits.")
+   (implicit-visits
+    0
+    :type integer
+    :documentation "Number of times the URL was visited by following a link on a page.
+This does not include explicit visits.")
    (scroll-position '()
                     :type (list-of number)
                     :documentation "The scroll position user was at when last visiting the page.
 It's a list of a form (Y &OPTIONAL X)."))
   (:export-class-name-p t)
   (:export-accessor-names-p t)
-  (:documentation "
-Entry for the global history.
+  (:documentation "Entry for the global history.
 The total number of visit for a given URL is (+ explicit-visits implicit-visits)."))
 
 (defmethod prompter:object-attributes ((entry history-entry) (source prompter:source))
@@ -98,7 +101,8 @@ class."
   (htree:make :key 'history-tree-key :initial-owners (when buffer (list (id buffer)))))
 
 (define-command delete-history-entry (&key (buffer (current-buffer)))
-  "Delete queried history entries."
+  "Delete queried history entries.
+Only deletes the disowned entries (= the ones not belonging to a buffer)."
   (let ((entries (prompt
                   :prompt "Delete entries"
                   :sources (make-instance 'history-disowned-source
@@ -107,19 +111,18 @@ class."
       (dolist (entry entries)
         (htree:delete-data history entry)))))
 
-(define-command reset-buffer-history (&optional buffer)
-  "Set selected buffers history to the current URL only.
+(define-command reset-buffer-history (&key (buffers (prompt :prompt "Reset histories of buffer(s)"
+                                                            :sources (make-instance
+                                                                      'buffer-source
+                                                                      :actions-on-return #'identity))))
+  "Set selected BUFFER's history to the current URL only.
 This removes the parenthood with the parent buffer, if there was any.
 
 When called over many or all buffers, it may free many history entries which
 then become available for deletion with `delete-history-entry'."
-  (let ((buffers (or (alex:ensure-list buffer)
-                     (prompt :prompt "Reset histories of buffer(s)"
-                             :sources (make-instance 'buffer-source
-                                                     :actions-on-return #'identity)))))
-    (files:with-file-content (history (history-file (current-buffer)))
-      (dolist (buffer buffers)
-        (htree:reset-owner history (id buffer))))))
+  (files:with-file-content (history (history-file (current-buffer)))
+    (dolist (buffer buffers)
+      (htree:reset-owner history (id buffer)))))
 
 (defun score-history-entry (htree-entry)
   "Return history ENTRY score.
@@ -138,8 +141,7 @@ lot."
            (* 1.0
               ;; Inverse number of hours since the last access.
               (/ 1
-                 (1+ (/ (time:timestamp-difference (time:now)
-                                                         last-access)
+                 (1+ (/ (time:timestamp-difference (time:now) last-access)
                         (* 60 60)))))
            0))))
 
@@ -313,7 +315,7 @@ lot."
     history))
 
 (defun restore-history-buffers (history history-file)
-  "Restore buffers corresponding to the HISTORY owners.
+  "Restore buffers corresponding to the HISTORY owners from HISTORY-FILE.
 
 This modifies the history owners as follows.
 For each owner, make a buffer, swap old owner identifier for the new buffer ID
@@ -371,10 +373,13 @@ Return non-NIL of history was restored, NIL otherwise."
            nil)))))
 
 (defun histories-directory (&optional (buffer (current-buffer)))
+  "Get the directory where history files are stored, based on `history-file' of BUFFER."
   (when (context-buffer-p buffer)
     (files:parent (files:expand (history-file buffer)))))
 
 (defun histories-list (&optional (buffer (current-buffer)))
+  "List all the files with persisted history.
+Uses `histories-directory' of the BUFFER to get files."
   (alex:when-let ((dir (histories-directory buffer)))
     (sera:keep "lisp" (uiop:directory-files dir)
                :test 'string-equal
@@ -385,13 +390,14 @@ Return non-NIL of history was restored, NIL otherwise."
    (prompter:constructor (mapcar #'pathname-name (histories-list)))
    (prompter:hide-attribute-header-p :single)))
 
-(define-command store-history-by-name ()
-  "Store the history data in the file named by user input.
-Useful for session snapshots, as `restore-history-by-name' will restore opened buffers."
-  (sera:and-let* ((name (prompt1
-                         :prompt "The name to store history with"
-                         :sources (list 'prompter:raw-source
-                                        (make-instance 'history-name-source))))
+(define-command store-history-by-name (&key (name (prompt1
+                                                   :prompt "The name to store history with"
+                                                   :sources (list 'prompter:raw-source
+                                                                  (make-instance 'history-name-source)))))
+  "Store the history data in the file with NAME.
+Useful for session snapshots, as `restore-history-by-name' will restore opened
+buffers alongside history contents."
+  (sera:and-let* ((name name)
                   (new-file (make-instance 'history-file
                                            :base-path (make-pathname
                                                        :name name
@@ -401,14 +407,14 @@ Useful for session snapshots, as `restore-history-by-name' will restore opened b
       (setf (files:content new-file) (buffer-history))
       (echo "History stored to ~s." (files:expand new-file)))))
 
-(define-command restore-history-by-name ()
-  "Delete all the buffers of the current session/history and import the history chosen by user.
+(define-command restore-history-by-name (&key (name (prompt1 :prompt "The name of the history to restore"
+                                                             :sources 'history-name-source)))
+  "Delete all the buffers of the current session/history and import the history with NAME.
 The imported history file is untouched while the current one is overwritten.
 If you want to save the current history file beforehand, call
 `store-history-by-name' to save it under a new name."
   ;; TODO: backup current history?
-  (sera:and-let* ((name (prompt1 :prompt "The name of the history to restore"
-                                 :sources 'history-name-source))
+  (sera:and-let* ((name name)
                   (new-file (make-instance 'history-file
                                            :base-path (make-pathname
                                                        :name name

--- a/source/keyscheme.lisp
+++ b/source/keyscheme.lisp
@@ -30,13 +30,13 @@
 (export-always 'make-keyscheme)
 (defun make-keyscheme (name &rest parents)
   "Return a new `nkeymaps:keyscheme' object of type `nyxt-keymap-value'.
-The scheme name inherits from the optional PARENTS, ordered by priority.
+The keyscheme inherits from the optional PARENTS, ordered by priority.
 
 Example:
 
-  (defvar emacs (make-keyscheme \"emacs\" cua))
+  (defvar cua-child (make-keyscheme \"cua-child\" cua))
 
-In the above, we define a new scheme name called `emacs' which inherits from the
+In above example defines a keyscheme called `cua-child', which inherits from the
 existing keyscheme `cua'."
   (the (values nkeymaps:keyscheme &optional)
        (make-instance 'nkeymaps:keyscheme

--- a/source/mode/annotate.lisp
+++ b/source/mode/annotate.lisp
@@ -2,30 +2,20 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/annotate
-  (:documentation "Mode to annotate documents.
+  (:documentation "Package for `annotate-mode', mode to annotate documents.
 
-Important pieces of functionality are (together with an obvious
-`annotate-mode'):
-- `annotation' and its subclasses: `url-annotation' and `snippet-annotation'.
-- Commands:
-  - `annotate-current-url'.
-  - `annotate-highlighted-text'.
-  - `show-annotation'.
-  - `show-annotations'.
-  - `show-annotations-for-current-url'."))
+The most important piece of functionality is the `annotation' class and its
+subclasses: `url-annotation' and `snippet-annotation'.
+
+See the `annotate-mode' for the external user-facing APIs."))
 (in-package :nyxt/mode/annotate)
 
 (define-mode annotate-mode ()
   "Annotate document with arbitrary comments.
 Annotations are persisted to disk, see the `annotations-file' mode slot.
 
-Commands are:
-- `annotate-current-url' and `annotate-highlighted-text' to create
-  annotations.
-- `show-annotation' and `show-annotations' to show the annotations
-  unconditionally.
-- And `show-annotations-for-current-url' to show the ones associated with the
-  current page."
+See `nyxt/mode/annotate' package documentation for implementation details and
+internal programming APIs."
   ((visible-in-status-p nil)
    (annotations-file
     (make-instance 'annotations-file)

--- a/source/mode/autofill.lisp
+++ b/source/mode/autofill.lisp
@@ -13,7 +13,9 @@ The whole API is centered around `autofill' class and its slots:
 autofill.
 
 Then, the command eponymously called `autofill' actually fills (with
-`ffi-buffer-paste') the contents into the page."))
+`ffi-buffer-paste') the contents into the page.
+
+See the `autofill-mode' for the external user-facing APIs."))
 (in-package :nyxt/mode/autofill)
 
 (export-always 'make-autofill)
@@ -21,7 +23,10 @@ Then, the command eponymously called `autofill' actually fills (with
   (apply #'make-instance 'autofill args))
 
 (define-mode autofill-mode ()
-  "Mode to fill forms more rapidly (with `autofill' command)."
+  "Mode to fill forms more rapidly.
+
+See `nyxt/mode/autofill' package documentation for implementation details and
+internal programming APIs."
   ((visible-in-status-p nil)
    (rememberable-p t)
    (autofills

--- a/source/mode/blocker.lisp
+++ b/source/mode/blocker.lisp
@@ -2,7 +2,7 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/blocker
-  (:documentation "Block resource queries for listed hosts.
+  (:documentation "Package for `blocker-mode', mode to block requests for listed hosts.
 `blocker-mode' relies on:
 - `hostlist' as the hostlist representation.
 - `*default-hostlist*' as the most reliable hostlist.
@@ -63,7 +63,10 @@ Example:
   ((nyxt/mode/blocker:hostlists (list *my-blocked-hosts* nyxt/mode/blocker:*default-hostlist*))))
 
 \(define-configuration :buffer
-  ((default-modes (append '(my-blocker-mode) %slot-default%))))"
+  ((default-modes (append '(my-blocker-mode) %slot-default%))))
+
+See `nyxt/mode/blocker' package documentation for implementation details and
+internal programming APIs."
   ((hostlists (list *default-hostlist*))
    (blocked-hosts
     (make-hash-table :test 'equal)

--- a/source/mode/bookmark-frequent-visits.lisp
+++ b/source/mode/bookmark-frequent-visits.lisp
@@ -2,7 +2,7 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/bookmark-frequent-visits
-  (:documentation "Mode to bookmark frequently visited URLs.
+  (:documentation "Package for `bookmark-frequent-visits-mode', mode to bookmark frequently visited URLs.
 The substance of it is `bookmark-frequent-visit' function."))
 (in-package :nyxt/mode/bookmark-frequent-visits)
 

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -2,15 +2,11 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/bookmark
-  (:documentation "Manage bookmarks.
+  (:documentation "Package for `bookmark-mode', mode to manage bookmarks.
 The main object is `bookmark-entry'. The main function to add a bookmark is
-`bookmark-add'. Commands utilizing it are:
-- `bookmarks-panel' (panel command).
-- `list-bookmarks' (internal page).
-- `bookmark-current-url', `bookmark-buffer-url', `bookmark-url', and
-  `bookmark-hint' to add bookmarks. `delete-bookmark' to remove.
-- `set-url-from-bookmark'.
-- `import-bookmarks-from-html'."))
+`bookmark-add'.
+
+See the `bookmark-mode' for the external user-facing APIs."))
 (in-package :nyxt/mode/bookmark)
 
 ;;; We don't use CL-prevalence to serialize / deserialize bookmarks for a couple for reasons:
@@ -30,12 +26,8 @@ The main object is `bookmark-entry'. The main function to add a bookmark is
   "Manage bookmarks.
 Bookmarks can be persisted to disk, see the `bookmarks-file' mode slot.
 
-- `bookmark-current-url', `bookmark-buffer-url', `bookmark-url', and
-  `bookmark-hint' to add bookmarks. `delete-bookmark' to remove them.
-- `set-url-from-bookmark' to open a bookmark.
-- `list-bookmarks' to list bookmarks as a separate page.
-- `bookmarks-panel' to show all bookmarks as a panel.
-- `import-bookmarks-from-html' to import the HTML-formatted bookmarks."
+See `nyxt/mode/bookmark' package documentation for implementation details and
+internal programming APIs."
   ((visible-in-status-p nil)
    (bookmarks-file
     (make-instance 'bookmarks-file)

--- a/source/mode/buffer-listing.lisp
+++ b/source/mode/buffer-listing.lisp
@@ -2,8 +2,7 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/buffer-listing
-  (:documentation "Mode for buffer listing.
-See `buffer-listing-mode'."))
+  (:documentation "Package for `buffer-listing-mode', mode for buffer listing."))
 (in-package :nyxt/mode/buffer-listing)
 
 (define-mode buffer-listing-mode ()

--- a/source/mode/cruise-control.lisp
+++ b/source/mode/cruise-control.lisp
@@ -8,12 +8,7 @@ The main API point is `cruise-control-mode'."))
 
 (define-mode cruise-control-mode (nyxt/mode/repeat:repeat-mode)
   "Mode for automatically scrolling up and down the page.
-Is an extension of `nyxt/mode/repeat:repeat-mode'.
-
-Commands changing velocity are:
-- `velocity-incf'.
-- `velocity-decf'.
-- `velocity-zero'."
+Is an extension of `nyxt/mode/repeat:repeat-mode'."
   ((rememberable-p t)
    (velocity 0 :documentation "The distance the page is scrolling up or down
   each update interval. A positive velocity corresponds to scrolling down, a

--- a/source/mode/help.lisp
+++ b/source/mode/help.lisp
@@ -2,11 +2,15 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/help
-    (:documentation "Mode to enhance navigation on internal documentation pages."))
+  (:documentation "Mode to enhance navigation on internal documentation pages."))
 (in-package :nyxt/mode/help)
 
 (define-mode help-mode ()
-  "Mode for help and documentation pages."
+  "Mode for help and documentation pages.
+
+Useful to enable on Nyxt help pages (such as `manual' or `describe-*') to
+provide convenient navigation keybindings.  For instance, \"s\" becomes bound
+`nyxt/mode/search-buffer:search-buffer'."
   ((visible-in-status-p nil)
    (keyscheme-map
     (define-keyscheme-map "help-mode" ()

--- a/source/mode/hint-prompt-buffer.lisp
+++ b/source/mode/hint-prompt-buffer.lisp
@@ -2,11 +2,11 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/hint-prompt-buffer
-    (:documentation "Prompt buffer mode for element hints."))
+  (:documentation "Package for `hint-prompt-buffer-mode', prompt buffer mode for element hints."))
 (in-package :nyxt/mode/hint-prompt-buffer)
 
 (define-command toggle-hints-transparency (&key (buffer (current-buffer)))
-  "Toggle the on-screen element hints transparency."
+  "Toggle the transparency of all element hints in BUFFER."
   (ps-eval :buffer buffer
     (ps:dolist (element (nyxt/ps:qsa document ".nyxt-hint"))
       (if (or (= (ps:@ element style opacity) "1")
@@ -15,13 +15,15 @@
           (setf (ps:@ element style opacity) "1.0")))))
 
 (define-command scroll-to-hint (&key (buffer (current-buffer)))
-  "Show the selected hint on screen."
+  "Display the current hint and center it in BUFFER."
   (with-current-buffer buffer
     (nyxt/mode/hint:highlight-selected-hint :element (current-suggestion-value)
                                             :scroll t)))
 
 (define-mode hint-prompt-buffer-mode (nyxt/mode/prompt-buffer:prompt-buffer-mode)
-  "Prompt buffer mode for element hinting."
+  "`prompt-buffer' mode for element hinting.
+
+Provides keybindings `toggle-hints-transparency' and `scroll-to-hint'."
   ((visible-in-status-p nil)
    (keyscheme-map
     (define-keyscheme-map "hint-prompt-buffer-mode" ()

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -2,7 +2,11 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/hint
-    (:documentation "Mode for element hints."))
+  (:documentation "Package for element hints infrastructure and `hint-mode'.
+
+Exposes the APIs below:
+- `query-hints' as the main driver for hinting procedures.
+- `hint-source' for `prompt-buffer' interaction."))
 (in-package :nyxt/mode/hint)
 
 (define-mode hint-mode ()

--- a/source/mode/history-tree.lisp
+++ b/source/mode/history-tree.lisp
@@ -2,11 +2,14 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/history-tree
-    (:documentation "Mode for history-trees."))
+  (:documentation "Package for `history-tree-mode', mode for history-trees styling."))
 (in-package :nyxt/mode/history-tree)
 
 (define-mode history-tree-mode ()
-  "Mode for history-tree listing."
+  "Mode for history-tree listing.
+
+Used by pages like `nyxt/mode/history:buffer-history-tree' and
+`nyxt/mode/history:history-tree'."
   ((visible-in-status-p nil)
    (style (theme:themed-css (theme *browser*)
             `(* :margin 0
@@ -34,7 +37,7 @@
               :content "' '"
               :position "absolute"
               :width "1px"
-              :background-color ,theme:on-background ; is this right??
+              :background-color ,theme:on-background ; FIXME: Is this right?
               :color ,theme:background
               :top "5px"
               :bottom "-12px"
@@ -48,7 +51,7 @@
               :content "' '"
               :position "absolute"
               :width "1px"
-              :background-color ,theme:on-background ; is this right??
+              :background-color ,theme:on-background ; FIXME: Is this right?
               :color ,theme:background
               :top "5px"
               :bottom "7px"
@@ -60,7 +63,7 @@
               :left "-10px"
               :width "10px"
               :height "1px"
-              :background-color ,theme:on-background ; is this right
+              :background-color ,theme:on-background ; FIXME: Is this right?
               :color ,theme:background
               :top "12px"))))
   (:toggler-command-p nil))

--- a/source/mode/input-edit.lisp
+++ b/source/mode/input-edit.lisp
@@ -2,10 +2,23 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/input-edit
-    (:documentation "Mode for editing HTML input areas."))
+  (:documentation "Mode for editing HTML input areas with convenient keybindings.
+
+In addition to the commands `input-edit-mode' exposes, there are
+several internal utilities for general HTML input editing:
+- Parenscript functions:
+  - `active-input-area-content'.
+  - `set-active-input-area-content'.
+  - `active-input-area-cursor'.
+  - `set-active-input-area-cursor'.
+- Macros `with-text-buffer' and `with-input-area'.
+- Definition macro `define-input-edit-command'.
+
+Several editing commands are based on `move-n-elements' internal
+function."))
 (in-package :nyxt/mode/input-edit)
 
-;;;; commands for navigating/editing input fields on HTML pages
+;;;; Commands for navigating/editing input fields on HTML pages.
 
 (define-parenscript active-input-area-content ()
   (ps:chain (nyxt/ps:active-element document) value))
@@ -26,7 +39,7 @@
 (export-always 'with-text-buffer)
 (defmacro with-text-buffer ((buffer-name cursor-name
                              &optional initial-contents
-                                       initial-cursor-position)
+                               initial-cursor-position)
                             &body body)
   `(let ((,buffer-name (make-instance 'text-buffer:text-buffer))
          (,cursor-name (make-instance 'text-buffer:cursor)))
@@ -130,9 +143,9 @@
                                     (cluffer:cursor-position cursor)))))
 
 (define-mode input-edit-mode ()
-  "Mode for editing input areas in HTML. Overrides many of the
-bindings in other modes, so you will have to disable/enable it as
-necessary."
+  "Mode for editing input areas in HTML.
+Overrides many of the bindings in other modes, so you will have to
+disable/enable it as necessary."
   ((visible-in-status-p nil)
    (rememberable-p nil)
    (keyscheme-map

--- a/source/mode/keyscheme.lisp
+++ b/source/mode/keyscheme.lisp
@@ -2,13 +2,26 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/keyscheme
-  (:documentation "All modes that set `keyscheme' should inherit from this mode.
+  (:documentation "Package for `keyscheme-mode' that all modes setting `keyscheme' should inherit from.
 Ensures that a single keybindings mode, such as `nyxt/mode/emacs', is enabled."))
 (in-package :nyxt/mode/keyscheme)
 
 (define-mode keyscheme-mode ()
   "All modes that set `keyscheme' should inherit from this mode.
-Ensures that a single keybindings mode, such as `nyxt/mode/emacs', is enabled."
+Ensures that a single keybindings mode, such as `nyxt/mode/emacs', is enabled.
+
+In addition to inheriting this mode for your keyscheme mode, define a new
+keyscheme in `nyxt/keyscheme' with `nyxt/keyscheme:make-keyscheme' so that you
+can conveniently reference it with \"keyscheme:mode-name\" shortcut.
+
+Example of defining a keyscheme mode:
+
+;; Beware that this may raise package locks condition on SBCL.
+(defvar keyscheme:my-keyscheme-mode
+        (keyscheme:make-keyscheme \"my-keyscheme-mode\" keyscheme:default))
+
+(define-mode my-keyscheme-mode (nyxt/mode/keyscheme:keyscheme-mode)
+  ((keyscheme keyscheme:my-keyscheme-mode)))"
   ((rememberable-p nil)
    (keyscheme                           ; This specialized `nyxt:keyscheme'.
     keyscheme:cua

--- a/source/mode/list-history.lisp
+++ b/source/mode/list-history.lisp
@@ -2,11 +2,12 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/list-history
-    (:documentation "Mode for listing history."))
+  (:documentation "Package for `list-history-mode', mode for history listing styles."))
 (in-package :nyxt/mode/list-history)
 
 (define-mode list-history-mode ()
-  "Mode for listing history."
+  "Mode for listing history.
+Used by `nyxt/mode/history:list-history'."
   ((visible-in-status-p nil)
    (style (theme:themed-css (theme *browser*)
             `(a

--- a/source/mode/macro-edit.lisp
+++ b/source/mode/macro-edit.lisp
@@ -2,16 +2,24 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/macro-edit
-    (:documentation "Mode for editing macros."))
+    (:documentation "Package for `macro-edit-mode', mode for editing macros.
+
+There are implementation details for (almost) every command in this mode:
+- `edit-macro': `render-functions'.
+- `add-command': `add-function', `remove-function', `macro-name', and
+  `generate-macro-form'.
+- `save-macro': `macro-form-valid-p'."))
 (in-package :nyxt/mode/macro-edit)
 
 (define-mode macro-edit-mode ()
-  "Mode for creating and editing macros."
+  "Mode for creating and editing macros.
+
+See `nyxt/mode/macro-edit' package documentation for implementation details."
   ((visible-in-status-p nil)
    (macro-name
     ""
     :accessor nil
-    :documentation "The name used for the macro.")
+    :documentation "The descriptive name used for the macro.")
    (functions
     '()
     :documentation "Functions the user has added to their macro."))

--- a/source/mode/message.lisp
+++ b/source/mode/message.lisp
@@ -2,16 +2,18 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/message
-    (:documentation "Mode for messages and logs"))
+  (:documentation "Package for `message-mode', a mode for messages and logs display.
+All the APIs of the `message-mode' are exported, no implementation details."))
 (in-package :nyxt/mode/message)
 
 (define-mode message-mode ()
-  "Mode for log and message listing."
+  "Mode for log and message listing.
+Mainly used on `list-messages' page."
   ((visible-in-status-p nil))
   (:toggler-command-p nil))
 
 (define-command clear-messages ()
-  "Clear the *Messages* buffer."
+  "Clear the *Messages* buffer and the underlying message data."
   (setf (slot-value *browser* 'messages-content) '())
   (echo "Messages cleared."))
 

--- a/source/mode/no-image.lisp
+++ b/source/mode/no-image.lisp
@@ -2,11 +2,13 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/no-image
-    (:documentation "Mode to disable image display in buffer."))
+  (:documentation "Package for `no-image-mode', mode to disable image display in buffer.
+Uses `ffi-buffer-auto-load-image-enabled-p' internally."))
 (in-package :nyxt/mode/no-image)
 
 (define-mode no-image-mode ()
-  "Disable images in current buffer.")
+  "Disable images in current buffer.
+Might need page reload to take effect.")
 
 (defmethod enable ((mode no-image-mode) &key)
   (setf (ffi-buffer-auto-load-image-enabled-p (buffer mode)) nil))

--- a/source/mode/no-procrastinate.lisp
+++ b/source/mode/no-procrastinate.lisp
@@ -3,12 +3,25 @@
 
 (nyxt:define-package :nyxt/mode/no-procrastinate
   (:use :nyxt/mode/blocker)
-  (:documentation "Block resource queries for listed hosts."))
+  (:documentation "Package for `no-procrastinate-mode' to lock requests for listed hosts.
+
+`no-procrastinate-entry' is the main class encapsulating the logic of
+entries. `no-procrastinate-add' is the wrapper around it to add new entries.
+
+`serialize-object' is the method to print these hosts to the Lisp file
+`read'ably.
+
+The mode itself inherits from `nyxt/mode/blocker:blocker-mode' and reuses its APIs."))
 (in-package :nyxt/mode/no-procrastinate)
+
+;;; TODO: Remove? It's mostly poorly duplicating the blocker-mode logic and is
+;;; poorly written, rotting in the dark.
 
 (export-always '*default-hostlist-no-procrastinate*)
 (defparameter *default-hostlist-no-procrastinate*
   (make-instance 'hostlist
+                 ;; FIXME: Use a local file instead of the absolutely
+                 ;; unnecessary network round-trip.
                  :url (quri:uri "https://raw.githubusercontent.com/atlas-engineer/default-hosts-no-procrastinate/main/hosts")
                  :base-path #p"hostlist-no-procrastinate.txt")
   "Default hostlist for `no-procrastinate-mode'.")
@@ -19,7 +32,16 @@
   (:export-class-name-p t))
 
 (define-mode no-procrastinate-mode (nyxt/mode/blocker:blocker-mode)
-  "Mode to block access to hosts associated with procrastination."
+  "Mode to block access to hosts associated with procrastination.
+
+Hostlists belong to hostlist-no-procrastinate.txt file in data directory.
+
+`*default-hostlist-no-procrastinate*' is a simple way to set things up for your
+hostlists. See `nyxt/mode/blocker:blocker-mode' documentation for how to
+configure such a hostlist variable.
+
+See `nyxt/mode/no-procrastinate' package documentation for implementation
+details and internal programming APIs."
   ((rememberable-p nil)
    (no-procrastinate-hosts-file
     (make-instance 'no-procrastinate-hosts-file)

--- a/source/mode/no-script.lisp
+++ b/source/mode/no-script.lisp
@@ -2,13 +2,21 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/no-script
-    (:documentation "Disable Javascript."))
+    (:documentation "Package for `no-script-mode', mode to disable JavaScript.
+
+Uses `ffi-buffer-javascript-markup-enabled-p' internally and hooks into
+`nyxt:on-signal-load-started' to allow toggling JS on internal pages."))
 (in-package :nyxt/mode/no-script)
 
 (define-mode no-script-mode ()
   "Disable Javascript in current buffer.
-If the current URL is an internal one (for instance 'nyxt://...'), JavaScript is enabled.
-It's automatically disabled when loading a non-internal URL.")
+
+Internal URLs ('nyxt://...') always have JavaScript enabled, otherwise they
+wouldn't be functional.  In other words, enabling `no-script-mode' is gracefully
+ignored.
+
+See `nyxt/mode/no-script' package documentation for implementation details and
+internal programming APIs.")
 
 (defmethod enable ((mode no-script-mode) &key)
   (echo "Reload the buffer for no-script-mode to take effect."))

--- a/source/mode/no-sound.lisp
+++ b/source/mode/no-sound.lisp
@@ -2,11 +2,16 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/no-sound
-    (:documentation "Disable sound."))
+  (:documentation "Package for `no-sound-mode', mode to disable sound.
+
+Uses `ffi-buffer-sound-enabled-p' internally."))
 (in-package :nyxt/mode/no-sound)
 
 (define-mode no-sound-mode ()
-  "Disable sound in current buffer.")
+  "Disable sound in current buffer.
+
+See `nyxt/mode/no-sound' package documentation for implementation details and
+internal programming APIs.")
 
 (defmethod enable ((mode no-sound-mode) &key)
   (setf (ffi-buffer-sound-enabled-p (buffer mode)) nil))

--- a/source/mode/no-webgl.lisp
+++ b/source/mode/no-webgl.lisp
@@ -2,14 +2,20 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/no-webgl
-    (:documentation "Disable WebGL."))
+  (:documentation "Package for `no-webgl-mode', mode to disable WebGL.
+
+Uses `ffi-buffer-webgl-enabled-p' internally and saves the settings to
+`previous-webgl-setting'."))
 (in-package :nyxt/mode/no-webgl)
 
 (define-mode no-webgl-mode ()
-  "Disable WebGL in current buffer."
-  ((previous-webgl-setting nil
-                           :documentation "The state of WebGL before
-no-webgl-mode was enabled.")))
+  "Disable WebGL in current buffer.
+
+See `nyxt/mode/no-webgl' package documentation for implementation details and
+internal programming APIs."
+  ((previous-webgl-setting
+    nil
+    :documentation "The state of WebGL before `no-webgl-mode' was enabled.")))
 
 (defmethod enable ((mode no-webgl-mode) &key)
   (setf (previous-webgl-setting mode) (ffi-buffer-webgl-enabled-p (buffer mode)))

--- a/source/mode/passthrough.lisp
+++ b/source/mode/passthrough.lisp
@@ -2,16 +2,19 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/passthrough
-    (:documentation "Forward all keybindings to the web view except those in the `override-map'."))
+  (:documentation "Package for `passthrough-mode', mode to forward all keybindings to the page.
+
+Keybindings in the `override-map' are an exception to the passthrough.
+
+Utilizes the `nyxt/keyscheme' API, `nyxt/mode/keyscheme' APIs, and
+`current-keymaps-hook' or `input-buffer'."))
 (in-package :nyxt/mode/passthrough)
 
-;;; Moving modes out of the `modes' slot is a bad idea: too many parts rely on
-;;; the presence of the `modes' slot. Instead, use a hook to temporarily override
-;;; the keymaps of all modes (except the override-map).
-
 (define-mode passthrough-mode ()
-  "Mode that forwards all keys to the renderer.
-See the mode `keyscheme-map' for special bindings."
+  "Mode that forwards all keys to the page.
+
+See the mode `keyscheme-map' for special bindings and `nyxt/mode/passthrough'
+package documentation for implementation details and internal programming APIs."
   ((visible-in-status-p nil)
    (keyscheme-map
     (define-keyscheme-map "passthrough-mode" ()

--- a/source/mode/password.lisp
+++ b/source/mode/password.lisp
@@ -2,14 +2,30 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/password
-    (:documentation "Interface with third-party password managers."))
+  (:documentation "Package for `password-mode', mode to  interface with password managers.
+
+Relies on the `password' library for most package manager interactions. In
+particular:
+- Specifies `password::execute' for KeePassXC to prompt for Yubikey tap.
+- Specifies `password:complete-interface' to prompt for details for interfaces
+  that need it.
+- Adds a `with-password' macro relying on `password:password-correct-p' to
+  decide whether the interface is properly connected and complete, and calling
+  `password:complete-interface' if it's not.
+
+Also note the internal `make-password-interface-user-classes' function to force
+password interfaces to become `user-class'es and thus
+`define-configuration'-friendly.
+
+See the `password-mode' for the external user-facing APIs."))
 (in-package :nyxt/mode/password)
 
 (define-mode password-mode ()
   "Enable interface with third-party password managers.
 You can customize the default interface with the mode slot `password-interface'.
-To interact with the password manager, see commands like `copy-password' or
-`save-new-password'."
+
+See `nyxt/mode/password' package documentation for implementation details and
+internal programming APIs."
   ((visible-in-status-p nil)
    (password-interface
     (make-password-interface)

--- a/source/mode/plaintext-editor.lisp
+++ b/source/mode/plaintext-editor.lisp
@@ -6,7 +6,10 @@
 (define-mode plaintext-editor-mode (editor-mode)
   "Mode for basic plaintext editing.
 
+It renders the file in a single textarea HTML element.
+
 To enable it, add this to your configuration file:
+
 \(define-configuration nyxt/mode/editor::editor-buffer
   ((default-modes (cons 'nyxt/mode/editor::plaintext-editor-mode %slot-value%))))"
   ((visible-in-status-p nil)

--- a/source/mode/preview.lisp
+++ b/source/mode/preview.lisp
@@ -2,7 +2,12 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/preview
-    (:documentation "Refresh file when changed on disk."))
+  (:documentation "Package for `preview-mode', mode to refresh file when changed on disk.
+
+Extends `nyxt/mode/process:process-mode' with custom actions and relies on the
+custom `updated-file-p' `nyxt/mode/process:firing-condition'.
+
+See the `preview-mode' documentation for the external user-facing APIs."))
 (in-package :nyxt/mode/preview)
 
 (defun updated-file-p (path-url mode)
@@ -14,7 +19,9 @@
          (last-access mode)))))
 
 (define-mode preview-mode (nyxt/mode/process:process-mode)
-  "Refreshes the buffer when associated local file is changed."
+  "Refreshes the buffer when associated local file is changed.
+
+See `nyxt/mode/preview' package documentation for implementation details and internal programming APIs."
   ((visible-in-status-p nil)
    (rememberable-p t)
    (nyxt/mode/process:firing-condition #'updated-file-p)
@@ -28,12 +35,10 @@
 
 (in-package :nyxt)
 
-(define-command preview-file (&optional file (buffer (current-buffer)))
-  "Open FILE in BUFFER and call `preview-mode' to continuously watch and refresh
-it."
-  (alex:when-let
-      ((file (or file (prompt :prompt "File to preview"
-                              :input (quri:uri-path (url (current-buffer)))
-                              :sources 'nyxt/mode/file-manager:file-source))))
-    (buffer-load (quri.uri.file:make-uri-file :path file) :buffer buffer)
-    (enable (make-instance 'nyxt/mode/preview:preview-mode :buffer buffer))))
+(define-command preview-file (&key (buffer (current-buffer))
+                              (file (prompt :prompt "File to preview"
+                                            :input (quri:uri-path (url buffer))
+                                            :sources 'nyxt/mode/file-manager:file-source)))
+  "Open a local FILE in BUFFER and call `preview-mode' to watch and refresh it."
+  (buffer-load (quri.uri.file:make-uri-file :path file) :buffer buffer)
+  (enable (make-instance 'nyxt/mode/preview:preview-mode :buffer buffer)))

--- a/source/mode/process.lisp
+++ b/source/mode/process.lisp
@@ -2,7 +2,22 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (nyxt:define-package :nyxt/mode/process
-    (:documentation "Act on file/directory based on a certain condition."))
+  (:documentation "Package for `process-mode', mode to conditionally act on file/directory.
+
+APIs that `process-mode' has:
+- Slots:
+  - `path-url' to set the path tracked by the mode.
+  - `firing-condition', continuously checked for whether to run the...
+  - `action'---the actual thing to run.
+  - `cleanup' runs after `firing-condition' returns :RETURN to clean up the mode.
+  - `thread' as the thread that all the `action's happen on. Usually needs not
+    be altered, because the default is intuitive enough.
+- Internal helpers:
+  - `thread-alive-p' to check on the `thread'.
+  - `call-cleanup' to relay things to `cleanup' code.
+
+It also uses threading utilities like `destroy-thread*', `sera:synchronized',
+and `bt:thread-alive-p'."))
 (in-package :nyxt/mode/process)
 
 (define-mode process-mode ()
@@ -12,7 +27,12 @@ Possible applications:
 - Web server.
 - Live preview of documents (`nyxt/mode/preview').
 - Refreshing a URL at regular intervals (`nyxt/mode/watch').
-- Live tracking of filesystem/data in a file/directory."
+- Live tracking of filesystem/data in a file/directory.
+
+The mode itself should not be used directly. Rather, it should be subclassed and
+extended with custom logic.
+
+See `nyxt/mode/process' package documentation for implementation details and internal programming APIs."
   ((visible-in-status-p nil)
    (rememberable-p nil)
    (path-url


### PR DESCRIPTION
# Description

This documents lots of modes as an attempt to document everything for #2303 (with minor indentation and function signature fixes I was unable to resist). @Ambrevar, @aadcg, you can push your documentation improvements to this branch, if you want to.

**Manual testing and bugfixes don't belong to this PR, it's about documentation exclusively. Push to master or open separate PRs for that.**

# Discussion

## Documentation formats
It the course of documenting things, I've kind of settled at a certain structure for package and mode documentation. Packages are for implementation details and APIs, modes are for commands, configuration, and other user-facing things. That's why their documentation is interlinked, but different. Here's what I've arrived at:

### Package 
```
Package for `...-mode', mode for [description].

Implementation details (functions, macros, classes, sources etc.):
- [...]
- [...]
[...]

See the `...-mode' for the external user-facing APIs.
```

## #Mode
```
[Concise and plain language description of the mode]
[Additional details about it]

Commands:
[...]

Configuration options:
[...]

Example configuration:
[...]

See `nyxt/mode/...' package documentation for implementation details and internal programming APIs.
```

Obviously, these formats are merely a recommendation, because every mode is unique. But still, would be nice to have a certain consistency and structure. So @Ambrevar, @aadcg, try using these formats and feel free to suggest better ones for us to have!

## Responsibility distribution

@Ambrevar, can I take care of `repeat-mode`, `editor-mode`, and `cruise-control-mode` documentation now that they're broken/underdocumented?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [X] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.