### PR TITLE
Push feature `X-pre-release` for all pre-releases on X-series.

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -768,6 +768,10 @@ color-picker support as an example application for this feature.")
      (:li (:nxref :class-name 'browser :slot 'external-editor-program)
           " returns its value rather than returning a string value in a list."))))
 
+(define-version "4-pre-release-1"
+  (:li "When on pre-release, push " (:code "X-pre-release")
+       " feature in addition to " (:code "X-pre-release-N") "one."))
+
 (define-version "4.0.0"
   (:ul
    (:li "Fix bug that made Nyxt display an out of date version in several places.")))

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -154,6 +154,7 @@ Return nil on error."
     (when +version+
       (push-feature +version+))
     (when (search "pre-release" +version+)
+      (push-feature (format nil "~a-pre-release" major))
       (push-feature (str:join "-" (subseq (str:split "-" +version+) 0 4))))
     (when major
       (push-feature major))


### PR DESCRIPTION
# Description

We've discussed it on the call with Pierre—would be nice to have a `X-pre-release` feature when we're on (any) pre-release for (major) version X. See `nx-ace` feature expression mentioned in the commit message 


Note that other version features don't cover this niche:
- `nyxt-unstable` is for any build beyond stable versions.
- `nyxt-COMMIT-HASH` is for a certain commit.
- `nyxt-X` requires quite a lot of exception enumeration to make sure it's not a stable version and the right set of pre-releases.

# Discussion

Maybe also add `X-beta` and `X-beta-N` as shortcuts for pre-releases? Not critical and is quite orthogonal to this PR, though.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [X] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [x] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
