### PR TITLE
mode/password: save-new-password now connects to password-interface.

### DIFF
--- a/source/mode/password.lisp
+++ b/source/mode/password.lisp
@@ -97,20 +97,21 @@ for which the `executable' slot is non-nil."
     ((and (password-interface buffer)
           (nyxt:has-method-p (password-interface (find-submode 'password-mode buffer))
                              #'password:save-password))
-     (let* ((password-name (prompt1 :prompt "Name for new password"
-                                    :input (or (quri:uri-domain (url (current-buffer)))
-                                               "")
-                                    :sources 'prompter:raw-source))
-            (new-password (prompt1 :prompt "New password (leave empty to generate)"
-                                   :sources 'prompter:raw-source
-                                   :height :fit-to-prompt
-                                   :invisible-input-p t))
-            (username (prompt1 :prompt "Username (can be empty)"
-                               :sources 'prompter:raw-source)))
-       (password:save-password (password-interface buffer)
-                               :username username
-                               :password-name password-name
-                               :password new-password)))
+     (with-password (password-interface buffer)
+       (let* ((password-name (prompt1 :prompt "Name for new password"
+                                      :input (or (quri:uri-domain (url (current-buffer)))
+                                                 "")
+                                      :sources 'prompter:raw-source))
+              (new-password (prompt1 :prompt "New password (leave empty to generate)"
+                                     :sources 'prompter:raw-source
+                                     :height :fit-to-prompt
+                                     :invisible-input-p t))
+              (username (prompt1 :prompt "Username (can be empty)"
+                                 :sources 'prompter:raw-source)))
+         (password:save-password (password-interface buffer)
+                                 :username username
+                                 :password-name password-name
+                                 :password new-password))))
     ((null (password-interface buffer))
      (echo-warning "No password manager found."))
     (t (echo-warning "Password manager ~s does not support saving passwords."


### PR DESCRIPTION
# Description

- Add `(with-password (password-interface buffer) ...) to allow `save-new-password` to connect to password interface, and prompt for password, analogous to `copy-password` and `copy-username` commands.

Fixes #3431 

# Checklist:

- [ ] Git branch state is mergable.
- [ ] Changelog is up to date (via a separate commit).
- [ ] New dependencies are accounted for.
- [ ] Documentation is up to date.
- [ ] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
