### PR TITLE
Restore bundle recipe

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,10 +73,11 @@ jobs:
       run: echo $(./nyxt --version | cut -d' ' -f3) > version
 
     # # Balance out '.
-    - name: Pack (Relocatable Binary)
+    - name: Bundle (Relocatable Binary)
       shell: bash
       run: |
-         guix pack -RR --no-grafts --compression=xz --symlink=/usr/local/bin/nyxt=bin/nyxt --root=nyxt-$(cat version).tar.xz -L build-scripts/ nyxt > store-path.txt
+        echo "Command: guix pack -RR --no-grafts --compression=xz --symlink=/usr/local/bin/nyxt=bin/nyxt --root=nyxt-bundle-$(cat version).tar.xz -L build-scripts/ nyxt" >> nyxt-bundle-reproducibility-recipe.txt
+         guix pack -RR --no-grafts --compression=xz --symlink=/usr/local/bin/nyxt=bin/nyxt --root=nyxt-bundle-$(cat version).tar.xz -L build-scripts/ nyxt > store-path.txt
 
     - name: Generate release notes
       shell: bash
@@ -85,10 +86,18 @@ jobs:
         echo "" >> release.txt
         echo "To compile from source, prefer the tarball including the submodules if you don't manage the Lisp dependencies yourself." >> release.txt
         echo "" >> release.txt
-        echo "\`nyxt-$(cat version).tar.xz\` is a self-contained bundle that runs on any GNU/Linux machine:" >> release.txt
+        echo "\`nyxt-bundle-$(cat version).tar.xz\` is a self-contained bundle that runs on any GNU/Linux machine:" >> release.txt
         echo "" >> release.txt
-        echo "1. Extract the archive, e.g. \`tar -xf /path/to/nyxt-$(cat version).tar.xz\`;" >> release.txt
-        echo "2. Issue \`./usr/local/bin/nyxt\`." >> release.txt
+        echo "1. (Optional) Verify the checksum: \`cat nyxt-bundle-$(cat version).tar.xz.sha256sum | sha256sum --check\`;" >> release.txt
+        echo "2. Extract the archive, e.g. \`tar -xf /path/to/nyxt-bundle-$(cat version).tar.xz\`;" >> release.txt
+        echo "3. Issue \`./usr/local/bin/nyxt\`." >> release.txt
+
+    - name: Generate bundle reproduction recipe
+      shell: bash
+      run: |
+        sha256sum nyxt-bundle-*.tar.xz > nyxt-bundle-$(cat version).tar.xz.sha256sum
+        echo "Store path: $(cat store-path.txt)" >> nyxt-bundle-reproducibility-recipe.txt
+        echo "Guix describe: $(guix describe)" >> nyxt-bundle-reproducibility-recipe.txt
 
     - name: Generate source archive with submodules
       shell: bash
@@ -98,4 +107,4 @@ jobs:
       uses: ncipollo/release-action@v1
       with:
         bodyFile: release.txt
-        artifacts: "nyxt-*.tar.xz*, *.flatpak"
+        artifacts: "nyxt-bundle-*.tar.xz*,nyxt-bundle-reproducibility-recipe.txt,*.flatpak"


### PR DESCRIPTION
# Description

Me and @jmercouris agreed that `guix-recipe.txt` needed to be reframed in the sense that the average user doesn't need to know that the Nyxt bundle is generated via `guix pack`. Not only it is extra-information, it could be also misleading (the user might think that they need Guix to run it). 

The content of the recipe, on the other hand, is extremely valuable. It details how can anyone reproduce this method of distributing Nyxt (thus giving us transparency).

I believe that these subtle but important changes address the issue. 


# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
