### PR TITLE
Use Nclasses more

### DIFF
--- a/source/auto-rules.lisp
+++ b/source/auto-rules.lisp
@@ -104,15 +104,15 @@ ARGS as in make-instance of `auto-rule'."
                   (list :excluded (normalize-modes (uiop:ensure-list excluded))))))
         *default-auto-rules*))
 
-(export-always 'undefine-auto-rule)
-(defgeneric undefine-auto-rule (token)
+(define-generic undefine-auto-rule (token)
+  "Remove the rule with TOKEN test."
   (:method ((token list))
     (loop for rule in *default-auto-rules*
           when (equal token (test rule))
             do (alex:deletef *default-auto-rules* rule :test #'equal)))
   (:method ((token string))
     (undefine-auto-rule (list 'match-url token)))
-  (:documentation "Remove the rule with TOKEN test."))
+  (:export-generic-name-p t ))
 
 (-> matching-auto-rules (quri:uri modable-buffer) (values list &optional))
 (defun matching-auto-rules (url buffer)

--- a/source/auto-rules.lisp
+++ b/source/auto-rules.lisp
@@ -91,17 +91,16 @@
 (defun define-auto-rule (test &key excluded included exact-p)
   "Define a new default `auto-rule'.
 ARGS as in make-instance of `auto-rule'."
-  (push (apply #'make-instance
-               'auto-rule
-               :exact-p exact-p
-               :test (if (stringp test)
-                         `(match-url ,test)
-                         test)
-               (append
-                (when included
-                  (list :included (normalize-modes (uiop:ensure-list included))))
-                (when excluded
-                  (list :excluded (normalize-modes (uiop:ensure-list excluded))))))
+  (push (make 'auto-rule
+              (exact-p)
+              :test (if (stringp test)
+                        `(match-url ,test)
+                        test)
+              (append
+               (when included
+                 (list :included (normalize-modes (uiop:ensure-list included))))
+               (when excluded
+                 (list :excluded (normalize-modes (uiop:ensure-list excluded))))))
         *default-auto-rules*))
 
 (define-generic undefine-auto-rule (token)
@@ -376,7 +375,7 @@ If there's an existing rule:
   (files:with-file-content (rules (auto-rules-file buffer))
     (let* ((rule (or (find test rules
                            :key #'test :test #'equal)
-                     (make-instance 'auto-rule :test test)))
+                     (make 'auto-rule (test) nil)))
            (include include)
            (exclude exclude))
       (setf (exact-p rule) exact-p
@@ -496,5 +495,5 @@ If there's an existing rule:
                         (getf rule :excluded) (normalize-modes (getf rule :excluded)))
                   (when (stringp (getf rule :test))
                     (setf (getf rule :test) `(match-url ,(getf rule :test))))
-                  (apply #'make-instance 'auto-rule rule)))
+                  (make 'auto-rule () rule)))
             rules)))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -598,8 +598,9 @@ The following example does a few things:
       (uiop:launch-program
        `(\"emacs\" ,(quri:uri-path url)))
       nil))))"
-  (make-instance
+  (make
    'hooks:handler
+   (name)
    :fn (lambda (request-data)
          (let ((url (url request-data)))
            (if (funcall test url)
@@ -622,8 +623,7 @@ The following example does a few things:
                            (log:info "Applied ~s shell-command URL-dispatcher on ~s"
                                      (symbol-name name)
                                      (render-url url)))))
-               request-data)))
-   :name name))
+               request-data)))))
 
 (defun javascript-error-handler (condition)
   (echo-warning "JavaScript error: ~a" condition))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1268,12 +1268,11 @@ See `make-buffer' for a description of the arguments."
     (containers:delete-item-if (recent-buffers *browser*) (buffer-match-predicate buffer))
     (containers:insert-item (recent-buffers *browser*) buffer)))
 
-(export-always 'buffer-delete)
-(defgeneric buffer-delete (buffer)
-  (:method ((buffer buffer))
-    (hooks:run-hook (buffer-delete-hook buffer) buffer)
-    (ffi-buffer-delete buffer))
-  (:documentation "Delete buffer after running `buffer-delete-hook'."))
+(define-generic buffer-delete ((buffer buffer))
+  "Delete buffer after running `buffer-delete-hook'."
+  (hooks:run-hook (buffer-delete-hook buffer) buffer)
+  (ffi-buffer-delete buffer)
+  (:export-generic-name-p t))
 
 (defmethod buffer-delete ((buffer context-buffer))
   (files:with-file-content (history (history-file buffer))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -99,9 +99,7 @@ These specializations are reserved to the user."))
 (export-always 'make-command)
 (defun make-command (name lambda-expression &optional (visibility :anonymous))
   "Return an non-globally defined command named NAME."
-  (make-instance 'command :name name
-                          :lambda-expression lambda-expression
-                          :visibility visibility))
+  (make 'command (name lambda-expression visibility) nil))
 
 (export-always 'lambda-command)
 (defmacro lambda-command (name args &body body)
@@ -295,9 +293,7 @@ It's the complement of `nyxt-packages' and `nyxt-user-packages'."
   "Return the list of all slot symbols in PACKAGES.
 See `sym:package-symbols'."
   (mappend (lambda (class-sym)
-             (mapcar (lambda (slot) (make-instance 'slot
-                                                   :name slot
-                                                   :class-sym class-sym))
+             (mapcar (lambda (slot) (make 'slot (slot class-sym) nil))
                      (class-slots class-sym :visibility visibility)))
            (sym:package-classes packages)))
 

--- a/source/configuration.lisp
+++ b/source/configuration.lisp
@@ -222,9 +222,7 @@ Return NIL if not a class form."
                         (multiple-value-bind (name value)
                             (read-init-form-slot class-name sexp)
                           (if name
-                              (make-instance 'slot-form
-                                             :name name
-                                             :value value)
+                              (make 'slot-form (name value) nil)
                               sexp)))
                       body)))))
 
@@ -242,9 +240,9 @@ Return NIL if not a class form."
            (multiple-value-bind (name forms)
                (read-init-form-class form)
              (if name
-                 (make-instance 'class-form
-                                :class-name name
-                                :forms forms)
+                 (make 'class-form
+                       (forms)
+                       :class-name name)
                  form))))
     (mapcar #'make-init-form
             (uiop:slurp-stream-forms raw-content))))
@@ -272,7 +270,7 @@ Return NIL if not a class form."
         (flet ((ensure-class-form (class-name)
                  (or (when config
                        (find-if (sera:eqs class-name) (sera:filter #'class-form-p config) :key #'class-name))
-                     (sera:lret ((form (make-instance 'class-form :class-name class-name)))
+                     (sera:lret ((form (make 'class-form (class-name) nil)))
                        (alex:appendf config (list form)))))
                (ensure-slot-form (class-form slot)
                  (or (find-if (sera:eqs slot) (sera:filter #'slot-form-p (forms class-form)) :key #'name)

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -186,8 +186,9 @@ JSON should have the format like what `get-document-body-json' produces:
       (json-to-plump json root)
       (name-dom-elements root))))
 
-(export-always 'copy)
-(defgeneric copy (node &optional parent)
+(define-generic copy (node &optional parent)
+  "Produce a full copy of NODE as belonging to the PARENT node.
+Full copy means recursively descending to the children of the NODE too."
   (:method ((element plump:root) &optional parent)
     (declare (ignore parent))
     (serapeum:lret ((copy (plump:make-root)))
@@ -224,17 +225,16 @@ JSON should have the format like what `get-document-body-json' produces:
                    :parent parent
                    :text (plump:text element)
                    :tag-name (plump:tag-name element)))
-  (:documentation "Produce a full copy of NODE as belonging to the PARENT node.
-Full copy means recursively descending to the children of the NODE too."))
+  (:export-generic-name-p t))
 
-(export-always 'parents)
-(defgeneric parents (node)
+(define-generic parents (node)
+  "Get the recursive parents of the NODE.
+The closest parent goes first, the furthest one goes last."
   (:method ((node plump:node)) nil)
   (:method ((node plump:child-node))
     (let ((parent (plump:parent node)))
       (cons parent (parents parent))))
-  (:documentation "Get the recursive parents of the NODE.
-The closest parent goes first, the furthest one goes last."))
+  (:export-generic-name-p t))
 
 ;; TODO: Copy the algo from https://github.com/antonmedv/finder
 (-> get-unique-selector (plump:element) t)
@@ -339,8 +339,8 @@ Return two values:
     (quri:uri (plump:get-attribute img "src"))))
 
 ;; REVIEW: Export to :nyxt? We are forced to use it with nyxt/dom: prefix.
-(export-always 'body)
-(defgeneric body (element)
+(define-generic body (element)
+  "Return the textual contents of the ELEMENT and its recursive children."
   (:method ((element plump:element))
     (when (plump:children element)
       (plump:text element)))
@@ -349,7 +349,7 @@ Return two values:
     (let ((result (call-next-method)))
       (when result
         (sera:collapse-whitespace (sera:trim-whitespace result)))))
-  (:documentation "Return the textual contents of the ELEMENT and its recursive children."))
+  (:export-generic-name-p t))
 
 (defun label-of (element)
   (let ((label-for (and (plump:has-attribute element "name")

--- a/source/dom.lisp
+++ b/source/dom.lisp
@@ -194,37 +194,30 @@ Full copy means recursively descending to the children of the NODE too."
     (serapeum:lret ((copy (plump:make-root)))
       (map nil (lambda (c) (plump:append-child copy (copy c copy))) (plump:children element))))
   (:method ((element plump:element) &optional parent)
-    (serapeum:lret ((copy (make-instance
-                           'plump:element
-                           :parent parent
+    (serapeum:lret ((copy (make
+                           'plump:element (parent)
                            :attributes (alexandria:copy-hash-table (plump:attributes element))
                            :tag-name (plump:tag-name element))))
       (map nil (lambda (c) (plump:append-child copy (copy c copy))) (plump:children element))))
   (:method ((element plump:text-node) &optional parent)
-    (make-instance 'plump:text-node
-                   :parent parent
-                   :text (plump:text element)))
+    (make 'plump:text-node (parent)
+          :text (plump:text element)))
   (:method ((element plump:comment) &optional parent)
-    (make-instance 'plump:comment
-                   :parent parent
-                   :text (plump:text element)))
+    (make 'plump:comment (parent)
+          :text (plump:text element)))
   (:method ((element plump:doctype) &optional parent)
-    (make-instance 'plump:doctype
-                   :parent parent
-                   :doctype (plump:doctype element)))
+    (make 'plump:doctype (parent)
+          :doctype (plump:doctype element)))
   (:method ((element plump:xml-header) &optional parent)
-    (make-instance 'plump:xml-header
-                   :parent parent
-                   :attributes (alexandria:copy-hash-table (plump:attributes element))))
+    (make 'plump:xml-header (parent)
+          :attributes (alexandria:copy-hash-table (plump:attributes element))))
   (:method ((element plump:cdata) &optional parent)
-    (make-instance 'plump:cdata
-                   :parent parent
-                   :text (plump:text element)))
+    (make 'plump:cdata (parent)
+          :text (plump:text element)))
   (:method ((element plump:processing-instruction) &optional parent)
-    (make-instance 'plump:processing-instruction
-                   :parent parent
-                   :text (plump:text element)
-                   :tag-name (plump:tag-name element)))
+    (make 'plump:processing-instruction (parent)
+          :text (plump:text element)
+          :tag-name (plump:tag-name element)))
   (:export-generic-name-p t))
 
 (define-generic parents (node)

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -110,8 +110,7 @@ class."
 Only deletes the disowned entries (= the ones not belonging to a buffer)."
   (let ((entries (prompt
                   :prompt "Delete entries"
-                  :sources (make-instance 'history-disowned-source
-                                          :buffer buffer))))
+                  :sources (make 'history-disowned-source (buffer) nil))))
     (files:with-file-content (history (history-file buffer))
       (dolist (entry entries)
         (htree:delete-data history entry)))))

--- a/source/inspector.lisp
+++ b/source/inspector.lisp
@@ -81,8 +81,12 @@ In case it's `scalar-p', simply print it."
             (when (> (length sequence) *inspector-print-length*)
               (:td "More: " (:raw (link-to sequence))))))))))))
 
-(export-always 'value->html)
-(defgeneric value->html (value &optional compact-p)
+(define-generic value->html (value &optional compact-p)
+  "Produce HTML showing the structure of the VALUE.
+If it's COMPACT-P, compress the output.
+
+Specialize this generic function if you want to have a different markup for Lisp
+values in help buffers, REPL and elsewhere."
   (:method :around (value &optional compact-p)
     (let ((spinneret:*html-style* :tree))
       (call-next-method value compact-p)))
@@ -95,11 +99,7 @@ In case it's `scalar-p', simply print it."
   (:method ((value string) &optional compact-p)
     (declare (ignore compact-p))
     (escaped-literal-print value))
-  (:documentation "Produce HTML showing the structure of the VALUE.
-If it's COMPACT-P, compress the output.
-
-Specialize this generic function if you want to have a different markup for Lisp
-values in help buffers, REPL and elsewhere."))
+  (:export-generic-name-p t))
 
 (defmethod value->html ((value function) &optional compact-p)
   (spinneret:with-html-string

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -404,7 +404,7 @@ If REMEMBER-P is true, save active modes so that auto-rules don't override those
     (mapcar (lambda (buffer)
               (mapcar (lambda (mode-sym)
                         (apply #'enable (or (find mode-sym (slot-value buffer 'modes) :key #'name)
-                                            (make-instance mode-sym :buffer buffer))
+                                            (make mode-sym (buffer) nil))
                                args))
                       modes)
               buffer)
@@ -434,8 +434,7 @@ If it's a single buffer, return it directly (not as a list)."
                     (unless explicit-modes-p
                       (prompt
                        :prompt "Enable mode(s)"
-                       :sources (make-instance 'inactive-mode-source
-                                               :buffers buffers))))))
+                       :sources (make 'inactive-mode-source (buffers) nil))))))
     (enable-modes* modes buffers)
     (remember-on-mode-toggle modes buffers :enabled-p t))
   buffers)
@@ -478,8 +477,7 @@ If it's a single buffer, return it directly (not as a list)."
                     (unless explicit-modes-p
                       (prompt
                        :prompt "Disable mode(s)"
-                       :sources (make-instance 'active-mode-source
-                                               :buffers buffers))))))
+                       :sources (make 'active-mode-source (buffers) nil))))))
     (disable-modes* modes buffers)
     (remember-on-mode-toggle modes buffers :enabled-p nil))
   buffers)
@@ -519,9 +517,7 @@ If it's a single buffer, return it directly (not as a list)."
           ;; TODO: Shall we pass args to `make-instance' or `enable'?
           ;; Have 2 args parameters?
           (let ((mode (or existing-instance
-                          (apply #'make-instance mode-sym
-                                 :buffer buffer
-                                 args))))
+                          (make mode-sym (buffer) args))))
             (enable mode)
             (echo "~@(~a~) mode enabled." mode))
           (when existing-instance

--- a/source/mode/annotate.lisp
+++ b/source/mode/annotate.lisp
@@ -106,16 +106,14 @@ extracted by `annotate-highlighted-text' command."))
             :sources (list (make-instance 'prompter:word-source
                                           :name "New tags"
                                           :enable-marks-p t)
-                           (make-instance 'keyword-source :buffer buffer)
+                           (make 'keyword-source (buffer) nil)
                            (make-instance 'annotation-tag-source)))))
   "Create an annotation of the URL of BUFFER.
 
 DATA and TAGS are passed as arguments to `url-annotation' make-instance."
-  (annotation-add (make-instance 'url-annotation
-                                 :url (url buffer)
-                                 :data data
-                                 :page-title (title buffer)
-                                 :tags tags)))
+  (annotation-add (make 'url-annotation (data tags)
+                        :url (url buffer)
+                        :page-title (title buffer))))
 
 (define-command annotate-highlighted-text
     (&key (buffer (current-buffer))
@@ -134,12 +132,10 @@ DATA and TAGS are passed as arguments to `url-annotation' make-instance."
 
 DATA, SNIPPET, and TAGS are passed as arguments to `snippet-annotation'
 make-instance."
-  (annotation-add (make-instance 'snippet-annotation
-                                 :snippet snippet
-                                 :url (url buffer)
-                                 :page-title (title buffer)
-                                 :data data
-                                 :tags tags)))
+  (annotation-add (make 'snippet-annotation
+                        (snippet data tags)
+                        :url (url buffer)
+                        :page-title (title buffer))))
 
 (defun render-annotations (annotations)
   "Show the ANNOTATIONS in a new buffer"

--- a/source/mode/autofill.lisp
+++ b/source/mode/autofill.lisp
@@ -23,7 +23,7 @@ See the `autofill-mode' for the external user-facing APIs."))
 (export-always 'make-autofill)
 (defun make-autofill (&rest args)
   "Shortcut to create `autofill's: ARGS are keyword initargs."
-  (apply #'make-instance 'autofill args))
+  (make 'autofill nil args))
 
 (define-mode autofill-mode ()
   "Mode to fill forms more rapidly.

--- a/source/mode/blocker.lisp
+++ b/source/mode/blocker.lisp
@@ -44,7 +44,7 @@ See `*default-hostlist*' for an example."))
 (defun make-hostlist (&rest args)
   "Return a new `hostlist'.
 See the `hostlist' class documentation."
-  (apply #'make-instance 'hostlist args))
+  (make 'hostlist nil args))
 
 
 (export-always '*default-hostlist*)

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -145,8 +145,7 @@ instead."
           (sera:partition (sera:partial #'url-equal url) bookmarks :key #'url)
         (let ((entry (if entries
                          (first entries)
-                         (make-instance 'bookmark-entry
-                                        :url url))))
+                         (make 'bookmark-entry (url) nil))))
           (unless (str:emptyp title)
             (setf (title entry) title))
           (setf (tags entry)
@@ -172,7 +171,7 @@ By default, matches URL, title, and tags of the bookmark, but can also match
 against date, given `prompter:active-attributes-keys' configuration."))
 
 (defmethod url-sources ((mode bookmark-mode) actions-on-return)
-  (make-instance 'bookmark-source :actions-on-return actions-on-return))
+  (make 'bookmark-source (actions-on-return) nil))
 
 (defun tag-suggestions ()
   (let ((bookmarks (files:content (bookmarks-file (current-buffer)))))
@@ -248,8 +247,7 @@ against date, given `prompter:active-attributes-keys' configuration."))
                                               (or suggestions
                                                   (list "")))
                                             :enable-marks-p t)
-                             (make-instance 'keyword-source
-                                            :buffer buffer)
+                             (make 'keyword-source (buffer) nil)
                              (make-instance 'tag-source
                                             :marks (url-bookmark-tags (url buffer)))))))
         (bookmark-add (url buffer)

--- a/source/mode/certificate-exception.lisp
+++ b/source/mode/certificate-exception.lisp
@@ -43,8 +43,7 @@ To make this change permanent, you can customize
                      :sources (list
                                (make-instance 'prompter:raw-source
                                               :name "URL")
-                               (make-instance 'nyxt/mode/history:history-all-source
-                                              :buffer buffer)))))
+                               (make 'nyxt/mode/history:history-all-source (buffer) nil)))))
         (sera:and-let* ((url (if (stringp input)
                                  (quri:uri input)
                                  (url (htree:data input))))

--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -490,7 +490,7 @@ The inner-text must not be modified, so that we can jump to the anchor of the sa
 (define-command jump-to-heading (&key (buffer (current-buffer)))
   "Jump to a particular heading, of type h1, h2, h3, h4, h5, or h6."
   (prompt :prompt "Jump to heading"
-          :sources (make-instance 'heading-source :buffer buffer)))
+          :sources (make 'heading-source (buffer) nil)))
 
 (define-command jump-to-heading-buffers ()
   "Jump to a particular heading, of type h1, h2, h3, h4, h5, or h6 across a set
@@ -503,10 +503,9 @@ of buffers."
     (prompt
      :prompt "Jump to heading"
      :sources (loop for buffer in buffers
-                    collect (make-instance
-                             'heading-source
-                             :name (format nil "Headings: ~a" (title buffer))
-                             :buffer buffer)))))
+                    collect (make
+                             'heading-source (buffer)
+                             :name (format nil "Headings: ~a" (title buffer)))))))
 
 (define-panel-command-global headings-panel ()
     (panel-buffer "*Headings panel*")
@@ -717,9 +716,8 @@ of buffers."
 (define-command select-frame-new-buffer (&key (buffer (current-buffer)))
   "Select a frame and open the links in new buffers."
   (prompt :prompt "Open selected links in new buffers"
-          :sources (make-instance
-                    'frame-source
-                    :buffer buffer
+          :sources (make
+                    'frame-source (buffer)
                     :enable-marks-p t
                     :actions-on-return (lambda-command open-new-buffers (urls)
                                          (mapcar (lambda (i) (make-buffer :url (quri:uri i)))

--- a/source/mode/editor.lisp
+++ b/source/mode/editor.lisp
@@ -54,37 +54,34 @@ implementation."
   (:toggler-command-p nil))
 
 ;; IMPORTANT: Implement this method specializing on your class extending editor-mode.
-(export-always 'get-content)
-(defgeneric get-content (editor-submode)
-  (:method ((editor editor-mode))
-    (declare (ignore editor))
-    (echo-warning "Editor buffer cannot edit files without configured editor mode."))
-  (:documentation "Get the content of the EDITOR-SUBMODE as a string."))
+(define-generic get-content ((editor editor-mode))
+  "Get the content of the EDITOR-SUBMODE as a string."
+  (declare (ignore editor))
+  (echo-warning "Editor buffer cannot edit files without configured editor mode.")
+  (:export-generic-name-p t))
 
 ;; IMPORTANT: Implement this method specializing on your class extending editor-mode.
-(export-always 'set-content)
-(defgeneric set-content (editor-submode content)
-  (:method ((editor editor-mode) (content t))
-    (declare (ignore editor))
-    (echo-warning "Editor buffer cannot edit files without configured editor mode.
-See `describe-class editor-mode' for details."))
-  (:documentation "Set the content of the EDITOR-SUBMODE to a new string/other CONTENT."))
+(define-generic set-content ((editor editor-mode) (content t))
+  "Set the content of the EDITOR-SUBMODE to a new string/other CONTENT."
+  (declare (ignore editor))
+  (echo-warning "Editor buffer cannot edit files without configured editor mode.
+See `describe-class editor-mode' for details.")
+  (:export-generic-name-p t))
 
 ;; IMPORTANT: Implement this method specializing on your class extending editor-mode.
-(export-always 'markup)
-(defgeneric markup (editor-submode)
-  (:method ((editor editor-mode))
-    (spinneret:with-html-string
-      (:head
-       (:nstyle (style (buffer editor))))
-      (:body
-       (:p "Please configure an editor mode to use an editor buffer. See "
-           (:code "describe-class") " for " (:code "editor-buffer")
-           " to see the list of functions to implement."))))
-  (:documentation "Produce at least a string/byte-array of the initial buffer contents.
+(define-generic markup ((editor editor-mode))
+  "Produce at least a string/byte-array of the initial buffer contents.
 
 See the `scheme' documentation for the format and the number of values that
-`markup' specializations could/should return."))
+`markup' specializations could/should return."
+  (spinneret:with-html-string
+    (:head
+     (:nstyle (style (buffer editor))))
+    (:body
+     (:p "Please configure an editor mode to use an editor buffer. See "
+         (:code "describe-class") " for " (:code "editor-buffer")
+         " to see the list of functions to implement.")))
+  (:export-generic-name-p t))
 
 (define-class editor-buffer (network-buffer ; Questionable, but needed for `buffer-load'.
                              context-buffer modable-buffer document-buffer input-buffer)

--- a/source/mode/expedition.lisp
+++ b/source/mode/expedition.lisp
@@ -42,15 +42,15 @@
 (define-command-global select-frame-expedition (&key (buffer (current-buffer)))
   "Run an expedition through a set of URLs selected with a rectangle."
   (let* ((urls (reverse (prompt :prompt "Start expedition with the following links"
-                                :sources (make-instance 'nyxt/mode/document::frame-source
-                                                        :buffer buffer
-                                                        :enable-marks-p t)
+                                :sources (make 'nyxt/mode/document::frame-source
+                                               (buffer)
+                                               :enable-marks-p t)
                                 :after-destructor
                                 (lambda ()
                                   (with-current-buffer buffer
                                     (nyxt/mode/document::frame-element-clear))))))
          (urls (mapcar #'quri:uri urls))
          (buffer (make-buffer :title "" :url (first urls))))
-    (enable (make-instance 'expedition-mode :urls urls :buffer buffer))
+    (enable (make 'expedition-mode (urls buffer) nil))
     (nyxt::remember-on-mode-toggle (list 'expedition-mode) buffer :enabled-p t)
     (set-current-buffer buffer)))

--- a/source/mode/hint.lisp
+++ b/source/mode/hint.lisp
@@ -353,12 +353,12 @@ FUNCTION is the action to perform on the selected elements."
                             :fit-to-prompt
                             :default)
                 :hide-suggestion-count-p (eq :vi (hinting-type (find-submode 'hint-mode)))
-                :sources (make-instance 'hint-source
-                                        :enable-marks-p enable-marks-p
-                                        :constructor
-                                        (lambda (source)
-                                          (declare (ignore source))
-                                          (add-hints :selector selector)))
+                :sources (make 'hint-source
+                               (enable-marks-p)
+                               :constructor
+                               (lambda (source)
+                                 (declare (ignore source))
+                                 (add-hints :selector selector)))
                 :after-destructor (lambda () (with-current-buffer buffer (remove-hints))))))
     (funcall function result)))
 

--- a/source/mode/history-migration.lisp
+++ b/source/mode/history-migration.lisp
@@ -54,10 +54,8 @@ Or the equivalent columns for the browser in question."
              (loop for (url title last-access visits) in (sqlite:execute-to-list db ,sql-query)
                    do (unless (url-empty-p url)
                         (htree:add-entry history
-                                         (make-instance 'history-entry
-                                                        :url url
-                                                        :title title
-                                                        :implicit-visits visits)
+                                         (make 'history-entry (url title)
+                                               :implicit-visits visits)
                                          (local-time:unix-to-timestamp last-access))))
              (echo "History import finished.")))))))
 

--- a/source/mode/history.lisp
+++ b/source/mode/history.lisp
@@ -194,8 +194,7 @@ history modification operations are:
   "Query parent URL to navigate back to."
   (let ((input (prompt1
                 :prompt "Navigate backwards to"
-                :sources (make-instance 'history-backwards-source
-                                        :buffer buffer))))
+                :sources (make 'history-backwards-source (buffer) nil))))
     (when input
       (with-history-access (history buffer)
         (loop until (eq input (htree:owner-node history (id buffer)))
@@ -218,8 +217,7 @@ history modification operations are:
   "Query child URL to navigate to."
   (let ((input (prompt1
                 :prompt "Navigate forwards to"
-                :sources (make-instance 'direct-history-forwards-source
-                                        :buffer buffer))))
+                :sources (make 'direct-history-forwards-source (buffer) nil))))
     (when input
       (with-history-access (history buffer)
         (htree:go-to-child (htree:data input) history (id buffer)))
@@ -249,8 +247,7 @@ Otherwise go forward to the only child."
 (define-command history-forwards-query (&optional (buffer (current-buffer)))
   "Query forward-URL to navigate to."
   (let ((input (prompt1 :prompt "Navigate forwards to"
-                        :sources (make-instance 'history-forwards-source
-                                                :buffer buffer))))
+                        :sources (make 'history-forwards-source (buffer) nil))))
     (when input
       (with-history-access (history buffer)
         ;; REVIEW: Alternatively, we could use the COUNT argument with
@@ -276,8 +273,7 @@ Otherwise go forward to the only child."
 (define-command history-forwards-all-query (&optional (buffer (current-buffer)))
   "Query URL to forward to, from all child branches."
   (let ((input (prompt1 :prompt "Navigate forwards to (all branches)"
-                        :sources (make-instance 'all-history-forwards-source
-                                                :buffer buffer))))
+                        :sources (make 'all-history-forwards-source (buffer) nil))))
     (when input
       (with-history-access (history buffer)
         (htree:visit-all history (id buffer) input))
@@ -299,8 +295,7 @@ Otherwise go forward to the only child."
 (define-command history-all-owner-nodes-query (&optional (buffer (current-buffer)))
   "Query URL to go to, from the list of all nodes owned by BUFFER."
   (let ((input (prompt1 :prompt "Navigate to"
-                        :sources (make-instance 'history-all-owner-nodes-source
-                                                :buffer buffer))))
+                        :sources (make 'history-all-owner-nodes-source (buffer) nil))))
     (when input
       (with-history-access (history buffer)
         (htree:visit-all history (id buffer) input))
@@ -322,7 +317,7 @@ Otherwise go forward to the only child."
   "Query URL to go to, from the whole history."
 
   (let ((input (prompt1 :prompt "Navigate to"
-                        :sources (make-instance 'history-all-source :buffer buffer))))
+                        :sources (make 'history-all-source (buffer) nil))))
     (when input
       (with-history (history buffer)
         (alex:when-let ((matching-node
@@ -444,9 +439,7 @@ case."
                                                :key (compose #'url #'htree:data))))))
         (if parent-position
             (htree:backward history (id buffer) (1+ parent-position))
-            (htree:add-child (make-instance 'nyxt::history-entry
-                                            :url url
-                                            :title title)
+            (htree:add-child (make 'nyxt::history-entry (url title) nil)
                              history
                              (id buffer))))
       (let* ((entry (htree:data (htree:current (htree:owner history (id buffer))))))

--- a/source/mode/no-procrastinate.lisp
+++ b/source/mode/no-procrastinate.lisp
@@ -152,8 +152,7 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
           (sera:partition (sera:partial #'url-equal url) no-procrastinate-hosts-list :key #'url)
         (let ((entry (if entries
                          (first entries)
-                         (make-instance 'no-procrastinate-entry
-                                        :url url))))
+                         (make 'no-procrastinate-entry (url) nil))))
           (unless (str:emptyp title)
             (setf (title entry) title))
           (unless (str:emptyp hostname)
@@ -205,8 +204,7 @@ In particular, we ignore the protocol (e.g. HTTP or HTTPS does not matter)."
                                                (or suggestions
                                                    (list "")))
                                              :enable-marks-p t)
-                              (make-instance 'keyword-source
-                                             :buffer buffer)
+                              (make 'keyword-source (buffer) nil)
                               (make-instance 'tag-source
                                              :marks (url-no-procrastinate-host-tags (url buffer))))))
              (homepage-url-string (render-host-and-scheme (url buffer)))
@@ -329,6 +327,6 @@ URLS is either a list or a single element."
               (when (getf entry :date)
                 (setf (getf entry :date)
                       (time:parse-timestring (getf entry :date))))
-              (apply #'make-instance 'no-procrastinate-entry
-                     entry))
+              (make 'no-procrastinate-entry
+                    () entry))
             entries)))

--- a/source/mode/password.lisp
+++ b/source/mode/password.lisp
@@ -189,9 +189,8 @@ See also `copy-password-prompt-details'."
       (with-password (password-interface buffer)
         (prompt1 :prompt "Password"
                  :input (quri:uri-domain (url buffer))
-                 :sources (make-instance
-                           'password-source
-                           :buffer buffer
+                 :sources (make
+                           'password-source (buffer)
                            :password-instance (password-interface buffer))))
       (echo-warning "No password manager found.")))
 
@@ -202,9 +201,8 @@ See also `copy-password-prompt-details'."
       (with-password (password-interface buffer)
         (prompt :prompt "Username"
                 :input (quri:uri-domain (url buffer))
-                :sources (make-instance
-                          'password-source
-                          :buffer buffer
+                :sources (make
+                          'password-source (buffer)
                           :password-instance (password-interface buffer)
                           :actions-on-return (sera:filter (sera:eqs 'clip-username)
                                                           password-source-actions

--- a/source/mode/preview.lisp
+++ b/source/mode/preview.lisp
@@ -41,4 +41,4 @@ See `nyxt/mode/preview' package documentation for implementation details and int
                                             :sources 'nyxt/mode/file-manager:file-source)))
   "Open a local FILE in BUFFER and call `preview-mode' to watch and refresh it."
   (buffer-load (quri.uri.file:make-uri-file :path file) :buffer buffer)
-  (enable (make-instance 'nyxt/mode/preview:preview-mode :buffer buffer)))
+  (enable (make 'nyxt/mode/preview:preview-mode (buffer) nil)))

--- a/source/mode/remembrance.lisp
+++ b/source/mode/remembrance.lisp
@@ -81,11 +81,10 @@ Set to 0 to disable.")
   (let ((path (files:expand (cache-path mode))))
     (log:info "Remembrance cache at ~s" path)
     (setf (cache mode)
-          (make-instance 'montezuma:index
-                         :path path
-                         ;; Unless otherwise specified, queries will search all
-                         ;; these fields simultaneously.
-                         :default-field "*"))))
+          (make 'montezuma:index (path)
+                ;; Unless otherwise specified, queries will search all
+                ;; these fields simultaneously.
+                :default-field "*"))))
 
 (defmethod cache-size ((mode remembrance-mode))
   (length (all-cache-entries mode)))
@@ -359,8 +358,8 @@ query terms), even when offline."
   (prompt
    :prompt "Search cache"
    :input (ffi-buffer-copy (current-buffer))
-   :sources (list (make-instance 'remembrance-source :actions-on-return actions-on-return)
-                  (make-instance 'remembrance-exact-source :actions-on-return actions-on-return))))
+   :sources (list (make 'remembrance-source (actions-on-return) nil)
+                  (make 'remembrance-exact-source (actions-on-return) nil))))
 
 (define-command toggle-auto-cache (&key (buffer (current-buffer)))
   "Whether to cache on URL load.

--- a/source/mode/repl.lisp
+++ b/source/mode/repl.lisp
@@ -97,74 +97,69 @@ new cells via UI."))
                      (unimplemented-method c) (sera:class-name-of (cell c)))))
   (:documentation "The condition that's thrown when the REPL mode method is not implemented."))
 
-(export-always 'evaluate)
-(defgeneric evaluate (cell)
-  (:method ((cell cell))
-    (cerror "Ignore the unimplemented method"
-            'method-unimplemented :method 'evaluate :cell cell))
-  (:documentation "Evaluate CELL and get its results.
+(define-generic evaluate ((cell cell))
+  "Evaluate CELL and get its results.
 Generic function to specialize for all the REPL cell types.
 Use CELL (and, likely, its `input') and set its `results' and `output' to the
-meaningful values."))
+meaningful values."
+  (cerror "Ignore the unimplemented method"
+          'method-unimplemented :method 'evaluate :cell cell)
+  (:export-generic-name-p t))
 
-(export-always 'suggest)
-(defgeneric suggest (cell)
-  (:documentation "Get a single most intuitive suggestion string for CELL contents.
-The suggestion listing may rely on the CELL's contents."))
+(define-generic suggest (cell)
+  "Get a single most intuitive suggestion string for CELL contents.
+The suggestion listing may rely on the CELL's contents."
+  (:export-generic-name-p t))
 
-(export-always 'render-input)
-(defgeneric render-input (cell)
-  (:method ((cell cell))
-    (spinneret:with-html-string
-      (:ninput
-        :autofocus (eq (current-cell (current-mode :repl)) cell)
-        :onfocus `(focus-cell ,cell)
-        :onchange `(setf (input ,cell)
-                         (ps-eval
-                           (ps:@ (nyxt/ps:active-element document) value)))
-        (input cell))))
-  (:documentation "Generate HTML for the input area of the CELL.
+(define-generic render-input ((cell cell))
+  "Generate HTML for the input area of the CELL.
 Generic function to specialize against new REPL cell types.
 The default implementation produces an `:ninput' field that updates `cell''s
-`input' when modified."))
+`input' when modified."
+  (spinneret:with-html-string
+    (:ninput
+      :autofocus (eq (current-cell (current-mode :repl)) cell)
+      :onfocus `(focus-cell ,cell)
+      :onchange `(setf (input ,cell)
+                       (ps-eval
+                         (ps:@ (nyxt/ps:active-element document) value)))
+      (input cell)))
+  (:export-generic-name-p t))
 
-(export-always 'render-actions)
-(defgeneric render-actions (cell)
-  (:method ((cell cell))
-    (spinneret:with-html-string
-      (dolist (action (actions cell))
-        (:nbutton :text (first action)
-          `(funcall (quote ,(second action)) ,cell)))))
-  (:documentation "Generate HTML for the `actions' of the CELL.
+(define-generic render-actions ((cell cell))
+  "Generate HTML for the `actions' of the CELL.
 Generic function to specialize against new REPL cell types.
-The default method simply draws buttons."))
+The default method simply draws buttons."
+  (spinneret:with-html-string
+    (dolist (action (actions cell))
+      (:nbutton :text (first action)
+        `(funcall (quote ,(second action)) ,cell))))
+  (:export-generic-name-p t))
 
-(export-always 'render-results)
-(defgeneric render-results (cell)
-  (:method ((cell cell))
-    (cerror "Ignore the unimplemented method"
-            'method-unimplemented :method 'render-results :cell cell))
-  (:documentation "Generate HTML for the `results' and `output' of the CELL.
-Generic function to specialize against new REPL cell types."))
+(define-generic render-results ((cell cell))
+  "Generate HTML for the `results' and `output' of the CELL.
+Generic function to specialize against new REPL cell types."
+  (cerror "Ignore the unimplemented method"
+          'method-unimplemented :method 'render-results :cell cell)
+  (:export-generic-name-p t))
 
-(export-always 'render-cell)
-(defgeneric render-cell (cell)
-  (:method ((cell cell))
-    (spinneret:with-html-string
-      (:div.cell
-       (:div.input-area
-        (:div.cell-name
-         (:code (name cell)))
-        (:div.cell-input
-         (:raw (render-input cell)))
-        (:div.cell-actions
-         (:raw (render-actions cell))))
-       (:div.evaluation-result
-        (:raw (render-results cell))))))
-  (:documentation "Generate HTML for the CELL.
+(define-generic render-cell ((cell cell))
+  "Generate HTML for the CELL.
 Overrides all the methods defined for the CELL type.
 By default utilizes `render-input', `render-actions', and `render-results'.
-Generic function to specialize against new REPL cell types."))
+Generic function to specialize against new REPL cell types."
+  (spinneret:with-html-string
+    (:div.cell
+     (:div.input-area
+      (:div.cell-name
+       (:code (name cell)))
+      (:div.cell-input
+       (:raw (render-input cell)))
+      (:div.cell-actions
+       (:raw (render-actions cell))))
+     (:div.evaluation-result
+      (:raw (render-results cell)))))
+  (:export-generic-name-p t))
 
 (defun reload-repl (repl)
   (with-current-buffer (buffer repl)

--- a/source/mode/search-buffer.lisp
+++ b/source/mode/search-buffer.lisp
@@ -329,11 +329,10 @@ MARK-P accepts the following values:
                          ;; Matches circumscribed to a single node
                          (loop with id = (nyxt/dom:get-nyxt-id node)
                                for match in (search-all pattern text :test test)
-                               do (push (make-instance
+                               do (push (make
                                          'search-match
-                                         :pattern pattern
+                                         (pattern buffer)
                                          :body text
-                                         :buffer buffer
                                          :nodes (list child)
                                          :id (incf idx)
                                          :identifier-beg id
@@ -355,10 +354,9 @@ MARK-P accepts the following values:
                                   (setf partial-match nil))
                                  ((null partial-match)
                                   (setf partial-match
-                                        (make-instance
+                                        (make
                                          'search-match
-                                         :pattern pattern
-                                         :buffer buffer
+                                         (pattern buffer)
                                          :nodes (list child)
                                          :identifier-beg (nyxt/dom:get-nyxt-id node)
                                          :node-index-beg index

--- a/source/mode/small-web.lisp
+++ b/source/mode/small-web.lisp
@@ -63,16 +63,16 @@ Gemini support is a bit more brittle, but you can override `line->html' for
 (defmethod cl-gopher:display-string :around ((line cl-gopher:gopher-line))
   (cl-ppcre:regex-replace-all "\\e\\[[\\d;]*[A-Za-z]" (slot-value line 'cl-gopher:display-string) ""))
 
-(export-always 'line->html)
-(defgeneric line->html (line)
-  (:documentation "Transform a Gopher or Gemini line to a reasonable HTML representation."))
+(define-generic line->html (line)
+  "Transform a Gopher or Gemini line to a reasonable HTML representation."
+  (:export-generic-name-p t))
 
-(export-always 'gopher-render)
-(defgeneric gopher-render (line)
-  (:documentation "Produce a Gopher page content string/array given LINE.
+(define-generic gopher-render (line)
+  "Produce a Gopher page content string/array given LINE.
 Second return value should be the MIME-type of the content.
 
-Implies that `small-web-mode' is enabled."))
+Implies that `small-web-mode' is enabled."
+  (:export-generic-name-p t))
 
 (defmethod line->html ((line cl-gopher:gopher-line))
   (spinneret:with-html-string
@@ -279,7 +279,7 @@ Implies that `small-web-mode' is enabled."
               (when mode
                 (:nstyle (style mode)))
               (loop for element in elements
-                    collect (:raw (nyxt/mode/small-web:line->html element))))
+                    collect (:raw (line->html element))))
             "text/html;charset=utf8")))
 
 ;; TODO: :secure-p t? Gemini is encrypted, so it can be considered secure.

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -80,6 +80,11 @@ Same as `progn' on implementations that don't have package locks."
           (:predicate-name-transformer 'nclasses:always-dashed-predicate-name-transformer))
        options)))
 
+(serapeum:export-always 'make :nyxt)
+(defmacro make (class &rest args)
+  "A prettier (more consistent) alias for `nclasses:make-instance*'."
+  `(nclasses:make-instance* ,class ,@args))
+
 (serapeum:export-always 'define-package :nyxt)
 (defmacro define-package (name &body options)
   "A helper around `uiop:define-package'.

--- a/source/panel.lisp
+++ b/source/panel.lisp
@@ -16,8 +16,8 @@
 (define-command-global delete-panel-buffer (&key (window (current-window))
                                             (panels (prompt
                                                      :prompt "Delete a panel buffer"
-                                                     :sources (make-instance 'panel-buffer-source
-                                                                             :window window))))
+                                                     :sources (make 'panel-buffer-source
+                                                                    (window) nil))))
   "Prompt for panel buffer(s) to be deleted.
 When provided, PANELS are deleted instead."
   (mapc (curry #'window-delete-panel-buffer window) (uiop:ensure-list panels)))

--- a/source/prompt-buffer.lisp
+++ b/source/prompt-buffer.lisp
@@ -683,12 +683,12 @@ See the documentation of `prompt-buffer' to know more about the options."
       (ffi-within-renderer-thread
        *browser*
        (lambda ()
-         (let ((prompt-buffer (apply #'make-instance 'prompt-buffer
-                                     (append args
-                                             (list
-                                              :window (current-window)
-                                              :result-channel (make-channel)
-                                              :interrupt-channel (make-channel))))))
+         (let ((prompt-buffer (make 'prompt-buffer ()
+                                    (append args
+                                            (list
+                                             :window (current-window)
+                                             :result-channel (make-channel)
+                                             :interrupt-channel (make-channel))))))
            (calispel:! prompt-object-channel prompt-buffer))))
       (let ((new-prompt (calispel:? prompt-object-channel)))
         (wait-on-prompt-buffer new-prompt)))))

--- a/source/renderer-script.lisp
+++ b/source/renderer-script.lisp
@@ -380,12 +380,12 @@ Example:
 \(define-internal-page my-page (&key arg1 arg2)
   (:title \"My beautiful page\")
   ...)"
-  `(apply #'make-instance 'internal-page
-          :name ',name
-          :visibility :anonymous
-          :lambda-list ',form-args
-          :form (quote (lambda (,@form-args) ,@body))
-          (list ,@initargs)))
+  `(make 'internal-page
+         :name ',name
+         :visibility :anonymous
+         :lambda-list ',form-args
+         :form (quote (lambda (,@form-args) ,@body))
+         (list ,@initargs)))
 
 (export-always 'define-internal-page-command)
 (defmacro define-internal-page-command (name (&rest arglist)

--- a/source/renderer.lisp
+++ b/source/renderer.lisp
@@ -9,11 +9,11 @@
   (:export-accessor-names-p t)
   (:documentation "Specialize this class and bind an instance to `*renderer*' to set the default renderer."))
 
-(export-always 'install)
-(defgeneric install (renderer)
-  (:documentation "Setup for renderer.  This may have side effects.
-See also `uninstall'."))
+(define-generic install (renderer)
+  "Setup for renderer.  This may have side effects.
+See also `uninstall'."
+  (:export-generic-name-p t))
 
-(export-always 'uninstall)
-(defgeneric uninstall (renderer)
-  (:documentation "Revert the side effects induced by `install'."))
+(define-generic uninstall (renderer)
+  "Revert the side effects induced by `install'."
+  (:export-generic-name-p t))

--- a/source/search-engine.lisp
+++ b/source/search-engine.lisp
@@ -63,10 +63,9 @@ For the actual uses and configuration of search engines, see:
   "Utility to create simple `search-engine's.
 Sets `shortcut', `search-url', and `fallback-url' of the search engine to the
 values of respective arguments."
-  (make-instance 'search-engine
-                 :shortcut shortcut
-                 :search-url search-url
-                 :fallback-url (ensure-url fallback-url)))
+  (make 'search-engine
+        (shortcut search-url)
+        :fallback-url (ensure-url fallback-url)))
 
 (export-always 'make-search-completion-function)
 (-> make-search-completion-function
@@ -148,5 +147,5 @@ QUERY-IN-NEW-BUFFER creates a new buffer with the search results."
                             (make-buffer-focus)
                             (current-buffer))))
     (when engine
-      (buffer-load (make-instance 'new-url-query :query selection :engine engine)
+      (buffer-load (make 'new-url-query (engine) :query selection)
                    :buffer target-buffer))))

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -601,11 +601,10 @@ Finally, run the browser, load URL-STRINGS if any, then run
                                                  (princ-to-string condition)
                                                  backtrace)))))
                 (load-or-eval :remote nil)
-                (setf *browser* (make-instance 'browser
-                                               :startup-error-reporter-function startup-error-reporter
-                                               :startup-timestamp startup-timestamp
-                                               :socket-thread (unless (nfiles:nil-pathname-p (files:expand *socket-file*))
-                                                                (listen-or-query-socket urls))))
+                (setf *browser* (make 'browser (startup-timestamp)
+                                      :startup-error-reporter-function startup-error-reporter
+                                      :socket-thread (unless (nfiles:nil-pathname-p (files:expand *socket-file*))
+                                                       (listen-or-query-socket urls))))
                 ;; Defaulting to :nyxt-user is convenient when evaluating code (such as
                 ;; remote execution or the integrated REPL).
                 ;; This must be done in a separate thread because the calling thread may

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -3,14 +3,13 @@
 
 (in-package :nyxt)
 
-(export-always 'mode-status)
-(defgeneric mode-status (status mode)
-  (:method ((status status-buffer) (mode mode))
-    (if (glyph-mode-presentation-p status)
-        (glyph mode)
-        (princ-to-string mode)))
-  (:documentation "Return a MODE `mode' string description for the STATUS `status-buffer'.
-Upon returning NIL, the mode is not displayed."))
+(define-generic mode-status ((status status-buffer) (mode mode))
+  "Return a MODE `mode' string description for the STATUS `status-buffer'.
+Upon returning NIL, the mode is not displayed."
+  (if (glyph-mode-presentation-p status)
+      (glyph mode)
+      (princ-to-string mode))
+  (:export-generic-name-p t))
 
 (defun sort-modes-for-status (modes)
   "Return visible modes in MODES, with `nyxt/mode/keyscheme:keyscheme-mode' placed

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -173,10 +173,9 @@ For keyword arguments' meaning, see the corresponding `scheme' slot
 documentation."
   (declare (ignorable local-p no-access-p secure-p cors-enabled-p))
   (setf (gethash scheme-name *schemes*)
-        (apply #'make-instance 'scheme
-               :name scheme-name
-               :callback callback
-               keys)))
+        (make 'scheme (callback)
+              :name scheme-name
+              keys)))
 
 (defmemo lookup-hostname (name)
   "Resolve hostname NAME and memoize the result."

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -195,10 +195,10 @@ documentation."
 Public Suffix list, T otherwise."
   (sera:true (cl:ignore-errors (cl-tld:get-tld hostname))))
 
-(export-always 'browser-schemes)
-(defgeneric browser-schemes (browser)
+(define-generic browser-schemes (browser)
+  "Return a list of schemes supported by a browser"
   (:method-combination append)
-  (:documentation "Return a list of schemes supported by a browser"))
+  (:export-generic-name-p t))
 
 ;; Set specifier to T because *BROWSER* can be bound to NIL
 (defmethod browser-schemes append ((browser t))

--- a/source/user-classes.lisp
+++ b/source/user-classes.lisp
@@ -49,10 +49,8 @@ Can be configured using `customize-instance' and `customize-hook'."))
 (defmethod closer-mop:validate-superclass ((class user-funcallable-class) (superclass user-mixin-class)) t)
 (defmethod closer-mop:validate-superclass ((superclass user-mixin-class) (class user-funcallable-class)) t)
 
-(export-always 'customize-instance)
-(defgeneric customize-instance (object &key &allow-other-keys)
-  (:method ((class t) &key) t)
-  (:documentation "Specialize this method to customize the default values and
+(define-generic customize-instance ((object t) &key &allow-other-keys)
+  "Specialize this method to customize the default values and
 behavior of some CLASS instance.
 
 This method is run after the instance has been initialized (in particular, after
@@ -62,7 +60,9 @@ The standard method is reserved for user configuration.
 
 Do not specialize the standard method in public code, prefer
 `initialize-instance :after' instead to initialize slots, and
-`customize-instance :after' for code that relies on finalized slot values."))
+`customize-instance :after' for code that relies on finalized slot values."
+  t
+  (:export-generic-name-p t))
 
 (defmethod make-instance
   :around ((class user-mixin-class) &rest initargs &key &allow-other-keys)


### PR DESCRIPTION
# Description

This uses the facilities provided by Nclasses to shorten and clean up our object-oriented code. In particular:
- `define-generic` is used to make generic declarations more `defun`-like and cohesive.
- `make` (alias for `nclasses:make-instance*`) is used to shorten object instantiation.

# Discussion

- `define-generic` doesn't save much lines and is somewhat complicated. The part with `:export-generic-name-p` especially. But we've established [that it's okay](https://github.com/atlas-engineer/nclasses/pull/25).
- `make` looks weird for short instantiations. For example, it turns `(make-instance x :buffer buffer)` into `(make x (buffer) nil)` to avoid shortcut slots and apply args ambiguity. But `make` is there mainly for big instantiations, like `request-data`, and it shines there.
  - The main use for `make` is not immediate (although it already saves quite a lot of repetitive lines), but rather future-focused. It's an elegant weapon meant to shorten a lot of common idioms. If we start using `make` and get used to it—we'll be able to make our OOP code much cleaner.
- I haven't used `make` for cases where it's just a class instantiation, i.e. `(make-instance 'buffer)`, because that'd be too much renamings for little practical use.

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [X] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [X] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [X] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [X] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [X] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [X] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.