### PR TITLE
Fix toolbar toggling when entering/leaving fullscreen mode

### DIFF
--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -501,11 +501,14 @@ response.  The BODY is wrapped with `with-protect'."
          (connect-signal window "window-state-event" nil (widget event)
            (declare (ignore widget))
            (setf (nyxt::fullscreen-p window)
-                 (find :fullscreen
-                       (gdk:gdk-event-window-state-new-window-state event)))
+                 (sera:true
+                  (find :fullscreen
+                        (gdk:gdk-event-window-state-new-window-state event))))
            (setf (nyxt::maximized-p window)
-                 (find :maximized
-                       (gdk:gdk-event-window-state-new-window-state event)))
+                 (sera:true
+                  (find :maximized
+                        (gdk:gdk-event-window-state-new-window-state event))))
+           (toggle-toolbars-on-fullscreen)
            nil))
 
        (unless nyxt::*headless-p*
@@ -1611,12 +1614,12 @@ the `active-buffer'."
   (connect-signal buffer "enter-fullscreen" nil (web-view)
     (declare (ignore web-view))
     (setf (nyxt::fullscreen-p (current-window)) t)
-    (toggle-fullscreen :skip-renderer-resize t)
+    (toggle-toolbars-on-fullscreen)
     nil)
   (connect-signal buffer "leave-fullscreen" nil (web-view)
     (declare (ignore web-view))
     (setf (nyxt::fullscreen-p (current-window)) nil)
-    (toggle-fullscreen :skip-renderer-resize t)
+    (toggle-toolbars-on-fullscreen)
     nil)
   buffer)
 

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -178,17 +178,12 @@ not try to quit the browser."
     (window-set-buffer window buffer)
     (values window buffer)))
 
-(define-command toggle-fullscreen (&key (window (current-window))
-                                   skip-renderer-resize)
-  "Fullscreen WINDOW, or the current window, when omitted.
-When `skip-renderer-resize' is non-nil, don't ask the renderer to fullscreen the window."
+(define-command toggle-fullscreen (&key (window (current-window)))
+  "Fullscreen WINDOW, or the current window, when omitted."
   (let ((fullscreen (fullscreen-p window)))
-    (unless skip-renderer-resize
-      (if fullscreen
-          (ffi-window-unfullscreen window)
-          (ffi-window-fullscreen window)))
-    (toggle-status-buffer :show-p (not fullscreen))
-    (toggle-message-buffer :show-p (not fullscreen))))
+    (if fullscreen
+        (ffi-window-unfullscreen window)
+        (ffi-window-fullscreen window))))
 
 (define-command toggle-maximize (&key (window (current-window)))
   "Maximize WINDOW, or the current window, when omitted."
@@ -241,3 +236,11 @@ If SHOW-P is provided:
               (zerop (height (message-buffer window))))
          (enable-message-buffer window))
         (t (disable-message-buffer window))))
+
+(defun toggle-toolbars-on-fullscreen (&key (window (current-window)))
+  "Toggle toolbar when fullscreen state is changed. Should be called
+from the renderer."
+  (let ((fullscreen (fullscreen-p window)))
+    (toggle-message-buffer :window window :show-p (not fullscreen))
+    (toggle-status-buffer  :window window :show-p (not fullscreen))))
+(export 'toggle-toolbars-on-fullscreen)


### PR DESCRIPTION
This PR fixes toolbar toggling when entering/leaving fullscreen, as the title says. This is what it looks like before the patch:

Leaving fullscreen mode:
![20240605_10h15m17s_grim](https://github.com/atlas-engineer/nyxt/assets/812069/cdc42ac3-baba-405b-938b-728493018b90)

Entering fullscreen mode:
![20240605_10h15m00s_grim](https://github.com/atlas-engineer/nyxt/assets/812069/d397d7c6-198e-47c0-a408-73f5c06d6848)

When you press f11 (`toggle-fullscreen`) your toolbar does not disappear in the fullscreen mode and disappears when you leave it. When you toggle fullscreen by external means (e.g. pressing Mod+f in sway), nothing happens with the toolbar.

This patch assures that toolbar disappears in the fullscreen mode and appears in "the normal mode" in following scenarios:

* When `toggle-fullscreen` is invoked
* When toggling fullscreen via X11 WM /Wayland compositor
* When pressing fullscreen button on Youtube.