### PR TITLE
delete-panel-buffer calls buffer-delete-hook

### DIFF
--- a/source/window.lisp
+++ b/source/window.lisp
@@ -104,6 +104,7 @@ The handlers take the window as argument."))
   "Remove a panel buffer from a window."
   (setf (panel-buffers window)
         (remove buffer (panel-buffers window)))
+  (hooks:run-hook (buffer-delete-hook buffer) buffer)
   (ffi-window-delete-panel-buffer window buffer))
 
 (defmethod (setf active-buffer) (buffer (window window))


### PR DESCRIPTION
# Description

delete-panel-buffer now calls buffer-delete-hook of the panel buffer

# Checklist:

- [X] Git branch state is mergable.
- [X] Changelog is up to date (via a separate commit).
- [X] New dependencies are accounted for.
- [X] Documentation is up to date.
- [X] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
