### PR TITLE
Delete html-string-p and related logic.

### DIFF
--- a/source/mode/message.lisp
+++ b/source/mode/message.lisp
@@ -25,6 +25,4 @@ Mainly used on `list-messages' page."
     (:h1 "Messages")
     (:ul
      (loop for message in (reverse (nyxt:messages-content *browser*))
-           collect (if (html-string-p message)
-                       (:li (:raw message))
-                       (:li (:pre message)))))))
+           collect (:li (:pre message))))))

--- a/source/spinneret-tags.lisp
+++ b/source/spinneret-tags.lisp
@@ -3,16 +3,6 @@
 
 (in-package :spinneret)
 
-(deftag :mayberaw (body attrs &rest keys &key &allow-other-keys)
-  "Spinneret's :raw, but with HTML escaping if BODY _does not_ look like HTML."
-  ;; Because (declare (ignorable ...)) doesn't work.
-  (let ((attrs attrs)
-        (keys keys))
-    (declare (ignorable attrs keys))
-    `(:raw (if (nyxt:html-string-p (progn ,@body))
-               (progn ,@body)
-               (escape-string (progn ,@body))))))
-
 (defun %nstyle-body (forms)
   (reduce #'uiop:strcat
           (mapcar (lambda (f) (typecase f

--- a/source/status.lisp
+++ b/source/status.lisp
@@ -41,13 +41,11 @@ Augment this with `style' of STATUS, if necessary."
                   collect
                   (let ((mode mode))
                     (alex:when-let ((formatted-mode (mode-status status mode)))
-                      (if (html-string-p formatted-mode)
-                          (:raw formatted-mode)
-                          (:nbutton
-                            :buffer status
-                            :text formatted-mode
-                            :title (format nil "Describe ~a" mode)
-                            `(describe-class :class (quote ,(name mode))))))))))
+                      (:nbutton
+                        :buffer status
+                        :text formatted-mode
+                        :title (format nil "Describe ~a" mode)
+                        `(describe-class :class (quote ,(name mode)))))))))
         "")))
 
 (defun modes-string (buffer)

--- a/source/types.lisp
+++ b/source/types.lisp
@@ -66,21 +66,6 @@ Unlike `(cons TYPE *)', it checks all the elements.
   '(member :character :word :sentence :line :paragraph :lineboundary
     :sentenceboundary :paragraphboundary :documentboundary))
 
-(export-always 'html-string-p)
-(defun html-string-p (string)
-  "Check whether the STRING is an HTML string:
-- Having proper starting/ending tags.
-- Being parseable with Plump."
-  (serapeum:and-let*
-   ((string string)
-    (-p (stringp string))
-    (trimmed (string-trim serapeum:whitespace string))
-    (has-closing-tag (ppcre:scan "</\\w+>$" trimmed))
-    (html (ignore-errors (plump:parse trimmed)))
-    (single-child (serapeum:single (plump:children html)))
-    (child (elt (plump:children html) 0)))
-   (plump:element-p child)))
-
 (export-always 'maybe)
 (deftype maybe (&rest types)
   "An optional/maybe type for a value that is either one of TYPES, or NIL."


### PR DESCRIPTION
# Description

I don't see the need for `html-string-p` in our API.

No need to for a changelog entry.

# Checklist:

- [x] Git branch state is mergable.
- [x] Changelog is up to date (via a separate commit).
- [x] New dependencies are accounted for.
- [x] Documentation is up to date.
- [x] Compilation and tests (`(asdf:test-system :nyxt/gi-gtk)`)
  - No new compilation warnings.
  - Tests are sufficient.
