### PR TITLE
Fix `make-hash-table` for `*context-menu-commands*`

### DIFF
--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -384,7 +384,7 @@ Return the text cut."
   (echo-warning "Redoing edits is not yet implemented for this renderer."))
 
 ;; TODO: Move to alists for arbitrary number of params?
-(defvar *context-menu-commands* (make-hash-table)
+(defvar *context-menu-commands* (make-hash-table :test #'equal)
   "A hash table from labels to context menu commands.
 Once a context menu appears, those commands will be added to it as actions with
 the labels they have as hash keys.")


### PR DESCRIPTION
# Description

Since context menu labels are strings, `:test` should be `equal` rather than the default `eql`.

# Discussion

Without this change, re-running `ffi-add-context-menu-command` causes additional context menu items to be added with the same label.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [ ] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
