### PR TITLE
renderer/gtk(context-source): Parse the existing contexts.

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -934,7 +934,8 @@ invoked via " (:code "flatpak-spawn --host <command> <command-args>") "."))))
   (:nsection :title "Bug fixes"
     (:ul
      (:li "Fix command "
-          (:nxref :command 'nyxt/mode/annotate:show-annotations-for-current-url) "."))))
+          (:nxref :command 'nyxt/mode/annotate:show-annotations-for-current-url) ".")
+     (:li "make-buffer-with-context lists previously defined contexts."))))
 
 (define-version "4-pre-release-1"
   (:li "When on pre-release, push " (:code "X-pre-release")

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -2226,11 +2226,26 @@ As a second value, return the current buffer index starting from 0."
 WebKit-specific."
   (webkit:webkit-web-view-reload-bypass-cache (gtk-object buffer)))
 
+(defun list-existing-contexts ()
+  (loop for dir in (uiop:subdirectories
+                    (files:expand (make-instance 'nyxt:nyxt-data-directory)))
+        ;; PATHNAME-DIRECTORY returns a list on most implementations (UIOP
+        ;; relies on that, at least), even though the standard doesn't mandate
+        ;; it.
+        for dirname = (alex:lastcar (uiop:ensure-list (pathname-directory dir)))
+        when (uiop:string-suffix-p dirname "web-context")
+          collect (subseq dirname
+                          0
+                          (- (length dirname) (length "web-context/")))))
+
 (define-class context-source (prompter:source)
   ((prompter:name "Context list")
-   (prompter:constructor (sort (delete-duplicates (append (mapcar #'context-name (buffer-list))
-                                                          (list +internal+ +default+))
-                                                  :test 'equal)
+   (prompter:constructor (sort (delete-duplicates
+                                (append
+                                 (mapcar #'context-name (buffer-list))
+                                 (list +internal+ +default+)
+                                 (list-existing-contexts))
+                                :test 'equal)
                                'string<)))
   (:export-class-name-p t))
 


### PR DESCRIPTION
# Description

This fixes the problem described in #3124: existing user-defined contexts are only listed if there are buffers with them. So the inactive contexts (the ones having a directory but not used in any buffer) are not listed. This parses the data directory to find context directories and lists them.

Fixes  #3124

# Discussion

Should we sort contexts for display? Feels like an unnecessary optimization.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [X] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.