### PR TITLE
mode/file-manager: Run URL-DECODE on a URL in OPEN-FILE

### DIFF
--- a/source/mode/file-manager.lisp
+++ b/source/mode/file-manager.lisp
@@ -309,7 +309,8 @@ Can be used as a `open-file-function'."
 (define-command-global open-file (&key (default-directory
                                         (if (quri:uri-file-p (url (current-buffer)))
                                             (uiop:pathname-directory-pathname
-                                             (quri:uri-path (url (current-buffer))))
+                                             (quri:url-decode
+                                              (quri:uri-path (url (current-buffer)))))
                                             *default-pathname-defaults*)))
   "Open a file from the filesystem.
 


### PR DESCRIPTION
The problem this PR fixes:

If you open a file (e.g. a PDF) residing in a directory which contains spaces or unicode characters and then invoke `open-file` again, you will see the directory percent-encoded and no hints will be available.

This is after the patch is applied:
![20250411_18h30m14s_grim](https://github.com/user-attachments/assets/1ba23a19-e5a2-40c4-8905-b01ba443c72c)
Currently you can see `/home/vasily/Downloads/Telegram%20Desktop`