### PR TITLE
Make command-dispatcher buffer local

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -131,11 +131,6 @@ Which commands will they invoke next?")
     nil
     :type (maybe function)
     :documentation "The last command invoked by the user.")
-   (command-dispatcher
-    #'dispatch-command
-    :type (or sym:function-symbol function)
-    :documentation "Function to process the command processed in `dispatch-input-event'.
-Takes the function/command as the only argument.")
    (prompt-buffer-generic-history
     (make-ring)
     :documentation "The default history of all prompt buffer entries.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -461,6 +461,11 @@ To access all modes, including disabled ones, use `slot-value'."
                    :combination #'hooks:combine-composed-hook)
     :type hook-keymaps-buffer
     :documentation "Hook run as a return value of `current-keymaps'.")
+   (command-dispatcher
+    #'dispatch-command
+    :type (or sym:function-symbol function)
+    :documentation "Function to process the command processed in `dispatch-input-event'.
+Takes the function/command as the only argument.")
    (conservative-word-move
     nil
     :documentation "If non-nil, the cursor moves to the end

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -34,8 +34,8 @@
    (:li "Refactor input to be handled on the buffer level rather than the window
 level.")
    (:li "Delete " (:code "input-skip-dispatcher") ".")
-   (:li "Move slot " (:nxref :slot 'command-dispatcher :class-name 'browser)
-        " from window to the browser class.")
+   (:li "Move slot " (:nxref :slot 'command-dispatcher :class-name 'input-buffer)
+        " from window to the input-buffer class.")
    (:li "Move slots " (:nxref :slot 'last-key :class-name 'buffer)
         " and " (:nxref :slot 'key-stack :class-name 'buffer)
         " from window to the buffer class.")

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -122,7 +122,7 @@ Return nil to forward to renderer or non-nil otherwise."
              (log:debug "Found key binding ~a to ~a." (keyspecs key-stack translated-key) bound-function)
              (setf (last-key buffer) (first key-stack))
              (run-thread "run-command"
-               (unwind-protect (funcall (command-dispatcher *browser*) command)
+               (unwind-protect (funcall (command-dispatcher buffer) command)
                  (setf key-stack nil)))
              t))
           ((or (and (input-buffer-p buffer) (forward-input-events-p buffer))


### PR DESCRIPTION
# Description

Make command-dispatcher buffer local. This makes the slot easier to be used/customized by modes, use cases include:
- per-buffer synchronous command loop
- buffer-local pre/post command hooks
- other custom processing like custom error handling

# Checklist:

- [X] Git branch state is mergable.
- [X] Changelog is up to date (via a separate commit).
- [X] New dependencies are accounted for.
- [X] Documentation is up to date.
- [x] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
