### PR TITLE
Allow for overwriting slots with repeated `define-configuration`.

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -846,6 +846,12 @@ Chromium, Brave and Vivaldi. For instance, "
      (:li "The installation process now takes into account the Appdata file and
 a scalable icon."))))
 
+(define-version "3.X.Y"
+  (:ul
+   (:li "Fix bug with subsequent invocations of "
+        (:nxref :macro 'define-configuration) " on the same class and slot
+being overwritten by the first.")))
+
 (define-version "4-pre-release-1"
   (:li "When on pre-release, push " (:code "X-pre-release")
        " feature in addition to " (:code "X-pre-release-N") "one."))

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -377,7 +377,7 @@ To discover the default value of a slot or all slots of a class, use the
                                                         (declare (ignorable %slot-value% %slot-default%))
                                                         ,value)))
                                           :name (quote ,handler-name))))
-                           (hooks:add-hook ,hook ,handler))
+                           (hooks:add-hook ,hook ,handler :append t))
                         else
                           do (log:warn "Not found slot ~a in class ~a, generating the wrapper method for configuration."
                                        slot-name class)

--- a/tests/offline/define-configuration.lisp
+++ b/tests/offline/define-configuration.lisp
@@ -7,32 +7,40 @@
   (let ((test-url (quri:uri "about:blank")))
     (nyxt:define-configuration nyxt:browser
       ((nyxt:default-new-buffer-url test-url)))
-    (let ((browser (make-instance 'browser)))
-      (assert-equality #'quri:uri=
-                       test-url
-                       (nyxt:default-new-buffer-url browser)))
+    (assert-equality #'quri:uri=
+                     test-url
+                     (nyxt:default-new-buffer-url (make-instance 'browser)))
     (nyxt:clean-configuration)
-    (let ((browser (make-instance 'browser)))
-      (assert-equality #'quri:uri=
-                       (quri:uri (nyxt-url 'new))
-                       (nyxt:default-new-buffer-url browser)))
+    (assert-equality #'quri:uri=
+                     (quri:uri (nyxt-url 'new))
+                     (nyxt:default-new-buffer-url (make-instance 'browser)))
+    (nyxt:clean-configuration)))
+
+(define-test overwritten-configuration ()
+  (let ((test-first-url (quri:uri "https://example.com/first"))
+        (test-second-url (quri:uri "https://example.com/second")))
+    (nyxt:define-configuration nyxt:browser
+      ((nyxt:default-new-buffer-url test-first-url)))
+    (nyxt:define-configuration nyxt:browser
+      ((nyxt:default-new-buffer-url test-second-url)))
+    (assert-equality #'quri:uri=
+                     test-second-url
+                     (nyxt:default-new-buffer-url (make-instance 'browser)))
     (nyxt:clean-configuration)))
 
 (define-test slot-default ()
   (let ((test-url (quri:uri "about:blank")))
     (nyxt:define-configuration nyxt:browser
       ((nyxt:default-new-buffer-url test-url)))
-    (let ((browser (make-instance 'browser)))
-      (assert-equality #'quri:uri=
-                       test-url
-                       (nyxt:default-new-buffer-url browser)))
+    (assert-equality #'quri:uri=
+                     test-url
+                     (nyxt:default-new-buffer-url (make-instance 'browser)))
     (nyxt:clean-configuration)
     (nyxt:define-configuration nyxt:browser
       ((nyxt:default-new-buffer-url nyxt:%slot-default%)))
-    (let ((browser (make-instance 'browser)))
-      (assert-equality #'quri:uri=
-                       (quri:uri (nyxt-url 'new))
-                       (nyxt:default-new-buffer-url browser)))
+    (assert-equality #'quri:uri=
+                     (quri:uri (nyxt-url 'new))
+                     (nyxt:default-new-buffer-url (make-instance 'browser)))
     (nyxt:clean-configuration)))
 
 (define-test test-slot-value ()
@@ -46,6 +54,5 @@
                                             (make-instance 'hooks:handler
                                                            :fn (lambda () (print 'dummy2))
                                                            :name 'dummy2)))))
-  (let ((browser (make-instance 'browser)))
-    (assert-eql 2
-                (length (hooks:handlers (nyxt:before-exit-hook browser))))))
+  (assert-eql 2
+              (length (hooks:handlers (nyxt:before-exit-hook (make-instance 'browser))))))


### PR DESCRIPTION
# Description

Added `:append t` to the `hooks:add-hook` call in `define-configuration`, so that the hooks are evaluated in the correct order.

Fixes #3138.

# Discussion

We could also add an `:append` key to `define-configuration` so that the user can choose the order, with the default being `:append t`. Would that be too confusing, maybe?

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
