### PR TITLE
Mimic GTK grab focus in electron for prompt

### DIFF
--- a/source/renderer/electron.lisp
+++ b/source/renderer/electron.lisp
@@ -260,6 +260,7 @@ Note that by changing the default value, modifier keys can be remapped."))
 
 (defmethod ffi-focus-prompt-buffer ((prompt-buffer prompt-buffer))
   (electron:focus prompt-buffer)
+  (electron:select-all prompt-buffer)
   prompt-buffer)
 
 (defmethod (setf ffi-height) ((height integer) (prompt-buffer prompt-buffer))


### PR DESCRIPTION
# Description

This small PR makes it so focusing the prompt buffer also selects all the text currently in the prompt for the electron renderer. This behavior is identical to GTK, and (although this is a matter of taste) preferable. See https://github.com/atlas-engineer/cl-electron/pull/58

# Checklist:

- [x] Git branch state is mergable.
- [x] Changelog is up to date (via a separate commit). (This is bringing it to feature parity on 3.x, so no changelog update is necessary?)
- [x] New dependencies are accounted for.
- [x] Documentation is up to date.
- [x] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
