### PR TITLE
Initialize WebExtension directory.

### DIFF
--- a/libraries/nasdf/install.lisp
+++ b/libraries/nasdf/install.lisp
@@ -20,6 +20,11 @@
   (:documentation "Component type for executables to install."))
 (import 'nasdf-binary-file :asdf-user)
 
+(export-always 'nasdf-library-file)
+(defclass nasdf-library-file (nasdf-binary-file) ()
+  (:documentation "Component type for libraries (shared objects) to install."))
+(import 'nasdf-library-file :asdf-user)
+
 (export-always 'nasdf-desktop-file)
 (defclass nasdf-desktop-file (nasdf-file) ()
   (:documentation "Component type for XDG .desktop files to install."))
@@ -118,6 +123,13 @@ Destination directory is given by the `dest-source-dir' generic function."))
 (defparameter *datadir* (path-from-env "DATADIR" (merge-pathnames* "share/" *prefix*)))
 (export-always '*bindir*)
 (defparameter *bindir* (path-from-env "BINDIR" (merge-pathnames* "bin/" *prefix*)))
+(export-always '*libdir*)
+(defparameter *libdir* (path-from-env "LIBDIR" (merge-pathnames* "lib/" *prefix*)))
+
+(export-always 'libdir)
+(defmethod libdir ((component nasdf-library-file))
+  (let ((name (primary-system-name (component-system component))))
+    (ensure-directory-pathname (merge-pathnames* name *libdir*))))
 
 (export-always '*dest-source-dir*)
 (defvar *dest-source-dir* (path-from-env "NASDF_SOURCE_PATH" *datadir*)
@@ -175,6 +187,10 @@ Final path is resolved in `dest-source-dir'.")
   (call-next-method)
   (mapc #'make-executable (output-files op c))
   nil)
+
+(defmethod output-files ((op compile-op) (c nasdf-library-file))
+  (values (list (merge-pathnames* (basename (component-name c)) (libdir c)))
+          t))
 
 (defmethod output-files ((op compile-op) (c nasdf-desktop-file))
   (values (list (merge-pathnames* (merge-pathnames*

--- a/libraries/nasdf/package.lisp
+++ b/libraries/nasdf/package.lisp
@@ -18,6 +18,8 @@ A system that installs files:
   :components ((:nasdf-desktop-file \"assets/my-project.desktop\")
                (:nasdf-icon-directory \"assets/\")
                (:nasdf-binary-file \"my-project\")
+               (:nasdf-library-file \"libraries/web-extensions/libmy.so\"
+                                   :if-does-not-exist nil)
                (:nasdf-source-directory \"source\")
                (:nasdf-source-directory \"nasdf\")
                (:nasdf-source-directory \"libraries\"

--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -18,7 +18,8 @@ of Nyxt.")
   (spinneret:with-html-string
     (let ((auto-config-file (namestring (files:expand *auto-config-file*)))
           (config-file (namestring (files:expand *config-file*)))
-          (rules-file (namestring (files:expand (make-instance 'auto-rules-file)))))
+          (rules-file (namestring (files:expand (make-instance 'auto-rules-file))))
+          (gtk-extensions-directory (namestring (uiop:merge-pathnames* "nyxt/" nasdf:*libdir*))))
       (:nsection :title "Configuration"
         (:p "Nyxt is written in the Common Lisp programming language which offers a
 great perk: everything in the browser can be customized by the user, even while
@@ -923,6 +924,17 @@ core to finalize the instance."))
         (:p "Extensions are regular Common Lisp systems.")
         (:p "Please find a catalog of Nyxt extensions "
             (:a :href (nyxt-url 'list-extensions) "here") "."))
+
+      (:nsection :title "Blocking ads using AdBlock rules"
+        (:p "With WebkitGTK backend you can use "
+            (:a :href "https://github.com/dudik/blockit" "BlocKit")
+            " extension to block ads.")
+        (:p "In short, you have to install "
+            (:a :href "https://crates.io/crates/adblock-rust-server" "adblock-rust-server")
+            " to a directory visible in " (:code "PATH")
+            " environment variable and the shared library ("
+            (:code "blockit.so") ") to " (:code gtk-extensions-directory)
+            ". After that, follow instructions on BlocKit github page."))
 
       (:nsection :title "Troubleshooting"
 

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -266,7 +266,17 @@ the renderer thread, use `defmethod' instead."
                    (handler-case
                        (nth-value 1 (ensure-directories-exist gtk-extensions-path))
                      (file-error ()))))
-      (log:info "GTK extensions directory: ~s" gtk-extensions-path))
+      (log:info "GTK extensions directory: ~s" gtk-extensions-path)
+      (gobject:g-signal-connect
+       context "initialize-web-extensions"
+       (lambda (context)
+         (with-protect ("Error in \"initialize-web-extensions\" signal thread: ~a" :condition)
+           ;; The following calls
+           ;; `webkit:webkit-web-context-add-path-to-sandbox' for us, so no need
+           ;; to add `gtk-extensions-path' to the sandbox manually.
+           (webkit:webkit-web-context-set-web-extensions-directory
+            context
+            (uiop:native-namestring gtk-extensions-path))))))
     (gobject:g-signal-connect
      context "download-started"
      (lambda (context download)

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -230,6 +230,12 @@ the renderer thread, use `defmethod' instead."
   ;; starting again.
   (unless nyxt::*run-from-repl-p* (gtk:leave-gtk-main)))
 
+(define-class gtk-extensions-directory (nyxt-file)
+  ((files:name "gtk-extensions")
+   (files:base-path (uiop:merge-pathnames* "nyxt/" nasdf:*libdir*)))
+  (:export-class-name-p t)
+  (:documentation "Directory to load WebKitWebExtensions from."))
+
 (define-class gtk-download ()
   ((gtk-object)
    (handler-ids
@@ -241,7 +247,8 @@ the renderer thread, use `defmethod' instead."
   (let* ((context (make-instance 'webkit:webkit-web-context
                                  :website-data-manager
                                  (make-instance 'webkit-website-data-manager)))
-         (cookie-manager (webkit:webkit-web-context-get-cookie-manager context)))
+         (cookie-manager (webkit:webkit-web-context-get-cookie-manager context))
+         (gtk-extensions-path (files:expand (make-instance 'gtk-extensions-directory))))
     (webkit:webkit-web-context-set-spell-checking-enabled context t)
     ;; Need to set the initial language list.
     (let ((pointer (cffi:foreign-alloc :string
@@ -252,6 +259,14 @@ the renderer thread, use `defmethod' instead."
                                        :null-terminated-p t)))
       (webkit:webkit-web-context-set-spell-checking-languages context pointer)
       (cffi:foreign-free pointer))
+    (when (and (not (nfiles:nil-pathname-p gtk-extensions-path))
+               ;; Either the directory exists.
+               (or (uiop:directory-exists-p gtk-extensions-path)
+                   ;; Or try to create it.
+                   (handler-case
+                       (nth-value 1 (ensure-directories-exist gtk-extensions-path))
+                     (file-error ()))))
+      (log:info "GTK extensions directory: ~s" gtk-extensions-path))
     (gobject:g-signal-connect
      context "download-started"
      (lambda (context download)


### PR DESCRIPTION
# Description

Initialization of WebExtensions (Webkit-specific .so plugins) was removed in aa2351. However, minimal support for them are required for useful add-ons like blockit, an ads blocker.

Fixes #3554

There was an idea (by @aadcg) to include information about blockit to the manual. I can do that too, but only if you tell me how to add custom WebKit extensions to the official nyxt build. On my system `*libdir*` is set to `/usr/local/lib` and I install blockit to `/usr/local/lib/nyxt` via `pkg`, FreeBSD's package manager. This, however, may not work for other systems.

# Checklist:

- [x] Git branch state is mergable.
- [ ] Changelog is up to date (via a separate commit).
- [ ] New dependencies are accounted for.
- [ ] Documentation is up to date.
- [ ] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
