### PR TITLE
Update makefile: default installation paths

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,6 +5,10 @@
 SHELL = /bin/sh
 UNAME := $(shell uname)
 
+DESTDIR ?= /usr/local/bin/
+PREFIX ?= /usr/local/bin/
+NASDF_SOURCE_PATH ?= /usr/local/lib/
+
 LISP ?= sbcl
 SBCL_FLAGS =
 ifeq ($(LISP), sbcl)


### PR DESCRIPTION
added default values of DESTDIR, PREFIX and NASDF_SOURCE_PATH. makefile now runs without need to edit.

# Description

Fixes # (issue)

# Checklist:

- [X ] Git branch state is mergable.
- [ X] Changelog is up to date (via a separate commit).
- [ X] New dependencies are accounted for.
- [ X] Documentation is up to date.
- [ X] Compilation and tests (`(asdf:test-system :nyxt/gi-gtk)`)
  - No new compilation warnings.
  - Tests are sufficient.
