### PR TITLE
fix: non-QWERTY keyboard layouts need the UI event's key property ins…

### DIFF
--- a/source/renderer/electron.lisp
+++ b/source/renderer/electron.lisp
@@ -589,8 +589,10 @@ Return nil when key must be discarded, e.g. for modifiers."
        ("F10" "f10")
        ("F11" "f11")
        ("F12" "f12")
+       ((simple-string #\K #\e #\y key-value) (string-downcase (string key-value)))
+       ((simple-string #\D #\i #\g #\i #\t digit-value) (string digit-value))
        ;; but return event's key, again for international compatibility
-       (_ key-string)))))
+       (_ code-string)))))
 
 (defmethod on-signal-key-press-event ((sender electron-buffer) event)
   (when (string= "keyDown" (assoc-value event :type))


### PR DESCRIPTION
…tead of the code property



# Description
At least for Xorg@Linux, the keydown event provides two relevant properties:
- code
- key [ Cf. https://w3c.github.io/uievents/tools/key-event-viewer.html ]

_code_ is based on „standard” QWERTY keyboard layout, whereas _key_ reflects/respects the user's keyboard layout. Prominent example for German QWERTZ layout: pressing z (located on the key for y on a QWERTY layout) leads to this situation:

 pressed  |  key  | code
-------------------------
 Z        |   z  |  KeyY
 Y        |   y  |  KeyZ

This behavior is obviously worse for Dvořak or Neo layouts and the like.

Unfortunately, just changing to the _key_ property is not feasible because _key_ does not provide the useful keycodes, e. g. `ShiftRight`. On the other hand, just adding a matching line for the previous mapping of event _codes_ lead to conflicts with special character keys remapped to alphanumeric letters, e. g. in Neo layout the letter ›y‹ is produced by the key producing a single quote on QWERTY keyboards, which would have led to lack of C-y and M-y for emacs mode keybindings.

The patch / pull request goes a middle ground by special handling of alphanumeric characters without modifying the handling of special characters. It's highly probable that it needs further special treatment for characters like / (slash) or # (hash).
It's only tested on QWERTY, QWERTZ, and Neo layouts. Further testing is necessary, esp. for various country-specific layouts (French, Italian, Greek, …), but the patch will allow international / non-QWERTY users to start using Nyxt4.

Fixes #3677 

# Checklist:

- [x] Git branch state is mergable.
- [ ] Changelog is up to date (via a separate commit).
- [ ] New dependencies are accounted for.
- [ ] Documentation is up to date.
- [ ] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient for Linux with Xorg. Not Wayland on Linux, not MacOS.
