### PR TITLE
mode/editor: Review delete-current-buffer keybinding.

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -697,7 +697,9 @@ color-picker support as an example application for this feature.")
 (define-version "3.X.Y"
   (:ul
    (:li "REPL provides symbol suggestions with " (:code "tab") "/" (:code "C-i") ".")
-   (:li "Re-enable global history."))
+   (:li "Re-enable global history.")
+   (:li "Bind " (:nxref :command 'nyxt:delete-current-buffer) " uniformly for
+all modes, when using the CUA keyscheme."))
   (:h3 "Programming interfaces")
   (:ul
    (:li (:code "conservative-history-movement-p") " was deprecated in favor of "

--- a/source/mode/editor.lisp
+++ b/source/mode/editor.lisp
@@ -36,7 +36,7 @@ impelementation."
       (list
        "C-o" 'editor-open-file
        "C-s" 'editor-write-file
-       "C-q" 'delete-current-buffer
+       "C-w" 'delete-current-buffer
        "C-tab" 'switch-buffer)
       keyscheme:emacs
       (list


### PR DESCRIPTION
In accordance to how it's bound in base-mode.

# Description

[See this comment](https://github.com/atlas-engineer/nyxt/issues/2984#issuecomment-1563237870).

# Discussion

I can't think of any reason why we had this command bound to different keys depending on the mode for CUA users.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
