### PR TITLE
Prompt buffer mark checkboxes

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -928,6 +928,8 @@ invoked via " (:code "flatpak-spawn --host <command> <command-args>") "."))))
   (:nsection :title "UI/UX"
     (:ul
      (:li "Improve source heading buttons, layout and interactions in the "
+          (:nxref :class-name 'prompt-buffer) ".")
+     (:li "Add checkboxes for suggestions within the "
           (:nxref :class-name 'prompt-buffer) ".")))
   (:nsection :title "Bug fixes"
     (:ul

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -423,6 +423,8 @@ an integer."
     (when (prompter:suggestions source)
       (:table :class "source-content"
               (:colgroup
+               (when (prompter:enable-marks-p source)
+                 (:col :style "width: 25px"))
                (dolist (width (attribute-widths
                                source :dynamic-p (dynamic-attribute-width-p prompt-buffer)))
                  (:col :style (format nil "width: ~,2f%" (* 100 width)))))
@@ -431,6 +433,8 @@ an integer."
                                        (sera:single (prompter:active-attributes-keys source))))
                               "display:none;"
                               "display:revert;")
+                   (when (prompter:enable-marks-p source)
+                     (:th " "))
                    (loop for attribute-key in (prompter:active-attributes-keys source)
                          collect (:th (spinneret::escape-string attribute-key))))
               (loop
@@ -448,13 +452,14 @@ an integer."
                                 "selection")
                           :class (when (prompter:marked-p source (prompter:value suggestion))
                                    "marked")
-                          :onclick (when (mouse-support-p prompt-buffer)
-                                     (ps:ps
-                                       (cond
-                                         ((or (ps:chain window event ctrl-key)
-                                              (ps:chain window event shift-key))
+                          (when (prompter:enable-marks-p source)
+                            (:td
+                             (:input
+                              :type "checkbox"
+                              :checked (prompter:marked-p source (prompter:value suggestion))
+                              :onchange (ps:ps
                                           (nyxt/ps:lisp-eval
-                                           (:title "mark-this-suggestion"
+                                           (:title "unmark-this-suggestion"
                                             :buffer prompt-buffer)
                                            (prompter::set-current-suggestion
                                             prompt-buffer
@@ -463,32 +468,49 @@ an integer."
                                            (prompter::set-current-suggestion
                                             prompt-buffer
                                             (- cursor-index suggestion-index))
-                                           (prompt-render-suggestions prompt-buffer)))
-                                         ((ps:chain window event alt-key)
-                                          (nyxt/ps:lisp-eval
-                                           (:title "return-this-suggestion-with-another-action"
-                                            :buffer prompt-buffer)
-                                           (prompter::set-current-suggestion
-                                            prompt-buffer
-                                            (- suggestion-index cursor-index))
-                                           (uiop:symbol-call
-                                            :nyxt/prompt-buffer-mode :set-action-on-return
-                                            (nyxt::current-prompt-buffer))))
-                                         (t
-                                          (nyxt/ps:lisp-eval
-                                           (:title "return-this-suggestion"
-                                            :buffer prompt-buffer)
-                                           (prompter::set-current-suggestion
-                                            prompt-buffer
-                                            (- suggestion-index cursor-index))
-                                           (prompter:run-action-on-return
-                                            (nyxt::current-prompt-buffer)))))))
+                                           (prompt-render-suggestions prompt-buffer))))))
                           (loop for (nil attribute attribute-display)
-                                in (prompter:active-attributes suggestion :source source)
-                                collect (:td :title attribute
-                                             (if attribute-display
-                                                 (:raw attribute-display)
-                                                 attribute))))))))))
+                                  in (prompter:active-attributes suggestion :source source)
+                                collect (:td
+                                         :title attribute
+                                         :onclick (when (mouse-support-p prompt-buffer)
+                                                    (ps:ps
+                                                      (cond
+                                                        ((or (ps:chain window event ctrl-key)
+                                                             (ps:chain window event shift-key))
+                                                         (nyxt/ps:lisp-eval
+                                                          (:title "mark-this-suggestion"
+                                                           :buffer prompt-buffer)
+                                                          (prompter::set-current-suggestion
+                                                           prompt-buffer
+                                                           (- suggestion-index cursor-index))
+                                                          (prompter:toggle-mark prompt-buffer)
+                                                          (prompter::set-current-suggestion
+                                                           prompt-buffer
+                                                           (- cursor-index suggestion-index))
+                                                          (prompt-render-suggestions prompt-buffer)))
+                                                        ((ps:chain window event alt-key)
+                                                         (nyxt/ps:lisp-eval
+                                                          (:title "return-this-suggestion-with-another-action"
+                                                           :buffer prompt-buffer)
+                                                          (prompter::set-current-suggestion
+                                                           prompt-buffer
+                                                           (- suggestion-index cursor-index))
+                                                          (uiop:symbol-call
+                                                           :nyxt/prompt-buffer-mode :set-action-on-return
+                                                           (nyxt::current-prompt-buffer))))
+                                                        (t
+                                                         (nyxt/ps:lisp-eval
+                                                          (:title "return-this-suggestion"
+                                                           :buffer prompt-buffer)
+                                                          (prompter::set-current-suggestion
+                                                           prompt-buffer
+                                                           (- suggestion-index cursor-index))
+                                                          (prompter:run-action-on-return
+                                                           (nyxt::current-prompt-buffer)))))))
+                                         (if attribute-display
+                                             (:raw attribute-display)
+                                             attribute))))))))))
 
 (export 'prompt-render-suggestions)
 (define-generic prompt-render-suggestions ((prompt-buffer prompt-buffer))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -94,6 +94,7 @@ See `nyxt::attribute-widths'.")
           :background-color ,theme:primary
           :color ,theme:on-primary
           :padding-left "10px"
+          :padding-right "8px"
           :line-height "28px")
         `("#prompt-input"
           :margin-right "-10px"


### PR DESCRIPTION
# Description

This adds a checkbox to every mark-able suggestion in prompt buffer. Looks like this right now:

![marking-checkboxes](https://github.com/atlas-engineer/nyxt/assets/57838654/cebbb09b-7879-4501-bd61-5c7108911238)

Clicking on a checkbox scrolls the prompt one suggestion down (like it does with `C-space`/`M-space` marking), which is convenient. I've also restricted the area where clicks mark/return suggestions to the attribute values they list. 

Note that I didn't apply the styling yet, because I was mainly working with the structure of the prompt in general. One particular thing that diverges from @lansingthomas' spec is the "Mark" column. I had to add it because otherwise prompt becomes much less structured and breaks table markup in general :P @lansingthomas, is the structure okay? Good to proceed with styling?

Fixes #3134

# Discussion

Mention there any suspicious parts of the new code, or the ideas that you'd like to discuss in regards to this change.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [X] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.