### PR TITLE
Set vi insert mode as default in the prompt buffer

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -989,6 +989,14 @@ allows access to common functions that are defined within the mode."))))
            (:li (:nxref :command 'nyxt/mode/buffer-listing:buffers-panel))
            (:li (:nxref :command 'nyxt/mode/bookmark:bookmarks-panel)))))))
 
+(define-version "3.X.Y"
+  (:nsection :title "Bug fixes"
+    (:ul
+     (:li "When enabling " (:code "vi") " keybindings via"
+          (:a :href (nyxt-url 'common-settings) "common settings")
+          ", start the prompt buffer with "
+          (:nxref :mode 'nyxt/mode/vi:vi-insert-mode) "enabled."))))
+
 (define-version "4-pre-release-1"
   (:li "When on pre-release, push " (:code "X-pre-release")
        " feature in addition to " (:code "X-pre-release-N") "one."))

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -166,9 +166,13 @@ to the next."
                  :form '(define-configuration (input-buffer)
                          ((default-modes (pushnew 'nyxt/mode/emacs:emacs-mode %slot-value%))))))
               '(vi "vi"
-                (nyxt::auto-configure
-                 :form '(define-configuration (input-buffer)
-                         ((default-modes (pushnew 'nyxt/mode/vi:vi-normal-mode %slot-value%))))))))
+                (progn
+                  (nyxt::auto-configure
+                   :form '(define-configuration (input-buffer)
+                           ((default-modes (pushnew 'nyxt/mode/vi:vi-normal-mode %slot-value%)))))
+                  (nyxt::auto-configure
+                   :form '(define-configuration (prompt-buffer)
+                           ((default-modes (pushnew 'nyxt/mode/vi:vi-insert-mode %slot-value%)))))))))
            (:div.right
             (:p "Make a selection to set the default keybindings for every new
 Nyxt session (after restart).")


### PR DESCRIPTION
# Description

- The user when using the common settings will now have the prompt buffer set to use vi-insert-mode when entering it.

Fixes #3242

# Checklist:

- [X] Git branch state is mergable.
- [X] Changelog is up to date (via a separate commit).
- [X] New dependencies are accounted for.
- [X] Documentation is up to date.
- [X] Compilation and tests (`(asdf:test-system :nyxt/gi-gtk)`)
  - No new compilation warnings.
  - Tests are sufficient.