### PR TITLE
Fix SET-URL

### DIFF
--- a/nyxt.asd
+++ b/nyxt.asd
@@ -2,10 +2,6 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 #-asdf3.1 (error "Nyxt requires ASDF 3.1.2")
-#+sbcl
-(progn
-  (sb-ext:assert-version->= 2 0 0)
-  (require 'sb-bsd-sockets))
 
 ;; WARNING: We _must_ declare the translation host or else ASDF won't recognize
 ;; the pathnames as logical-pathnames, thus returning the system directory

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -1398,22 +1398,18 @@ Loads the entry with default `prompter:actions-on-return'."))
   (:documentation "Structure that processes a new URL query from user input.
 Checks whether a valid https or local file URL is requested, in a DWIM fashion."))
 
-;; TODO: Remove CHECK-DNS-P from everywhere in this file and url.lisp
-(defmethod initialize-instance :after ((query new-url-query)
-                                       &key check-dns-p &allow-other-keys)
-  (declare (ignore check-dns-p))
-  (with-slots (query engine)
-      query
+(defmethod initialize-instance :after ((query new-url-query) &key &allow-other-keys)
+  (with-slots (query engine) query
     ;; Trim whitespace, in particular to detect URL properly.
     (setf query (str:trim query))
     (cond
       (engine
        ;; First check engine: if set, no need to change anything.
        nil)
-      ((valid-url-p query :check-dns-p nil :check-tld-p nil)
+      ((valid-url-p query :check-tld-p nil)
        ;; Valid URLs should be passed forward.
        nil)
-      ((valid-url-p (str:concat "https://" query) :check-dns-p nil :check-tld-p t)
+      ((valid-url-p (str:concat "https://" query) :check-tld-p t)
        (setf query (str:concat "https://" query)))
       ;; Rest is for invalid URLs:
       ((uiop:file-exists-p query)
@@ -1449,19 +1445,17 @@ Checks whether a valid https or local file URL is requested, in a DWIM fashion."
       (fallback-url (engine query)))
      (t (query query)))))
 
-(defun make-completion-query (completion &key engine (check-dns-p t))
+(defun make-completion-query (completion &key engine)
   (typecase completion
     (string (make-instance 'new-url-query
-                           :engine      engine
-                           :check-dns-p check-dns-p
-                           :query completion))
+                           :engine engine
+                           :query  completion))
     (list (make-instance 'new-url-query
                          :engine engine
-                         :check-dns-p check-dns-p
                          :query (second completion)
                          :label (first completion)))))
 
-(defun input->queries (input &key (check-dns-p t) (engine-completion-p))
+(defun input->queries (input &key (engine-completion-p))
   (let* ((terms (sera:tokens input))
          (engines (let ((all-prefixed-engines
                           (remove-if
@@ -1477,14 +1471,12 @@ Checks whether a valid https or local file URL is requested, in a DWIM fashion."
                                          (mapcar #'shortcut engines)
                                          :test #'string=))
               (list (make-instance 'new-url-query
-                                   :query       input
-                                   :check-dns-p check-dns-p)))
+                                   :query input)))
             (or (mappend (lambda (engine)
                            (append
                             (list (make-instance 'new-url-query
-                                                 :query       (str:join " " (rest terms))
-                                                 :engine      engine
-                                                 :check-dns-p check-dns-p))
+                                                 :query  (str:join " " (rest terms))
+                                                 :engine engine))
                             ;; Some engines (I'm looking at you, Wikipedia!)
                             ;; return garbage in response to an empty request.
                             (when (and engine-completion-p
@@ -1492,8 +1484,7 @@ Checks whether a valid https or local file URL is requested, in a DWIM fashion."
                                        (completion-function engine)
                                        (rest terms))
                               (mapcar (rcurry #'make-completion-query
-                                              :engine      engine
-                                              :check-dns-p check-dns-p)
+                                              :engine engine)
                                       (with-protect ("Error while completing search: ~a" :condition)
                                         (funcall (completion-function engine)
                                                  (str:join " " (rest terms))))))))
@@ -1506,8 +1497,7 @@ Checks whether a valid https or local file URL is requested, in a DWIM fashion."
                                 (completion (completion-function engine))
                                 (all-terms (str:join " " terms)))
                   (mapcar (rcurry #'make-completion-query
-                                  :engine      engine
-                                  :check-dns-p check-dns-p)
+                                  :engine engine)
                           (with-protect ("Error while completing default search: ~a" :condition)
                             (funcall (completion-function engine) all-terms))))))))
 
@@ -1516,14 +1506,14 @@ Checks whether a valid https or local file URL is requested, in a DWIM fashion."
    (prompter:filter-preprocessor
     (lambda (suggestions source input)
       (declare (ignore suggestions source))
-      (input->queries input :check-dns-p t :engine-completion-p nil)))
+      (input->queries input :engine-completion-p nil)))
    (prompter:filter-postprocessor
     (lambda (suggestions source input)
       (declare (ignore source))
       ;; Avoid long computations until the user has finished the query.
       (sleep 0.15)
       (append suggestions
-              (input->queries input :check-dns-p nil :engine-completion-p t))))
+              (input->queries input :engine-completion-p t))))
    (prompter:filter nil)
    (prompter:actions-on-return #'buffer-load*))
   (:export-class-name-p t)

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -137,17 +137,6 @@ signatures."
   (setf (gethash scheme-name *schemes*)
         (list callback error-callback)))
 
-(defmemo lookup-hostname (name)
-  "Resolve hostname NAME and memoize the result."
-  ;; `sb-bsd-sockets:get-host-by-name' may signal a `ns-try-again-condition' which is
-  ;; not an error, so we can't use `ignore-errors' here.
-  (handler-case
-      #+sbcl
-    (sb-bsd-sockets:get-host-by-name name)
-    #-sbcl
-    (iolib/sockets:lookup-hostname name)
-    (t () nil)))
-
 (export-always 'valid-tld-p)
 (defun valid-tld-p (hostname)
   "Return NIL if HOSTNAME does not include a valid TLD as determined by the
@@ -190,12 +179,9 @@ Usually means that either:
   (sera:true (find scheme (browser-schemes *browser*) :test #'string=)))
 
 (export-always 'valid-url-p)
-(defun valid-url-p (url &key (check-dns-p t) (check-tld-p t))
-  "Return non-nil when URL is a valid URL.  The domain name existence
-is verified only if CHECK-DNS-P is T. Domain name validation may take
-significant time since it looks up the DNS. CHECK-TLD-P also checks if
+(defun valid-url-p (url &key (check-tld-p t))
+  "Return non-nil when URL is a valid URL. CHECK-TLD-P also checks if
 the host has a known TLD."
-  (declare (ignore check-dns-p))
   (let ((%url (ignore-errors (quri:uri url))))
     (and %url
          (valid-scheme-p (quri:uri-scheme %url))

--- a/tests/offline/urls.lisp
+++ b/tests/offline/urls.lisp
@@ -55,7 +55,15 @@
   ;; "valid syntax but unknown scheme"
   (assert-equality #'quri:uri=
                    (quri:uri "https://search.atlas.engineer/searxng/search?q=foo:blank")
-                   (url (first (nyxt::input->queries "foo:blank")))))
+                   (url (first (nyxt::input->queries "foo:blank"))))
+  ;; "'Partial' URLs without scheme but with path"
+  (assert-equality #'quri:uri=
+                   (quri:uri "https://github.com/atlas-engineer")
+                   (url (first (nyxt::input->queries "github.com/atlas-engineer"))))
+  ;; IP address without scheme
+  (assert-equality #'quri:uri=
+                   (quri:uri "https://127.0.0.1")
+                   (url (first (nyxt::input->queries "127.0.0.1")))))
 
 (define-test nyxt-urls ()
   (assert-error 'simple-error


### PR DESCRIPTION
As discussed in #3383, I open another PR which fixes navigation to URLs like "github.com/atlas-engineer".

It brings two changes:
1) Uses `valid-url-p` to check if `"https://"` + query is a valid URL.
2) In `valid-url-p` move the check of TLD validity out of `(or (not check-dns-p) ...)` block. Maybe it is my fault (I'm too lazy to do git blame), but this has nothing to do with DNS lookup.

Now you can set URL to `github.com`, `github.com/foobar`, `wiki foobar` or `foobar` and get what you want in all those cases.