### PR TITLE
mode/file-manager: Open PDF files locally with OPEN-FILE

### DIFF
--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -192,7 +192,9 @@ It takes a pathname and returns a boolean.  For simpler cases, use
       ;; Audio.
       "mp3" "oga" "m4a"
       ;; Video.
-      "flac" "ogv" "m4v" "flv" "mov" "wmv" "webm" "mkv")
+      "flac" "ogv" "m4v" "flv" "mov" "wmv" "webm" "mkv"
+      ;; Documents
+      "pdf")
     :type (list-of string)
     :documentation "Media types that Nyxt opens.
 Other formats are opened relying on the OS.")


### PR DESCRIPTION
Since PDF.js is supported by nyxt, it may be a good idea to open PDF files which are stored locally right in the browser (with `C-x C-f` or `C-Space open-file`), so add `"pdf"` to `supported-media-types`.