### PR TITLE
Reimplement fast bookmark remove buttons in bookmarks-buffer

### DIFF
--- a/source/changelog.lisp
+++ b/source/changelog.lisp
@@ -27,6 +27,8 @@
 
 (define-version "4.0.0"
   (:ul
+   (:li "Add buttons to quickly remove bookmarks in a buffer shown by "
+        (:nxref :command 'nyxt/mode/bookmark:list-bookmarks))
    (:li "Refactor the " (:nxref :package :theme) " API.")
    (:li "Delete support for panel buffers and all related logic.")
    (:li "Refactor " (:nxref :command 'quick-start) " as an internal page.")

--- a/source/mode/bookmark.lisp
+++ b/source/mode/bookmark.lisp
@@ -324,12 +324,26 @@ Splits bookmarks into groups by tags."
                 :id (or tag "unsorted")
                 :open-p nil
                 (dolist (bookmark bookmarks)
-                  (:div
-                   :class "bookmark-entry"
-                   (:dl
-                    (:dt (:a :href (render-url (url bookmark)) (title bookmark)))
-                    (when (tags bookmark)
-                      (:dd (:pre (format nil "Tags: ~{~a~^, ~}" (tags bookmark))))))))))
+                  (let ((url (render-url (url bookmark)))
+                        (title (title bookmark))
+                        (tags  (tags bookmark)))
+                    (:div
+                     :class "bookmark-entry"
+                     (:dl
+                      (:dt
+                       (:button
+                        :onclick
+                        (ps:ps
+                          (let ((section (ps:chain (nyxt/ps:active-element document)
+                                                   (closest ".bookmark-entry"))))
+                            (ps:chain section parent-node (remove-child section)))
+                          (nyxt/ps:lisp-eval (:title "Delete"
+                                              :buffer bookmarks-buffer)
+                                             (delete-bookmark url)))
+                        "×")
+                       (:a :href url title))
+                      (when tags
+                        (:dd (:pre (format nil "Tags: ~{~a~^, ~}" tags))))))))))
             bookmarks))))))
 
 (defmethod serialize-object ((entry bookmark-entry) stream)


### PR DESCRIPTION
# Description

This change adds quick bookmark remove buttons in `bookmarks-buffer`.

Fixes #3578

# Checklist:

- [x] Git branch state is mergable.
- [x] Changelog is up to date (via a separate commit).
- [x] New dependencies are accounted for.
- [x] Documentation is up to date.
- [x] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
