### PR TITLE
Dispatch command hook

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -131,11 +131,6 @@ Which commands will they invoke next?")
     nil
     :type (maybe function)
     :documentation "The last command invoked by the user.")
-   (command-dispatcher
-    #'dispatch-command
-    :type (or sym:function-symbol function)
-    :documentation "Function to process the command processed in `dispatch-input-event'.
-Takes the function/command as the only argument.")
    (prompt-buffer-generic-history
     (make-ring)
     :documentation "The default history of all prompt buffer entries.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -468,13 +468,13 @@ To access all modes, including disabled ones, use `slot-value'."
     :documentation "Hook run as a return value of `current-keymaps'.")
    (dispatch-command-hook
     (make-instance 'hook-command
-                   :handlers (list #'dispatch-command)
                    :combination #'hooks:combine-hook-until-success)
     :type (or sym:function-symbol function)
     :documentation "Hook to process the command processed in `dispatch-input-event'.
 Takes the function/command as the only argument.  Each handler should return a
 boolean indicating whether it dispatched the command successfully.  Handlers are
-tried in successsion until the first handler which returns T.")
+tried in successsion until the first handler which returns T.  If no handlers in
+this hook dispatched the command, `dispatch-command' is used as fallback.")
    (conservative-word-move
     nil
     :documentation "If non-nil, the cursor moves to the end

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -8,6 +8,11 @@
   "Hook to modify keymaps.
 Get a list of `nkeymaps:keymap's and `buffer' and return a new list and buffer.")
 (export-always '(hook-keymaps-buffer))
+(hooks:define-hook-type command (function ((or sym:function-symbol function))
+                                          boolean)
+  "Hook to dispatch command.
+Get a command and return a boolean indicating whether the command is handled.")
+(export-always '(hook-command))
 (hooks:define-hook-type url->url (function (quri:uri) quri:uri)
   "Hook getting a `quri:uri' and returning same/another one. ")
 
@@ -461,6 +466,15 @@ To access all modes, including disabled ones, use `slot-value'."
                    :combination #'hooks:combine-composed-hook)
     :type hook-keymaps-buffer
     :documentation "Hook run as a return value of `current-keymaps'.")
+   (dispatch-command-hook
+    (make-instance 'hook-command
+                   :handlers (list #'dispatch-command)
+                   :combination #'hooks:combine-hook-until-success)
+    :type (or sym:function-symbol function)
+    :documentation "Hook to process the command processed in `dispatch-input-event'.
+Takes the function/command as the only argument.  Each handler should return a
+boolean indicating whether it dispatched the command successfully.  Handlers are
+tried in successsion until the first handler which returns T.")
    (conservative-word-move
     nil
     :documentation "If non-nil, the cursor moves to the end

--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -34,8 +34,8 @@
    (:li "Refactor input to be handled on the buffer level rather than the window
 level.")
    (:li "Delete " (:code "input-skip-dispatcher") ".")
-   (:li "Move slot " (:nxref :slot 'command-dispatcher :class-name 'browser)
-        " from window to the browser class.")
+   (:li "Change slot " (:code "command-dispatcher")
+        " in window class to the " (:nxref :slot 'dispatch-command-hook :class-name 'buffer) ".")
    (:li "Move slots " (:nxref :slot 'last-key :class-name 'buffer)
         " and " (:nxref :slot 'key-stack :class-name 'buffer)
         " from window to the buffer class.")

--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -636,15 +636,16 @@ A command is a special kind of function that can be called with
   (buffer-load-internal-page-focus 'describe-bindings :buffer-id (id buffer)))
 
 (defun describe-key-dispatch (command)
+  (hooks:remove-hook (dispatch-command-hook (current-buffer)) 'describe-key-dispatch)
   (unwind-protect (describe-command :command (typecase command
                                                (symbol command)
                                                (command (name command))))
-    (setf (command-dispatcher *browser*) #'dispatch-command)
-    (echo-dismiss)))
+    (echo-dismiss)
+    t))
 
 (define-command describe-key ()
   "Display binding of user-inputted keys."
-  (setf (command-dispatcher *browser*) #'describe-key-dispatch)
+  (hooks:add-hook (dispatch-command-hook (current-buffer)) 'describe-key-dispatch)
   (echo "Press a key sequence to describe:"))
 
 (export-always 'system-information)

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -122,7 +122,7 @@ Return nil to forward to renderer or non-nil otherwise."
              (log:debug "Found key binding ~a to ~a." (keyspecs key-stack translated-key) bound-function)
              (setf (last-key buffer) (first key-stack))
              (run-thread "run-command"
-               (unwind-protect (funcall (command-dispatcher *browser*) command)
+               (unwind-protect (hooks:run-hook (dispatch-command-hook buffer) command)
                  (setf key-stack nil)))
              t))
           ((or (and (input-buffer-p buffer) (forward-input-events-p buffer))

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -122,7 +122,8 @@ Return nil to forward to renderer or non-nil otherwise."
              (log:debug "Found key binding ~a to ~a." (keyspecs key-stack translated-key) bound-function)
              (setf (last-key buffer) (first key-stack))
              (run-thread "run-command"
-               (unwind-protect (hooks:run-hook (dispatch-command-hook buffer) command)
+               (unwind-protect (or (hooks:run-hook (dispatch-command-hook buffer) command)
+                                   (dispatch-command command))
                  (setf key-stack nil)))
              t))
           ((or (and (input-buffer-p buffer) (forward-input-events-p buffer))


### PR DESCRIPTION
# Description

I apologize for the noises made last time as I didn't realize there are other places using `dispatch-command` in the code base. This version also fixes the uses in describe-key and repeat-mode.

Change `command-dispatcher` to the buffer local `dispatch-command-hook`. This makes the slot easier to be used/customized by modes, use cases include:

- per-buffer synchronous command loop
- buffer-local pre/post command hooks
- other custom processing like custom error handling

This PR also does the following:
- bug fix: `repeat-mode` was broken due to calling `last-key` on window instead of buffer.
- using hook-based API, users of `dispatch-command-hook` no longer need to assume the value of `command-dispatcher` before they modify it (they were assuming the old dispatcher was always `#'dispatch-command`). Now they just push/pop handlers onto `dispatch-command-hook`. This makes it easier to correctly recursively call commands that changes command-dispatcher, similar to Emacs' recursive edits.

# Checklist:

- [X] Git branch state is mergable.
- [X] Changelog is up to date (via a separate commit).
- [X] New dependencies are accounted for.
- [X] Documentation is up to date.
- [X] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
