### PR TITLE
Show function arguments before their documentation string

### DIFF
--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -388,6 +388,7 @@ For generic functions, describe all the methods."
       (let ((input function))
         (flet ((fun-desc (input)
                  (spinneret:with-html-string
+                   (:pre (:code (prini-to-string (arglist input) :package (symbol-package input)))) ;; Argument list
                    (:pre (:code (:raw (resolve-backtick-quote-links (documentation input 'function) (symbol-package input)))))
                    (when (sym:command-symbol-p input)
                      (let* ((key-keymap-pairs (nth-value 1 (keymaps:pretty-binding-keys input (all-keymaps) :print-style (keymaps:name (keyscheme buffer)))))
@@ -405,9 +406,6 @@ For generic functions, describe all the methods."
                             (loop for (binding keymapname) in key-keymapname-pairs
                                   collect (:tr (:td binding)
                                                (:td keymapname))))))))
-                   (:nsection
-                     :title "Argument list"
-                     (:pre (:code (prini-to-string (arglist input) :package (symbol-package input)))))
                    #+sbcl
                    (unless (or (macro-function input)
                                (eq 'function (sb-introspect:function-type input)))


### PR DESCRIPTION
source/describe.lisp: insert arguments before docstring.

Also remove the section and its title (again following Emacs' example). I can add them back if you'd prefer it.

Closes #3278

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.

- [x] Git hygiene:
  - I have pulled from master before submitting this PR
  - There are no merge conflicts.
- [x] I've added the new dependencies as:
  - ASDF dependencies,
  - Git submodules,
    ```sh
	cd /path/to/nyxt/checkout
    git submodule add https://gitlab.common-lisp.net/nyxt/py-configparser _build/py-configparser
    ```
  - and Guix dependencies.
- [x] My code follows the style guidelines for Common Lisp code. See:
  - [Norvig & Pitman's Tutorial on Good Lisp Programming Style (PDF)](https://www.cs.umd.edu/~nau/cmsc421/norvig-lisp-style.pdf)
  - [Google Common Lisp Style Guide](https://google.github.io/styleguide/lispguide.xml)
- [x] I have performed a self-review of my own code.
- [ ] My code has been reviewed by at least one peer.  (The peer review to approve a PR counts.  The reviewer must download and test the code.)
- [x] Documentation:
  - All my code has docstrings and `:documentation`s written in the aforementioned style.  (It's OK to skip the docstring for really trivial parts.)
  - I have updated the existing documentation to match my changes.
  - I have commented my code in hard-to-understand areas.
  - I have updated the `changelog.lisp` with my changes if it's anything user-facing (new features, important bug fix, compatibility breakage).
    - Changelog update should be a separate commit.
  - I have added a `migration.lisp` entry for all compatibility-breaking changes.
  - (If this changes something about the features showcased on Nyxt website) I have these changes described in the new/existing article at Nyxt website or will notify one of maintainters to do so.
- [x] Compilation and tests:
  - My changes generate no new warnings.
  - I have added tests that prove my fix is effective or that my feature works.  (If possible.)
  - I ran the tests locally (`(asdf:test-system :nyxt)` and `(asdf:test-system :nyxt/gi-gtk)`) and they pass.
