### PR TITLE
mode/document: Add scroll-half-page-{up,down} (C-d/C-u in vi-normal)

### DIFF
--- a/source/mode/document.lisp
+++ b/source/mode/document.lisp
@@ -110,7 +110,9 @@ Important pieces of functionality are:
        "pageup" 'scroll-page-up
        "C-f" 'scroll-page-down
        "space" 'scroll-page-down
-       "pagedown" 'scroll-page-down)))))
+       "pagedown" 'scroll-page-down
+       "C-d" 'scroll-half-page-down
+       "C-u" 'scroll-half-page-up)))))
 
 (define-configuration document-buffer
   ((default-modes (cons 'document-mode %slot-value%))))
@@ -294,6 +296,14 @@ The amount scrolled is determined by the buffer's `horizontal-scroll-distance'."
   "Scroll up by one page height."
   (ps-eval (ps:chain window (scroll-by 0 (- (* (ps:lisp (page-scroll-ratio (current-buffer)))
                                              (ps:@ window inner-height)))))))
+
+(define-command scroll-half-page-down ()
+  "Scroll down by half a page height."
+  (ps-eval (ps:chain window (scroll-by 0 (/ (ps:@ window inner-height) 2)))))
+
+(define-command scroll-half-page-up ()
+  "Scroll up by half a page height."
+  (ps-eval (ps:chain window (scroll-by 0 (- (/ (ps:@ window inner-height) 2))))))
 
 (define-command zoom-page (&key (buffer (current-buffer)))
   "Zoom in the current buffer."


### PR DESCRIPTION
# Description

Add `scroll-half-page-down` and `scroll-half-page-up` commands and
bind them to `C-d` / `C-u` in the `document-mode` `vi-normal` keyscheme.

Vim users expect `C-d` / `C-u` to scroll by half a viewport. Nyxt
already ships `scroll-page-{up,down}` (bound to `C-f` / `C-b`,
`space` / `shift-space`, etc.) and `scroll-to-{top,bottom}` (`gg` /
`G`), but no half-page variant — so the `vi-normal` keyscheme
currently leaves `C-d` and `C-u` unbound and they fall through to
the renderer.

The new commands are tiny wrappers around
`window.scrollBy(0, ±innerHeight/2)`, matching the style of the
existing `scroll-page-{up,down}`. They are bound alongside the
existing page-scroll bindings in `vi-normal`; `cua` and `emacs`
keyschemes are intentionally left unchanged since `C-d` / `C-u`
have meanings there (e.g. Emacs `C-d` = delete-char).

Fixes # (no existing issue — happy to file one if preferred)

# Checklist:

- [x] Git branch state is mergable.
- [ ] Changelog is up to date (via a separate commit). _(n/a — I
      couldn't find a CHANGELOG file in the repo; happy to add a
      release-notes entry if you point me at the right location.)_
- [x] New dependencies are accounted for. _(none)_
- [x] Documentation is up to date. _(commands are self-documenting
      via their docstrings; no manual entries reference the existing
      scroll commands by name.)_
- [x] Compilation and tests (`(asdf:test-system :nyxt/<renderer>)`)
  - No new compilation warnings.
  - Tests are sufficient. _(no test changes; the new commands are
    one-liners structurally identical to the existing
    `scroll-page-{up,down}` and aren't covered by automated tests.)_
