### PR TITLE
buffer.lisp: Fix rendering of buffer menu on long pages.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -274,8 +274,10 @@ See also the `profile' slot in the `browser' class.")
               :overflow-x "scroll"
               :white-space "nowrap"
               :background-color ,theme:background-alt
-              :margin-left "-20px"
+              :position "sticky"
               :margin-top "-20px"
+              :top 0
+              :width "100%"
               :height "32px")
             `(".mode-menu > button"
               :color ,theme:on-secondary

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -97,6 +97,11 @@ elements are scaled accordingly.")
   (:li "When on pre-release, push " (:code "X-pre-release")
        " feature in addition to " (:code "X-pre-release-N") "one."))
 
+(define-version "3.11.8"
+  (:nsection :title "UI/UX"
+    (:ul
+     (:li "Fix mode menu bar."))))
+
 (define-version "3.11.7"
   (:nsection :title "Bug fixes"
     (:ul


### PR DESCRIPTION
Additionally, change the width of the menu to be the same as the content, make it a clearer visual indicator that it operates *on* the content.

Fixes #3416.