### PR TITLE
Mention missing cursor icons issue in Troubleshooting.

### DIFF
--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -1107,4 +1107,12 @@ nyxt
     can try to disable compositing. To disable compositing from your
     initialization file, you can do the following: ")
           (:ncode
-            '(setf (uiop:getenv "WEBKIT_DISABLE_COMPOSITING_MODE") "1")))))))
+            '(setf (uiop:getenv "WEBKIT_DISABLE_COMPOSITING_MODE") "1")))
+
+        (:nsection :title "Missing cursor icons"
+          (:p "If you are having issues with the cursor not changing when
+hovering over buttons or links, it might be because Nyxt can't locate your cursor theme.
+To fix that, try adding the following to your" (:code ".bash_profile") " or similar:")
+          (:ncode :repl-p nil :config-p nil
+            "export XCURSOR_PATH=${XCURSOR_PATH}:/usr/share/icons
+export XCURSOR_PATH=${XCURSOR_PATH}:~/.local/share/icons"))))))


### PR DESCRIPTION
# Description

Add subsection to Troubleshooting in the Manual that mentions the issue with missing cursor icons.

Resolves #3062.

# Discussion

If anyone else wants to weigh in on whether this belongs in the manual, feel free.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [ ] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [ ] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [ ] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [ ] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
