### PR TITLE
Enhance/electron

### DIFF
--- a/source/foreign-interface.lisp
+++ b/source/foreign-interface.lisp
@@ -136,8 +136,16 @@ Usually setf-able."))
 Dispatches over `window' and classes inheriting from `buffer'.
 Usually setf-able."))
 
-(define-ffi-generic ffi-buffer-make (buffer)
+(define-ffi-generic ffi-buffer-make (browser)
+  (:method ((browser t))
+    (make-instance 'buffer))
   (:documentation "Return BUFFER and display it."))
+
+(define-ffi-generic ffi-buffer-initialize-foreign-object (buffer)
+  (:documentation "Create and configure the foreign object for a given buffer.
+This differs from `ffi-buffer-make' because it takes an existing buffer object
+and creates the foreign objects necessary for rendering the buffer."))
+
 (define-ffi-generic ffi-buffer-delete (buffer)
   (:documentation "Delete BUFFER."))
 

--- a/source/recent-buffers.lisp
+++ b/source/recent-buffers.lisp
@@ -5,7 +5,7 @@
 
 (defun reopen-dead-buffer (buffer)
   (cond ((dead-buffer-p buffer)
-         (ffi-buffer-make buffer)
+         (ffi-buffer-initialize-foreign-object buffer)
          ;; Re-positions buffer in `recent-buffers'.
          (add-to-recent-buffers buffer)
          ;; Ensure buffer is seen by the `buffers' hash table.

--- a/source/renderer/gtk.lisp
+++ b/source/renderer/gtk.lisp
@@ -761,7 +761,7 @@ with this scheme.")
                                       &allow-other-keys)
   "Make BUFFER with EXTRA-MODES.
 See `finalize-buffer'."
-  (ffi-buffer-make buffer)
+  (ffi-buffer-initialize-foreign-object buffer)
   (finalize-buffer buffer :extra-modes extra-modes :no-hook-p no-hook-p))
 
 (define-ffi-method ffi-buffer-url ((buffer gtk-buffer))
@@ -1183,7 +1183,7 @@ See `finalize-buffer'."
       (echo "[~a] ~a: ~a" (webkit:webkit-web-view-uri web-view) title body)
       t)))
 
-(define-ffi-method ffi-buffer-make ((buffer gtk-buffer))
+(define-ffi-method ffi-buffer-initialize-foreign-object ((buffer gtk-buffer))
   "Initialize BUFFER's GTK web view."
   (setf (gtk-object buffer)
         (if (prompt-buffer-p buffer)


### PR DESCRIPTION
# Description

Refactor the API for restoring buffers, create a new endpoint to avoid misusing `ffi-buffer-make`. Depends upon: https://github.com/atlas-engineer/cl-electron/pull/54