### PR TITLE
Change electron create window behavior to focus a new buffer

### DIFF
--- a/source/renderer/electron.lisp
+++ b/source/renderer/electron.lisp
@@ -129,7 +129,18 @@ Note that by changing the default value, modifier keys can be remapped."))
    (when (member (type-of buffer) '(status-buffer message-buffer prompt-buffer))
     (electron:load-url buffer "about:blank"))
   (initialize-listeners buffer)
+  (initialize-window-open-handler buffer)
   (finalize-buffer buffer :extra-modes extra-modes :no-hook-p no-hook-p))
+
+(defmethod initialize-window-open-handler ((buffer electron-buffer))
+  ;; When following a link with target="_blank" or through JS window.open,
+  ;; we don't want to let electron open a new window, instead we want to
+  ;; put it into a new buffer
+  (electron:override-window-open-handler
+   (electron:web-contents buffer)
+   (lambda (details)
+     (let ((url (assoc-value details :url)))
+       (make-buffer-focus :url (quri:uri url) :parent-buffer (current-buffer))))))
 
 (defmethod initialize-listeners ((buffer electron-buffer))
   (electron:add-listener buffer :before-input-event


### PR DESCRIPTION
# Description

Previously, in the electron renderer, clicking a link with `target="_blank"` or calling `window.create()` from JS would result in electron opening a new window outside the scope of nyxt. We want to prevent the default electron behavior by setting our own create window handler and denying the default behavior. See https://github.com/atlas-engineer/cl-electron/pull/59

# Checklist:

- [x] Git branch state is mergable.
- [x] Changelog is up to date (via a separate commit).
- [x] New dependencies are accounted for.
- [x] Documentation is up to date.
- [x] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
