### PR TITLE
Build with ocicl instead of git submodules (first-pass)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/
 node_modules/
 package.json
 package-lock.json
+ocicl*
+init.lisp
 
 # Ignore compiled lisp files
 *.FASL


### PR DESCRIPTION
# Description

This PR  is a first pass at updating the build process to use ocicl to pull the cl systems needed instead of git submodules.
Opening for review and better visibility to align/clean things up accordingly. Happy to help/assist an any way necessary, just need advisement.

Update makefile to incorporate build with ocicl
  - First pass at incorporating ocicl into build (needs refinement)
  - Update makefile replacing submodules flag with ocicl flag
  - Updated gitignore to ignore ocicl directory & asdf registry init.lisp
  - Kept _build directory for later removal
  - Did not include ocicl package registry ocicl.csv for now (this is where we would pin specific commits)
    - As of current this build will install latest of all cl systems  

Fixes # (issue) - N/A

# Checklist:

I have only tested this build with the electron variant as of current - would need assistance checking the below:

- [ ] Git branch state is mergable.
- [ ] Changelog is up to date (via a separate commit).
- [ ] New dependencies are accounted for.
- [ ] Documentation is up to date.
- [ ] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient.
