### PR TITLE
mode/password: filename-based usernames for pass

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -96,6 +96,20 @@ elements are scaled accordingly.")
   (:li "When on pre-release, push " (:code "X-pre-release")
        " feature in addition to " (:code "X-pre-release-N") "one."))
 
+(define-version "3.12.0"
+  (:nsection :title "Features"
+    (:ul
+     (:li "Added new filename-based fallback strategy to "
+          (:nxref :command 'nyxt/mode/password:copy-username)
+          " when using the default password-store password interface."
+     (:li "Allow skipping the primary key-based username strategy utilized by "
+          (:nxref :command 'nyxt/mode/password:copy-username)
+          " via the new slot "
+          (:nxref :class-name 'password:password-store-interface
+            :slot 'scan-for-username-entries)
+          ". By default, it is set to "
+          (:code "t") " (do not skip).")))))
+
 (define-version "3.11.7"
   (:nsection :title "Bug fixes"
     (:ul


### PR DESCRIPTION
# Description
Introduces a new filename-based code pathway for determining the username of a GNU password-store credential. This new pathway simply uses the credential file name (_not including extension_) as the username.

By default, the new pathway is only used as a fallback strategy for when no matching username keys could be found using the current strategy, though users who *only* want the new filename-based behavior can entirely skip using the original strategy via the new `scan-for-username-entries` slot. Disabling scanning credential files for a key-based username is particularly useful in use-cases where the store credentials are encrypted and would require touch verification to open.

In the special case that a credential is on the root directory of the password store, we also trim off the domain signifier to match the behavior of other password-store based utilities (*e.g.: "me@example.net" becomes "me", "me@example.org@example.net" becomes "me@example.org"*)

Fixes #3293

# Checklist:

- [x] Git branch state is mergable.
- [x] Changelog is up to date (via a separate commit).
- [x] New dependencies are accounted for.
- [x] Documentation is up to date.
- [x] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.