### PR TITLE
Use Lparallel-powered prompter library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -593,11 +593,11 @@
 	path = _build/nclasses
 	url = https://github.com/atlas-engineer/nclasses/
 	shallow = true
-[submodule "_build/prompter"]
-	path = _build/prompter
-	url = https://github.com/atlas-engineer/prompter
-	shallow = true
 [submodule "_build/cl-colors2_fixed"]
 	path = _build/cl-colors2
 	url = https://notabug.org/cage/cl-colors2
 	shallow = false # Notabug does not advertize commits.
+[submodule "prompter-lparallel"]
+	path = _build/prompter
+	url = https://github.com/atlas-engineer/prompter
+	branch = lparalle-overhaul

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1315,9 +1315,8 @@ proceeding."
                                              "Set current BUFFER for the active window."
                                              (set-current-buffer buffer :focus nil)))
    (prompter:destructor (let ((buffer (current-buffer)))
-                          (lambda (prompter source)
-                            (declare (ignore source))
-                            (unless (or (prompter:returned-p prompter)
+                          (lambda (source)
+                            (unless (or (prompter:returned-p (prompter:prompter source))
                                         (eq buffer (current-buffer)))
                               (set-current-buffer buffer))))))
   (:export-class-name-p t)

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -713,4 +713,10 @@ color-picker support as an example application for this feature.")
   (:ul
    (:li "Add new command, "
         (:nxref :command 'nyxt/mode/prompt-buffer:toggle-suggestions-display)
-         ", that allows collapsing the prompt buffer to its input area.")))
+        ", that allows collapsing the prompt buffer to its input area."))
+  (:h3 "Programming interfaces")
+  (:ul
+   (:li "The " (:code "prompter") " was updated and uses a slightly different API based on Lparallel.
+Noteworthy changes include " (:code "prompter:result-channel") " which is replaced by "
+(:code "result")" and " (:code "prompt-buffer-canceled") " which has been deprecated in favor
+of " (:code "prompter:canceled") ".")))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -339,7 +339,7 @@ With MODE-SYMBOLS and GLOBAL-P, include global commands."
   (with-current-buffer (current-buffer)
     (let ((*interactive-p* t))
       (handler-case (apply #'funcall command args)
-        (prompt-buffer-canceled ()
+        (prompter:canceled ()
           (log:debug "Prompt buffer interrupted")
           nil)))))
 

--- a/source/concurrency.lisp
+++ b/source/concurrency.lisp
@@ -26,7 +26,7 @@ raised condition."
   (alex:with-gensyms (c sub-c)
     `(if (or *run-from-repl-p* *debug-on-error*)
          (handler-case (progn ,@body)
-           (prompt-buffer-canceled ()
+           (prompter:canceled ()
              (log:debug "Prompt buffer interrupted")))
          (ignore-errors
           (handler-bind

--- a/source/conditions.lisp
+++ b/source/conditions.lisp
@@ -20,8 +20,9 @@ It should abort the ongoing command, but not the whole process."))
   ((context :initarg :context :reader context)))
 
 (export-always 'prompt-buffer-canceled)
-(define-condition prompt-buffer-canceled (error)
-  ())
+(define-condition prompt-buffer-canceled (prompter:canceled) ; TODO: Remove with 4.0.0.
+  ()
+  (:documentation "Obsolete.  Use `prompter:canceled' instead."))
 (export-always 'prompt-buffer-non-interactive)
 (define-condition prompt-buffer-non-interactive (error)
   ((name :initarg :name :accessor name))

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -445,7 +445,7 @@ Examples:
                                               ,@(when explicit-no-p
                                                   (list :no no)))
                       :hide-suggestion-count-p t)
-                   (prompt-buffer-canceled () nil))))
+                   (prompter:canceled () nil))))
      (if answer
          ,yes-form
          ,no-form)))

--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -347,7 +347,7 @@ Otherwise prompt for matches."
                                         (prompt1
                                          :prompt (format nil "Set ~a to" variable)
                                          :sources 'prompter:raw-source))))
-                              (prompt-buffer-canceled nil))))
+                              (prompter:canceled nil))))
            "Change value")
           (:p (:raw (value->html (symbol-value variable))))
           (:nsection

--- a/source/inspector.lisp
+++ b/source/inspector.lisp
@@ -280,7 +280,7 @@ values in help buffers, REPL and elsewhere."))
                                                 (prompt1
                                                  :prompt (format nil "Set ~a to" slot-name)
                                                  :sources 'prompter:raw-source))))
-                                      (prompt-buffer-canceled nil))))
+                                      (prompter:canceled nil))))
                    "change "))
              (:dd (:raw (value->html (slot-value value slot-name) t)))))
           (:raw (escaped-literal-print value))))))

--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -348,7 +348,7 @@ current unmarked suggestion."
         (prompter:actions-on-return first-prompt-buffer))
       (progn
         (echo-warning "No actions to choose from.")
-        (error 'prompt-buffer-canceled))))
+        (error 'prompt-buffer-canceled)))) ; TODO: Obsolete, switch to `promter:canceled' with 4.0.0.
 
 (defun prompt-buffer-actions-on-current-suggestion (&optional (window (current-window)))
   (sera:and-let* ((first-prompt-buffer (first (nyxt::active-prompt-buffers window))))

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -296,7 +296,7 @@ Implies that `small-web-mode' is enabled."
                                 (prompt1 :prompt meta
                                          :sources 'prompter:raw-source
                                          :invisible-input-p (eq status :sensitive-input))
-                              (nyxt::prompt-buffer-canceled () "")))))
+                              (prompter:canceled () "")))))
                  (buffer-load (str:concat url "?" text) :buffer buffer)))
               (:success
                (if (str:starts-with-p "text/gemini" meta)

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -386,11 +386,15 @@ See also `show-prompt-buffer'."
       ;; critical.
       (if dynamic-p
           (loop with suggestions = (prompter:suggestions source)
-                with attributes = (mapcar (rcurry #'prompter:active-attributes :source source) suggestions)
+                with suggestions-attributes = (mapcar (rcurry #'prompter:active-attributes :source source) suggestions)
                 for key in (prompter:active-attributes-keys source)
+                ;; REVIEW: A `prompter' function to retrieve attributes by key would be nice.
                 for width
-                  = (funcall width-function (mapcar #'prompter:attribute-value
-                                                    (remove key attributes :test 'string/= :key #'prompter:attribute-key)))
+                  = (funcall width-function (mapcar (lambda (attributes)
+                                                      (prompter:attribute-value
+                                                       (find key attributes :test 'string=
+                                                                            :key #'prompter:attribute-key)))
+                                                    suggestions-attributes))
                 collect width into widths
                 finally (return (clip-extremes (width-normalization widths))))
           (sera:and-let* ((suggestions (prompter:suggestions source))

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -1272,7 +1272,7 @@ the `active-buffer'."
                                    :extra-modes 'nyxt/mode/file-manager:file-manager-mode
                                    :sources (make-instance 'nyxt/mode/file-manager:file-source
                                                            :enable-marks-p multiple))
-                         (prompt-buffer-canceled ()
+                         (prompter:canceled ()
                            nil)))))
           (if files
               (webkit:webkit-file-chooser-request-select-files
@@ -1416,7 +1416,7 @@ the `active-buffer'."
                                        :prompt (webkit:webkit-script-dialog-get-message dialog)
                                        :input (webkit:webkit-script-dialog-prompt-get-default-text dialog)
                                        :sources 'prompter:raw-source)
-                                    (prompt-buffer-canceled () nil)))))
+                                    (prompter:canceled () nil)))))
                  (if text
                      (webkit:webkit-script-dialog-prompt-set-text dialog text)
                      (progn


### PR DESCRIPTION
# Description

This uses the updated `prompter` library from the https://github.com/atlas-engineer/prompter/pull/16 patch set.

Fixes #2134 (at least the hang).

# Discussion

- [x] Shall we merge this on `3-series`? I've tried to retain as much back-compatibility as possible, but `prompter` itself is not fully backward compatible.  That said, it's concerns only very "under the hood" elements (like `prompter:result-channel` which is now an Lparallel promise).

  Answer: Yes, let's merge it, `prompter:result` is only used as a lower-level implementation detail.

- [ ] #2134 hang is fixed indeed, however keeping a key pressed is very CPU intensive and pretty slow in the UI.  Not sure why, as if the UI was waiting the prompt-buffer.  Issue on the Nyxt side?  @aartaka @aadcg any idea?
- [ ] There are still dangling threads.

For the last 2 issues, I think I know what's going on: `update-prompt` is run on each key press, and evidently does not terminate properly.

Proposed solution: Use a strategy of "buffering" like the new `prompter` does, so we only update the buffer after some time delay.
Also while we are at it, switch from Calispel to Lparallel to avoid the accidental dangling threads.

Better idea?  Listening to `prompter`s `update-notifier` would save us having to reimplement this logic.

# To do:

- More testing! @aadcg @jmercouris @aartaka Please give this a spin on a few prompt buffers.
- Ensure #2134 is fixed.
- Update Git submodule
  DO NOT MERGE LAST COMMIT: Instead, wait for `prompter` master to be updated, then update the Git submodule.
- Update Guix package.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
