### PR TITLE
Fix describe-function

### DIFF
--- a/source/describe.lisp
+++ b/source/describe.lisp
@@ -389,7 +389,8 @@ For generic functions, describe all the methods."
                                                (:td keymapname))))))))
                    (:nsection
                      :title "Argument list"
-                     (:pre (:code (prini-to-string (arglist input) :package (symbol-package input)))))
+                     (:pre (:code (prini-to-string (swank-backend:arglist input)
+                                                   :package (symbol-package input)))))
                    #+sbcl
                    (unless (or (macro-function input)
                                (eq 'function (sb-introspect:function-type input)))


### PR DESCRIPTION
# Description

This PR fixes `describe-function`. It's identical to 1d3f1fa

# Checklist:

- [x] Git branch state is mergable.
- [ ] Changelog is up to date (via a separate commit).
- [ ] New dependencies are accounted for.
- [ ] Documentation is up to date.
- [ ] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
