### PR TITLE
Improve `pick-color` discoverability

### DIFF
--- a/source/color.lisp
+++ b/source/color.lisp
@@ -85,6 +85,5 @@ rgb()/hsl() CSS functions representing them."))
 (define-command-global pick-color ()
   "Pick a color and copy it to clipboard."
   (prompt :prompt "Color"
-          :input "#37A8E4"
           :sources (make-instance 'color-source
                                   :actions-on-return copy-actions)))

--- a/source/color.lisp
+++ b/source/color.lisp
@@ -83,7 +83,13 @@ rgb()/hsl() CSS functions representing them."))
         ("HSL" ,hsl ,(display hsl))))))
 
 (define-command-global pick-color ()
-  "Pick a color and copy it to clipboard."
+  "Pick a color and copy it to clipboard.
+The current color is previewed in the prompt buffer's input area.
+
+Color can be entered as:
+- CSS color name: \"PapayaWhip\" (capitalization is optional.)
+- HEX code: \"#37A8E4\".
+- HSL and RGB functions inspired by CSS."
   (prompt :prompt "Color"
           :sources (make-instance 'color-source
                                   :actions-on-return copy-actions)))


### PR DESCRIPTION
# Description

As noted in #3053, `pick-color` is somewhat confusing in having a pre-set color that hides all the possible other colors. And then, documentation doesn't help much either, because it's a simple generic line.

Fixes #3053.

CC @aadcg 

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [X] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.