### PR TITLE
Restore Scroll Position on Reload

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1646,14 +1646,21 @@ specified for their contents."
     (current-buffer)))
 
 (export-always 'reload-buffer)
-(defun reload-buffer (buffer)
-  "Reload BUFFER and return it."
+(defun reload-buffer (buffer &key retain-scroll-position)
+  "Reload BUFFER and return it.
+
+If retain-scroll-position is t, calculate the position of the scroll, and
+attempt to restore it upon reload."
+  (when retain-scroll-position
+    (let ((scroll-position (ps-eval :buffer buffer (ps:chain window page-y-offset))))
+      (hooks:once-on (buffer-loaded-hook buffer) (buffer)
+        (ps-eval :buffer buffer (ps:chain window (scroll-to 0 (ps:lisp scroll-position)))))))
   (buffer-load (url buffer) :buffer buffer))
 
-(define-command reload-current-buffer ()
+(define-command reload-current-buffer (&key (retain-scroll-position t))
   "Reload current buffer.
 Return it."
-  (reload-buffer (current-buffer)))
+  (reload-buffer (current-buffer) :retain-scroll-position retain-scroll-position))
 
 (define-command reload-buffers
     (&optional (buffers

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -989,6 +989,11 @@ allows access to common functions that are defined within the mode."))))
            (:li (:nxref :command 'nyxt/mode/buffer-listing:buffers-panel))
            (:li (:nxref :command 'nyxt/mode/bookmark:bookmarks-panel)))))))
 
+(define-version "3.X.Y"
+  (:nsection :title "New features"
+    (:ul
+     (:li "When reloading a buffer, restore the scroll position."))))
+
 (define-version "4-pre-release-1"
   (:li "When on pre-release, push " (:code "X-pre-release")
        " feature in addition to " (:code "X-pre-release-N") "one."))


### PR DESCRIPTION
# Description

- When the user uses the command "reload-buffer" or "reload-current-buffer" they can have it restore the scroll position that they were at.

Fixes #3325

# Checklist:

- [x] Git branch state is mergable.
- [x] Changelog is up to date (via a separate commit).
- [x] New dependencies are accounted for.
- [x] Documentation is up to date.
- [x] Compilation and tests (`(asdf:test-system :nyxt/gi-gtk)`)
  - No new compilation warnings.
  - Tests are sufficient.