### PR TITLE
Fix prompt buffer UI

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -801,7 +801,9 @@ buffers.")
   ;; (:nsection :title "Bug fixes"
   ;;   (:ul))
   (:nsection :title "UI/UX"
-    (:ul (:li "Fix styling of progress bar."))))
+    (:ul
+     (:li "Fix styling of progress bar.")
+     (:li "Fix styling of prompt buffer's input area."))))
 
 (define-version "4-pre-release-1"
   (:li "When on pre-release, push " (:code "X-pre-release")

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -236,9 +236,15 @@ See `prompt' for how to invoke prompts.")
 (defmethod (setf height) (value (prompt-buffer prompt-buffer))
   (setf (ffi-height prompt-buffer)
         (case value
-          (:default (prompt-buffer-open-height (window prompt-buffer)))
-          (:fit-to-prompt (ps-eval :buffer prompt-buffer
-                            (ps:chain (nyxt/ps:qs document "#prompt") offset-height)))
+          (:default
+           (prompt-buffer-open-height (window prompt-buffer)))
+          (:fit-to-prompt
+           (ps-eval :buffer prompt-buffer
+             (+ (ps:chain (nyxt/ps:qs document "#prompt-area") offset-height)
+                ;; Buffer whitespace between the prompt buffer's input area and
+                ;; the status buffer.  Not clear how to the derive the value
+                ;; from another element's height.
+                4)))
           (t value)))
   (setf (slot-value prompt-buffer 'height) value))
 

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -155,7 +155,8 @@ See `nyxt::attribute-widths'.")
           :width "100%"
           :autofocus "true")
         `("#input:focus"
-          :box-shadow ,(format nil "inset 0 0 0 2px ~a~X" theme:accent-alt 75))
+          :box-shadow ,(format nil "inset 0 0 0 3px ~a"
+                               (cl-colors2:print-hex theme:accent-alt :alpha 0.40)))
         `(".source"
           :margin-left "10px"
           :margin-top "15px")


### PR DESCRIPTION
# Description

Fixes #3086.

# Discussion

Commit 367856947 attributed to @aartaka since it was [his idea](https://github.com/atlas-engineer/nyxt/pull/3023#discussion_r1230931845). Should have been part of #3023.

Should be merged by Monday so that it lands on the next release.

Screenshots:

![2023_07_20_13:41:07-nyxt](https://github.com/atlas-engineer/nyxt/assets/45483512/ec161497-4600-4ea4-b6b3-b7b95d0d5967)

-----

![2023_07_20_13:41:55-nyxt](https://github.com/atlas-engineer/nyxt/assets/45483512/cac4d808-1e81-4ac7-9a5b-b40853cee8a7)

-----

![2023_07_20_13:41:22-nyxt](https://github.com/atlas-engineer/nyxt/assets/45483512/4bcf8822-079f-407b-bb48-6f0864b56d63)



# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
