### PR TITLE
Add copy-otp command to password-mode

### DIFF
--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -40,6 +40,11 @@
     ;; Outputting to string blocks `pass'.
     :output 'nil))
 
+(defmethod clip-otp ((password-interface password-store-interface) &key password-name service)
+  (declare (ignore service))
+  (execute password-interface (list "otp" "--clip" password-name)
+           :output 'nil))
+
 (defvar *multiline-separator* ": *"
   "A regular expression to separate keys from values in the `pass' multiline format.")
 

--- a/libraries/password-manager/password.lisp
+++ b/libraries/password-manager/password.lisp
@@ -27,6 +27,10 @@
 (defgeneric clip-username (password-interface &key password-name service)
   (:documentation "Retrieve specific login by name of the password entry."))
 
+(export-always 'clip-otp)
+(defgeneric clip-otp (password-interface &key password-name service)
+  (:documentation "Retrive specific OTP code by name."))
+
 (export-always 'save-password)
 (defgeneric save-password (password-interface
                            &key password-name username password service)


### PR DESCRIPTION
# Description

- Introduces a new `copy-otp` command to `nyxt/modes/password-mode` resembling `copy-password` and `copy-username`, to aid [Password Store](https://www.passwordstore.org/) users, especially those who use the `pass-otp` extension, in logging in to websites, by allowing them to copy OTP Codes directly in the browser alongside their password, improving their user experience.

N/A

# Checklist:

- [X] Git branch state is mergable.
- [ ] Changelog is up to date (via a separate commit).
- [X] Documentation is up to date.
- [ ] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)

  - No new dependencies added.
  - No new compilation warnings.
  - Tested manually by running the browser
