### PR TITLE
mode/prompt-buffer: Add delete-backwards-word vi keybinding

### DIFF
--- a/source/mode/prompt-buffer.lisp
+++ b/source/mode/prompt-buffer.lisp
@@ -139,7 +139,7 @@ listed and chosen from with the command `set-action-on-return' (bound to
        "w" 'nyxt/mode/input-edit:cursor-forwards-word
        "b" 'nyxt/mode/input-edit:cursor-backwards-word
        "x" 'nyxt/mode/input-edit:delete-forwards
-       ;; VI has no short keybinding for delete-backwards-word, hasn't it?
+       "d b" 'nyxt/mode/input-edit:delete-backwards-word
        "d w" 'nyxt/mode/input-edit:delete-forwards-word
        "z f" 'toggle-actions-on-current-suggestion-enabled
        "z a" 'toggle-attributes-display


### PR DESCRIPTION
# Description

Add missing `delete-backwards-word` vi keybinding to `prompt-buffer`.

# Discussion

Not much to discuss:

> db	delete from cursor to previous start of [word](https://vimhelp.org/motion.txt.html#word)
 
→ [vim help](https://vimhelp.org/usr_04.txt.html#04.10)

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.

- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [ ] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
