### PR TITLE
password-manager/password-secret-service: Implement and document

### DIFF
--- a/libraries/password-manager/password-secret-service.lisp
+++ b/libraries/password-manager/password-secret-service.lisp
@@ -1,0 +1,123 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+;; Search for password, get password, write password, using Secret Service API:
+;; https://specifications.freedesktop.org/secret-service
+;; Password entries are retrieved using python package SecretStorage: https://pypi.org/project/SecretStorage
+;; This package may be provided by your linux distribution. In Ubuntu python3-secretstorage.
+;; Password entries are written using python package keyring: https://pypi.org/project/keyring
+;; This package may be provided by your linux distribution. In Ubuntu python3-keyring.
+;; The default collection (service) in Secret Service is used, this is normally the login collection.
+;; On at least Ubuntu this collection is by default open when a user is logged in. So there is no
+;; need to enter a master password to unlock the collection, when logging in at a web page.
+;;
+;; It would have been preferable to only use keyring, and not secretstorage, but keyring does not
+;; provide facilities to search the Secret Service collection.
+;;
+;; This interface relies on a number of command line scripts:
+;; keyring: Provided by python package keyring
+;; secret-service-keys, secret-service-show-password, secret-service-show-username: Implementation shown below,
+;; also available from https://github.com/johanwiden/secret-service-scripts
+;;
+;; Limitations:
+;; - Currently this interface does not generate a new password, if an empty password is saved.
+;;   The user must therefore use some other facility to generate a new password.]
+
+(in-package :password)
+
+(define-class password-secret-service-interface (password-interface)
+  ((executable (pathname->string (sera:resolve-executable "keyring"))))
+  (:export-class-name-p t)
+  (:export-accessor-names-p t))
+
+(push 'password-secret-service-interface *interfaces*)
+
+;; Return something like ("pypi.org" "foo.org")
+;; If executable "secret-service-list-keys" is available, return result from that, otherwise nil.
+;; https://stackoverflow.com/questions/72020628/how-do-i-list-and-access-the-secrets-stored-in-ubuntus-keyring-from-the-command
+;; In ubuntu: sudo apt get python3-secretstorage
+;; Example implementation of "secret-service-list-keys":
+;; #!/usr/bin/env python3
+;; import secretstorage
+;; conn = secretstorage.dbus_init()
+;; collection = secretstorage.get_default_collection(conn)
+;; services = []
+;; for item in collection.get_all_items():
+;;     attributes = item.get_attributes()
+;;     if 'service' in attributes:
+;;         services.append(attributes['service'])
+;; print(' '.join(e for e in sorted(set(services))))
+(defmethod list-passwords ((password-interface password-secret-service-interface))
+  (let ((secret-service-keys (pathname->string (serapeum:resolve-executable "secret-service-list-keys"))))
+    (when secret-service-keys
+      (let* ((key-string (uiop:run-program (list secret-service-keys) :output '(:string :stripped t)))
+             (key-list (split-sequence:split-sequence #\Space key-string :remove-empty-subseqs t)))
+        key-list))))
+
+;; If executable "secret-service-show-password" is available, and returns result, then copy result to clipboard, return t.
+;; Otherwise return nil.
+;; In ubuntu: sudo apt get python3-secretstorage
+;; Example implementation of "secret-service-show-password":
+;; #!/usr/bin/env python3
+;; import argparse
+;; import secretstorage
+;; parser = argparse.ArgumentParser(
+;;     prog = 'secret-service-show-password',
+;;     description = 'Return password for password entry password_name')
+;; parser.add_argument('password_name', type=str)
+;; args = parser.parse_args()
+;; conn = secretstorage.dbus_init()
+;; collection = secretstorage.get_default_collection(conn)
+;; for item in collection.get_all_items():
+;;     attributes = item.get_attributes()
+;;     if 'service' in attributes and attributes['service'] == args.password_name:
+;;         print(item.get_secret().decode('utf-8'))
+;;         break
+(defmethod clip-password ((password-interface password-secret-service-interface) &key password-name service)
+  (declare (ignore service))
+  (let ((secret-service-show-password (pathname->string (serapeum:resolve-executable "secret-service-show-password"))))
+    (when secret-service-show-password
+      (let* ((password-str (uiop:run-program (list secret-service-show-password password-name) :output '(:string :stripped t)))
+             (password (if (uiop:emptyp password-str) nil password-str)))
+        (when password
+          (trivial-clipboard:text password)
+          t)))))
+
+;; If executable "secret-service-show-username" is available, and returns result, then copy result to clipboard, return t.
+;; Otherwise return nil.
+;; In ubuntu: sudo apt get python3-secretstorage
+;; Example implementation of "secret-service-show-username":
+;; #!/usr/bin/env python3
+;; import argparse
+;; import secretstorage
+;; parser = argparse.ArgumentParser(
+;;     prog = 'secret-service-show-username',
+;;     description = 'Return field "username" for password entry password_name')
+;; parser.add_argument('password_name', type=str)
+;; args = parser.parse_args()
+;; conn = secretstorage.dbus_init()
+;; collection = secretstorage.get_default_collection(conn)
+;; for item in collection.get_all_items():
+;;     attributes = item.get_attributes()
+;;     if 'service' in attributes and attributes['service'] == args.password_name and 'username' in attributes:
+;;         print(attributes['username'])
+;;         break
+(defmethod clip-username ((password-interface password-secret-service-interface) &key password-name service)
+  (declare (ignore service))
+  (let ((secret-service-show-username (pathname->string (serapeum:resolve-executable "secret-service-show-username"))))
+    (when secret-service-show-username
+      (let* ((username-str (uiop:run-program (list secret-service-show-username password-name) :output '(:string :stripped t)))
+             (username (if (uiop:emptyp username-str) nil username-str)))
+        (when username
+          (trivial-clipboard:text username)
+          t)))))
+
+;; Generate new password is not supported.
+(defmethod save-password ((password-interface password-secret-service-interface)
+                          &key password-name username password service)
+  (declare (ignore service))
+  (with-input-from-string (st (format nil "~a~C" password #\newline))
+    (execute password-interface (list "set" password-name username) :input st)))
+
+(defmethod password-correct-p ((password-interface password-secret-service-interface))
+  t)

--- a/nyxt.asd
+++ b/nyxt.asd
@@ -593,6 +593,7 @@ The renderer is configured from NYXT_RENDERER or `*nyxt-renderer*'."))
                (:file "password")
                (:file "password-keepassxc")
                (:file "password-security")
+               (:file "password-secret-service")
                ;; Keep password-store last so that it has higher priority.
                (:file "password-pass")))
 


### PR DESCRIPTION
An interface to https://specifications.freedesktop.org/secret-service

# Description
Implement a password interface that uses Secret Service: https://specifications.freedesktop.org/secret-service

One can normally use this service without having to provide a master password at each interaction.

Depends on two python packages, and three script files:
- Password entries are retrieved using python package [SecretStorage](https://pypi.org/project/SecretStorage). This package may be provided by your linux distribution. In Ubuntu python3-secretstorage.
- Password entries are written using python package [keyring](https://pypi.org/project/keyring). This package may be provided by your linux distribution. In Ubuntu python3-keyring.
- The three extra command line scripts are documented in the interface lisp file. They may also be retrieved from [secret-service-scripts](https://github.com/johanwiden/secret-service-scripts)

Fixes # (issue)
No issue has currently been created.

# Discussion
A current limitation of the interface, is that it does not generate a new password, if the user saves an empty password. The user must use some other facility to generate a new password.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [v] Git hygiene:
  - I have pulled from master before submitting this PR yes
  - There are no merge conflicts. yes
- [v] I've added the new dependencies as:
  - ASDF dependencies, yes, in nyxt.asd
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [v] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [v] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [v] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.) Docstrings are provided by the super class: password.lisp
  - I have updated the existing documentation to match my changes. yes
  - I have commented my code in hard-to-understand areas. yes
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage). no
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes. It is not compatibility-breaking.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.) no
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
