### PR TITLE
prompt-buffer: Improve input area focus UI.

### DIFF
--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -83,6 +83,9 @@ See `nyxt::attribute-widths'.")
         `("#prompt-area"
           :background-color ,theme:primary
           :color ,theme:on-primary
+          :border-top "2px solid"
+          :border-bottom "2px solid"
+          :border-color ,theme:primary
           :display "grid"
           :grid-template-columns "auto auto 1fr auto auto"
           :width "100%")
@@ -146,13 +149,15 @@ See `nyxt::attribute-widths'.")
           :background-color ,theme:background
           :color ,theme:on-background
           :opacity 0.9
-          :border 2px solid ,theme:primary
+          :border "none"
           :outline "none"
           :padding "3px"
           :width "100%"
           :autofocus "true")
         `("#input:focus"
-          :border-color ,theme:accent)
+          :box-shadow ,(format nil
+                               "inset 11px 0px 0 2px ~a~X, inset -21px 0px 0 2px ~a~X"
+                               theme:accent-alt 75 theme:accent-alt 75))
         `(".source"
           :margin-left "10px"
           :margin-top "15px")

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -155,9 +155,7 @@ See `nyxt::attribute-widths'.")
           :width "100%"
           :autofocus "true")
         `("#input:focus"
-          :box-shadow ,(format nil
-                               "inset 11px 0px 0 2px ~a~X, inset -21px 0px 0 2px ~a~X"
-                               theme:accent-alt 75 theme:accent-alt 75))
+          :box-shadow ,(format nil "inset 0 0 0 2px ~a~X" theme:accent-alt 75))
         `(".source"
           :margin-left "10px"
           :margin-top "15px")


### PR DESCRIPTION
Reverts changes introduced by 5d3877e52f8faccd8144227db4997e06f58b9ba2, which were a regression.

# Description


Fixes #2951

# Discussion

@lansingthomas, interested in your feedback. Please find a demo below:


https://github.com/atlas-engineer/nyxt/assets/45483512/4d3187ce-9bcf-4037-af25-54869f901625




# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
