### PR TITLE
Add `plaintext-editor-mode` to default modes.

### DIFF
--- a/source/mode/editor.lisp
+++ b/source/mode/editor.lisp
@@ -97,8 +97,8 @@ See the `scheme' documentation for the format and the number of values that
 contains an `nyxt/mode/editor:editor-mode' instance (or a subclass thereof)."))
 
 (defmethod nyxt:default-modes append ((buffer editor-buffer))
-  "Add `editor-mode' to `editor-buffer' by default."
-  (list 'editor-mode))
+  "Add `editor-mode' and `plaintext-editor-mode' to `editor-buffer' by default."
+  (list 'editor-mode 'plaintext-editor-mode))
 
 (defmethod nyxt:default-modes :around ((buffer editor-buffer))
   ;; REVIEW: Really remove document-mode from editor-buffer?


### PR DESCRIPTION
# Description

Add `plaintext-editor-mode` to default modes for `editor-buffer`. This is the default, built-in editor for Nyxt.

Fixes #3006.

# Discussion

I don't think we need both of the modes enabled for this to work, but I kept `editor-mode` in just in case.
Also, as mentioned in #3006, we could change the `Edit user files` button in `common-settings` to launch the built-in editor instead of an external editor.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
