### PR TITLE
Add collapse prompt buffer command

### DIFF
--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -62,7 +62,8 @@ listed and chosen from with the command `set-action-on-return' (bound to
        ; TODO: This is the Emacs Helm binding.  Better?
        "C-c C-f" 'toggle-actions-on-current-suggestion-enabled
        ; TODO: This is the Emacs Helm binding.  Better?
-       "C-]" 'toggle-attributes-display)
+       "C-]" 'toggle-attributes-display
+       "M-shift-up" 'toggle-suggestions-display)
       keyscheme:cua
       (list
        "C-up" 'first-suggestion
@@ -315,6 +316,11 @@ current unmarked suggestion."
     (setf (prompter:active-attributes-keys (current-source prompt-buffer))
           attributes)
     (prompt-render-suggestions prompt-buffer)))
+
+(define-command-prompt toggle-suggestions-display (prompt-buffer)
+  "Toggle between showing suggestions."
+  (setf (height prompt-buffer)
+        (if (eq (height prompt-buffer) :fit-to-prompt) :default :fit-to-prompt)))
 
 (define-class prompt-buffer-command-source (command-source)
   ((prompter:name "Prompt buffer commands")


### PR DESCRIPTION
# Description

Fixes #2788.

# Discussion

I'm not a huge fan of the keybinding I've choose. Suggestions are welcome.

Find a little demo below (@lansingthomas, I did it for you). After all these years, there are still little and trivial UI improvements that make a huge difference. 

https://github.com/atlas-engineer/nyxt/assets/45483512/f57c4846-1317-4b2e-9465-a124f71578ec


# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
